### PR TITLE
Launch Portico with a supervised helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ go.work.sum
 # Editor/IDE
 # .idea/
 # .vscode/
+
+# Local Xcode and helper build output
+.build/

--- a/Portico.xcodeproj/project.pbxproj
+++ b/Portico.xcodeproj/project.pbxproj
@@ -1,0 +1,155 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		A00000000000000000000001 /* PorticoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00000000000000000000010 /* PorticoApp.swift */; };
+		A00000000000000000000002 /* HelperProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00000000000000000000011 /* HelperProtocolTests.swift */; };
+		A00000000000000000000004 /* HelperProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00000000000000000000014 /* HelperProtocol.swift */; };
+		A00000000000000000000005 /* HelperSupervisorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00000000000000000000015 /* HelperSupervisorTests.swift */; };
+		A00000000000000000000006 /* HelperSupervisor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00000000000000000000016 /* HelperSupervisor.swift */; };
+		A00000000000000000000007 /* HelperShutdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00000000000000000000017 /* HelperShutdownTests.swift */; };
+		A00000000000000000000009 /* ProcessHelperLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00000000000000000000019 /* ProcessHelperLauncher.swift */; };
+		A0000000000000000000000A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0000000000000000000001A /* AppDelegate.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		A00000000000000000000003 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A00000000000000000000040 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A00000000000000000000030;
+			remoteInfo = Portico;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		A00000000000000000000010 /* PorticoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PorticoApp.swift; sourceTree = "<group>"; };
+		A00000000000000000000011 /* HelperProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperProtocolTests.swift; sourceTree = "<group>"; };
+		A00000000000000000000012 /* Portico.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Portico.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A00000000000000000000013 /* PorticoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PorticoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A00000000000000000000014 /* HelperProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperProtocol.swift; sourceTree = "<group>"; };
+		A00000000000000000000015 /* HelperSupervisorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperSupervisorTests.swift; sourceTree = "<group>"; };
+		A00000000000000000000016 /* HelperSupervisor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperSupervisor.swift; sourceTree = "<group>"; };
+		A00000000000000000000017 /* HelperShutdownTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperShutdownTests.swift; sourceTree = "<group>"; };
+		A00000000000000000000019 /* ProcessHelperLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessHelperLauncher.swift; sourceTree = "<group>"; };
+		A0000000000000000000001A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A00000000000000000000052 /* Frameworks */ = {isa = PBXFrameworksBuildPhase; buildActionMask = 2147483647; files = (); runOnlyForDeploymentPostprocessing = 0; };
+		A00000000000000000000055 /* Frameworks */ = {isa = PBXFrameworksBuildPhase; buildActionMask = 2147483647; files = (); runOnlyForDeploymentPostprocessing = 0; };
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		A00000000000000000000020 = {
+			isa = PBXGroup;
+			children = (
+				A00000000000000000000021 /* Portico */,
+				A00000000000000000000022 /* PorticoTests */,
+				A00000000000000000000023 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		A00000000000000000000021 /* Portico */ = {isa = PBXGroup; children = (A00000000000000000000010 /* PorticoApp.swift */, A0000000000000000000001A /* AppDelegate.swift */, A00000000000000000000014 /* HelperProtocol.swift */, A00000000000000000000016 /* HelperSupervisor.swift */, A00000000000000000000019 /* ProcessHelperLauncher.swift */,); path = Portico; sourceTree = "<group>"; };
+		A00000000000000000000022 /* PorticoTests */ = {isa = PBXGroup; children = (A00000000000000000000011 /* HelperProtocolTests.swift */, A00000000000000000000015 /* HelperSupervisorTests.swift */, A00000000000000000000017 /* HelperShutdownTests.swift */,); path = PorticoTests; sourceTree = "<group>"; };
+		A00000000000000000000023 /* Products */ = {isa = PBXGroup; children = (A00000000000000000000012 /* Portico.app */, A00000000000000000000013 /* PorticoTests.xctest */,); name = Products; sourceTree = "<group>"; };
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		A00000000000000000000030 /* Portico */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A00000000000000000000081 /* Build configuration list for PBXNativeTarget "Portico" */;
+			buildPhases = (A00000000000000000000050 /* Sources */, A00000000000000000000052 /* Frameworks */, A00000000000000000000051 /* Resources */, A00000000000000000000056 /* Build and Embed Helper */,);
+			buildRules = ();
+			dependencies = ();
+			name = Portico;
+			productName = Portico;
+			productReference = A00000000000000000000012 /* Portico.app */;
+			productType = "com.apple.product-type.application";
+		};
+		A00000000000000000000031 /* PorticoTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A00000000000000000000082 /* Build configuration list for PBXNativeTarget "PorticoTests" */;
+			buildPhases = (A00000000000000000000053 /* Sources */, A00000000000000000000055 /* Frameworks */, A00000000000000000000054 /* Resources */,);
+			buildRules = ();
+			dependencies = (A00000000000000000000060 /* PBXTargetDependency */,);
+			name = PorticoTests;
+			productName = PorticoTests;
+			productReference = A00000000000000000000013 /* PorticoTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A00000000000000000000040 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {BuildIndependentTargetsInParallel = 1; LastSwiftUpdateCheck = 2630; LastUpgradeCheck = 2630; TargetAttributes = {A00000000000000000000030 = {CreatedOnToolsVersion = 26.3; }; A00000000000000000000031 = {CreatedOnToolsVersion = 26.3; TestTargetID = A00000000000000000000030; }; }; };
+			buildConfigurationList = A00000000000000000000080 /* Build configuration list for PBXProject "Portico" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (en, Base,);
+			mainGroup = A00000000000000000000020;
+			productRefGroup = A00000000000000000000023 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (A00000000000000000000030 /* Portico */, A00000000000000000000031 /* PorticoTests */,);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		A00000000000000000000051 /* Resources */ = {isa = PBXResourcesBuildPhase; buildActionMask = 2147483647; files = (); runOnlyForDeploymentPostprocessing = 0; };
+		A00000000000000000000054 /* Resources */ = {isa = PBXResourcesBuildPhase; buildActionMask = 2147483647; files = (); runOnlyForDeploymentPostprocessing = 0; };
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		A00000000000000000000056 /* Build and Embed Helper */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = ();
+			inputPaths = (
+				"$(SRCROOT)/helper/go.mod",
+				"$(SRCROOT)/helper/cmd/portico-helper/main.go",
+				"$(SRCROOT)/helper/internal/protocol/server.go",
+			);
+			name = "Build and Embed Helper";
+			outputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/$(CONTENTS_FOLDER_PATH)/Helpers/portico-helper",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/bash;
+			shellScript = "set -euo pipefail\nhelper_output=\"${BUILT_PRODUCTS_DIR}/${CONTENTS_FOLDER_PATH}/Helpers/portico-helper\"\nmkdir -p \"$(dirname \"${helper_output}\")\"\ncd \"${SRCROOT}/helper\"\nGOCACHE=\"${DERIVED_FILE_DIR}/go-build-cache\" go build -trimpath -o \"${helper_output}\" ./cmd/portico-helper\nchmod 755 \"${helper_output}\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A00000000000000000000050 /* Sources */ = {isa = PBXSourcesBuildPhase; buildActionMask = 2147483647; files = (A00000000000000000000001 /* PorticoApp.swift in Sources */, A0000000000000000000000A /* AppDelegate.swift in Sources */, A00000000000000000000004 /* HelperProtocol.swift in Sources */, A00000000000000000000006 /* HelperSupervisor.swift in Sources */, A00000000000000000000009 /* ProcessHelperLauncher.swift in Sources */,); runOnlyForDeploymentPostprocessing = 0; };
+		A00000000000000000000053 /* Sources */ = {isa = PBXSourcesBuildPhase; buildActionMask = 2147483647; files = (A00000000000000000000002 /* HelperProtocolTests.swift in Sources */, A00000000000000000000005 /* HelperSupervisorTests.swift in Sources */, A00000000000000000000007 /* HelperShutdownTests.swift in Sources */,); runOnlyForDeploymentPostprocessing = 0; };
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		A00000000000000000000060 /* PBXTargetDependency */ = {isa = PBXTargetDependency; target = A00000000000000000000030 /* Portico */; targetProxy = A00000000000000000000003 /* PBXContainerItemProxy */; };
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		A00000000000000000000070 /* Debug */ = {isa = XCBuildConfiguration; buildSettings = {CLANG_ENABLE_MODULES = YES; MACOSX_DEPLOYMENT_TARGET = 14.0; SDKROOT = macosx; SWIFT_VERSION = 5.0; }; name = Debug; };
+		A00000000000000000000071 /* Release */ = {isa = XCBuildConfiguration; buildSettings = {CLANG_ENABLE_MODULES = YES; MACOSX_DEPLOYMENT_TARGET = 14.0; SDKROOT = macosx; SWIFT_COMPILATION_MODE = wholemodule; SWIFT_VERSION = 5.0; }; name = Release; };
+		A00000000000000000000072 /* Debug */ = {isa = XCBuildConfiguration; buildSettings = {ARCHS = arm64; CODE_SIGNING_ALLOWED = NO; CODE_SIGNING_REQUIRED = NO; ENABLE_TESTABILITY = YES; ENABLE_USER_SCRIPT_SANDBOXING = NO; GENERATE_INFOPLIST_FILE = YES; INFOPLIST_KEY_LSUIElement = YES; MACOSX_DEPLOYMENT_TARGET = 14.0; ONLY_ACTIVE_ARCH = YES; PRODUCT_BUNDLE_IDENTIFIER = dev.chrisbanes.Portico; PRODUCT_NAME = "$(TARGET_NAME)"; SWIFT_OPTIMIZATION_LEVEL = "-Onone"; SWIFT_VERSION = 5.0; }; name = Debug; };
+		A00000000000000000000073 /* Release */ = {isa = XCBuildConfiguration; buildSettings = {ARCHS = arm64; CODE_SIGNING_ALLOWED = NO; CODE_SIGNING_REQUIRED = NO; ENABLE_USER_SCRIPT_SANDBOXING = NO; GENERATE_INFOPLIST_FILE = YES; INFOPLIST_KEY_LSUIElement = YES; MACOSX_DEPLOYMENT_TARGET = 14.0; ONLY_ACTIVE_ARCH = YES; PRODUCT_BUNDLE_IDENTIFIER = dev.chrisbanes.Portico; PRODUCT_NAME = "$(TARGET_NAME)"; SWIFT_VERSION = 5.0; }; name = Release; };
+		A00000000000000000000074 /* Debug */ = {isa = XCBuildConfiguration; buildSettings = {ARCHS = arm64; BUNDLE_LOADER = "$(TEST_HOST)"; CODE_SIGNING_ALLOWED = NO; GENERATE_INFOPLIST_FILE = YES; MACOSX_DEPLOYMENT_TARGET = 14.0; ONLY_ACTIVE_ARCH = YES; PRODUCT_BUNDLE_IDENTIFIER = dev.chrisbanes.PorticoTests; PRODUCT_NAME = "$(TARGET_NAME)"; SWIFT_VERSION = 5.0; TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Portico.app/Contents/MacOS/Portico"; }; name = Debug; };
+		A00000000000000000000075 /* Release */ = {isa = XCBuildConfiguration; buildSettings = {ARCHS = arm64; BUNDLE_LOADER = "$(TEST_HOST)"; CODE_SIGNING_ALLOWED = NO; GENERATE_INFOPLIST_FILE = YES; MACOSX_DEPLOYMENT_TARGET = 14.0; ONLY_ACTIVE_ARCH = YES; PRODUCT_BUNDLE_IDENTIFIER = dev.chrisbanes.PorticoTests; PRODUCT_NAME = "$(TARGET_NAME)"; SWIFT_VERSION = 5.0; TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Portico.app/Contents/MacOS/Portico"; }; name = Release; };
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		A00000000000000000000080 /* Build configuration list for PBXProject "Portico" */ = {isa = XCConfigurationList; buildConfigurations = (A00000000000000000000070 /* Debug */, A00000000000000000000071 /* Release */,); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
+		A00000000000000000000081 /* Build configuration list for PBXNativeTarget "Portico" */ = {isa = XCConfigurationList; buildConfigurations = (A00000000000000000000072 /* Debug */, A00000000000000000000073 /* Release */,); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
+		A00000000000000000000082 /* Build configuration list for PBXNativeTarget "PorticoTests" */ = {isa = XCConfigurationList; buildConfigurations = (A00000000000000000000074 /* Debug */, A00000000000000000000075 /* Release */,); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
+/* End XCConfigurationList section */
+	};
+	rootObject = A00000000000000000000040 /* Project object */;
+}

--- a/Portico.xcodeproj/xcshareddata/xcschemes/Portico.xcscheme
+++ b/Portico.xcodeproj/xcshareddata/xcschemes/Portico.xcscheme
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme LastUpgradeVersion="2630" version="1.7">
+   <BuildAction parallelizeBuildables="YES" buildImplicitDependencies="YES">
+      <BuildActionEntries>
+         <BuildActionEntry buildForTesting="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForAnalyzing="YES">
+            <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="A00000000000000000000030" BuildableName="Portico.app" BlueprintName="Portico" ReferencedContainer="container:Portico.xcodeproj"/>
+         </BuildActionEntry>
+         <BuildActionEntry buildForTesting="YES" buildForRunning="NO" buildForProfiling="NO" buildForArchiving="NO" buildForAnalyzing="NO">
+            <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="A00000000000000000000031" BuildableName="PorticoTests.xctest" BlueprintName="PorticoTests" ReferencedContainer="container:Portico.xcodeproj"/>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction buildConfiguration="Debug" selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB" selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB" shouldUseLaunchSchemeArgsEnv="YES">
+      <Testables>
+         <TestableReference skipped="NO">
+            <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="A00000000000000000000031" BuildableName="PorticoTests.xctest" BlueprintName="PorticoTests" ReferencedContainer="container:Portico.xcodeproj"/>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction buildConfiguration="Debug" selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB" selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB" launchStyle="0" useCustomWorkingDirectory="NO" ignoresPersistentStateOnLaunch="NO" debugDocumentVersioning="YES" debugServiceExtension="internal" allowLocationSimulation="YES">
+      <BuildableProductRunnable runnableDebuggingMode="0"><BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="A00000000000000000000030" BuildableName="Portico.app" BlueprintName="Portico" ReferencedContainer="container:Portico.xcodeproj"/></BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction buildConfiguration="Release" shouldUseLaunchSchemeArgsEnv="YES" savedToolIdentifier="" useCustomWorkingDirectory="NO" debugDocumentVersioning="YES"><BuildableProductRunnable runnableDebuggingMode="0"><BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="A00000000000000000000030" BuildableName="Portico.app" BlueprintName="Portico" ReferencedContainer="container:Portico.xcodeproj"/></BuildableProductRunnable></ProfileAction>
+   <AnalyzeAction buildConfiguration="Debug"/>
+   <ArchiveAction buildConfiguration="Release" revealArchiveInOrganizer="YES"/>
+</Scheme>

--- a/Portico/AppDelegate.swift
+++ b/Portico/AppDelegate.swift
@@ -1,0 +1,27 @@
+import AppKit
+
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    let supervisor: HelperSupervisor
+
+    override init() {
+        let helperURL = Bundle.main.bundleURL
+            .appendingPathComponent("Contents/Helpers/portico-helper", isDirectory: false)
+        let supervisor = HelperSupervisor(
+            helperURL: helperURL,
+            launcher: ProcessHelperLauncher()
+        )
+        self.supervisor = supervisor
+        super.init()
+    }
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        supervisor.start()
+    }
+
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        supervisor.shutdown {
+            sender.reply(toApplicationShouldTerminate: true)
+        }
+        return .terminateLater
+    }
+}

--- a/Portico/HelperProtocol.swift
+++ b/Portico/HelperProtocol.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+let helperProtocolVersion = 1
+
+enum HelperCommand: String, Codable {
+    case handshake
+    case shutdown
+}
+
+struct EmptyPayload: Codable, Equatable {}
+
+struct HelperRequest<Payload: Codable>: Codable {
+    let version: Int
+    let requestId: String
+    let command: HelperCommand
+    let payload: Payload
+}
+
+struct HelperResponse<Result: Codable>: Codable {
+    let version: Int
+    let requestId: String
+    let result: Result?
+    let error: HelperProtocolError?
+}
+
+struct HandshakeResult: Codable, Equatable {
+    let protocolVersion: Int
+}
+
+struct ShutdownResult: Codable, Equatable {
+    let accepted: Bool
+}
+
+struct HelperProtocolError: Codable, Equatable {
+    let code: String
+    let message: String
+}

--- a/Portico/HelperSupervisor.swift
+++ b/Portico/HelperSupervisor.swift
@@ -1,0 +1,178 @@
+import Foundation
+
+enum HelperAvailability: Equatable {
+    case connecting
+    case connected
+    case failed
+}
+
+protocol HelperProcess: AnyObject {
+    var isRunning: Bool { get }
+
+    func send(_ data: Data) throws
+    func closeInput()
+    func terminate()
+}
+
+protocol HelperLaunching {
+    func launch(
+        at executableURL: URL,
+        onLine: @escaping (Data) -> Void,
+        onEOF: @escaping () -> Void,
+        onExit: @escaping (Int32) -> Void
+    ) throws -> HelperProcess
+}
+
+final class HelperSupervisor: ObservableObject {
+    @Published private(set) var availability: HelperAvailability = .connecting
+
+    private let helperURL: URL
+    private let launcher: HelperLaunching
+    private let requestIDProvider: () -> String
+    private let handshakeTimeout: TimeInterval
+    private let shutdownGraceInterval: TimeInterval
+    private var process: HelperProcess?
+    private var handshakeRequestID: String?
+    private var handshakeTimeoutWorkItem: DispatchWorkItem?
+    private var shutdownTimeoutWorkItem: DispatchWorkItem?
+    private var isShuttingDown = false
+    private var isShutdownComplete = false
+    private var shutdownCompletions: [() -> Void] = []
+
+    init(
+        helperURL: URL,
+        launcher: HelperLaunching,
+        requestIDProvider: @escaping () -> String = { UUID().uuidString },
+        handshakeTimeout: TimeInterval = 3,
+        shutdownGraceInterval: TimeInterval = 1
+    ) {
+        self.helperURL = helperURL
+        self.launcher = launcher
+        self.requestIDProvider = requestIDProvider
+        self.handshakeTimeout = handshakeTimeout
+        self.shutdownGraceInterval = shutdownGraceInterval
+    }
+
+    func start() {
+        availability = .connecting
+        let requestID = requestIDProvider()
+        handshakeRequestID = requestID
+
+        do {
+            process = try launcher.launch(
+                at: helperURL,
+                onLine: { [weak self] data in self?.receive(line: data) },
+                onEOF: { [weak self] in self?.processExited() },
+                onExit: { [weak self] _ in self?.processExited() }
+            )
+            try send(command: .handshake, requestID: requestID)
+            let workItem = DispatchWorkItem { [weak self] in self?.fail() }
+            handshakeTimeoutWorkItem = workItem
+            DispatchQueue.main.asyncAfter(deadline: .now() + handshakeTimeout, execute: workItem)
+        } catch {
+            fail()
+        }
+    }
+
+    func shutdown(completion: @escaping () -> Void) {
+        if isShutdownComplete {
+            completion()
+            return
+        }
+
+        shutdownCompletions.append(completion)
+        guard !isShuttingDown else { return }
+        isShuttingDown = true
+        handshakeTimeoutWorkItem?.cancel()
+        handshakeTimeoutWorkItem = nil
+
+        guard process?.isRunning == true else {
+            finishShutdown()
+            return
+        }
+
+        do {
+            try send(command: .shutdown, requestID: requestIDProvider())
+            process?.closeInput()
+            let workItem = DispatchWorkItem { [weak self] in self?.forceShutdown() }
+            shutdownTimeoutWorkItem = workItem
+            DispatchQueue.main.asyncAfter(deadline: .now() + shutdownGraceInterval, execute: workItem)
+        } catch {
+            process?.closeInput()
+            process?.terminate()
+            finishShutdown()
+        }
+    }
+
+    private func receive(line: Data) {
+        guard !isShuttingDown else { return }
+        guard availability == .connecting else { return }
+        guard let response = try? JSONDecoder().decode(HelperResponse<HandshakeResult>.self, from: line) else {
+            fail()
+            return
+        }
+        guard response.requestId == handshakeRequestID else { return }
+        guard response.version == helperProtocolVersion,
+              response.error == nil,
+              response.result?.protocolVersion == helperProtocolVersion
+        else {
+            fail()
+            return
+        }
+
+        handshakeTimeoutWorkItem?.cancel()
+        handshakeTimeoutWorkItem = nil
+        availability = .connected
+    }
+
+    private func send(command: HelperCommand, requestID: String) throws {
+        var data = try JSONEncoder().encode(
+            HelperRequest(
+                version: helperProtocolVersion,
+                requestId: requestID,
+                command: command,
+                payload: EmptyPayload()
+            )
+        )
+        data.append(0x0A)
+        try process?.send(data)
+    }
+
+    private func fail() {
+        guard availability != .failed else { return }
+
+        handshakeTimeoutWorkItem?.cancel()
+        handshakeTimeoutWorkItem = nil
+        availability = .failed
+        process?.closeInput()
+        if process?.isRunning == true {
+            process?.terminate()
+        }
+    }
+
+    private func processExited() {
+        if isShuttingDown {
+            finishShutdown()
+        } else {
+            fail()
+        }
+    }
+
+    private func finishShutdown() {
+        guard !isShutdownComplete else { return }
+        shutdownTimeoutWorkItem?.cancel()
+        shutdownTimeoutWorkItem = nil
+        isShutdownComplete = true
+        let completions = shutdownCompletions
+        shutdownCompletions.removeAll()
+        completions.forEach { $0() }
+    }
+
+    private func forceShutdown() {
+        guard isShuttingDown, !isShutdownComplete else { return }
+        if process?.isRunning == true {
+            process?.terminate()
+        }
+        finishShutdown()
+    }
+}

--- a/Portico/PorticoApp.swift
+++ b/Portico/PorticoApp.swift
@@ -1,0 +1,44 @@
+import AppKit
+import SwiftUI
+
+@main
+struct PorticoApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+
+    var body: some Scene {
+        MenuBarExtra("Portico", systemImage: "door.left.hand.open") {
+            HelperStatusView(supervisor: appDelegate.supervisor)
+        }
+    }
+}
+
+private struct HelperStatusView: View {
+    @ObservedObject var supervisor: HelperSupervisor
+
+    var body: some View {
+        Label(supervisor.availability.title, systemImage: supervisor.availability.symbolName)
+        Divider()
+        Button("Quit Portico") {
+            NSApp.terminate(nil)
+        }
+        .keyboardShortcut("q")
+    }
+}
+
+private extension HelperAvailability {
+    var title: String {
+        switch self {
+        case .connecting: "Connecting"
+        case .connected: "Connected"
+        case .failed: "Helper unavailable"
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .connecting: "ellipsis.circle"
+        case .connected: "checkmark.circle"
+        case .failed: "exclamationmark.triangle"
+        }
+    }
+}

--- a/Portico/ProcessHelperLauncher.swift
+++ b/Portico/ProcessHelperLauncher.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+final class ProcessHelperLauncher: HelperLaunching {
+    func launch(
+        at executableURL: URL,
+        onLine: @escaping (Data) -> Void,
+        onEOF: @escaping () -> Void,
+        onExit: @escaping (Int32) -> Void
+    ) throws -> HelperProcess {
+        let process = Process()
+        let input = Pipe()
+        let output = Pipe()
+        let diagnostics = Pipe()
+        let lineBuffer = JSONLineBuffer()
+
+        process.executableURL = executableURL
+        process.standardInput = input
+        process.standardOutput = output
+        process.standardError = diagnostics
+
+        output.fileHandleForReading.readabilityHandler = { handle in
+            let data = handle.availableData
+            if data.isEmpty {
+                handle.readabilityHandler = nil
+                if let remainder = lineBuffer.finish() {
+                    DispatchQueue.main.async { onLine(remainder) }
+                }
+                DispatchQueue.main.async { onEOF() }
+                return
+            }
+
+            for line in lineBuffer.append(data) {
+                DispatchQueue.main.async { onLine(line) }
+            }
+        }
+        diagnostics.fileHandleForReading.readabilityHandler = { handle in
+            if handle.availableData.isEmpty {
+                handle.readabilityHandler = nil
+            }
+        }
+        process.terminationHandler = { process in
+            output.fileHandleForReading.readabilityHandler = nil
+            diagnostics.fileHandleForReading.readabilityHandler = nil
+            DispatchQueue.main.async { onExit(process.terminationStatus) }
+        }
+
+        do {
+            try process.run()
+        } catch {
+            output.fileHandleForReading.readabilityHandler = nil
+            diagnostics.fileHandleForReading.readabilityHandler = nil
+            throw error
+        }
+
+        return FoundationHelperProcess(process: process, input: input.fileHandleForWriting)
+    }
+}
+
+private final class FoundationHelperProcess: HelperProcess {
+    private let process: Process
+    private let input: FileHandle
+
+    init(process: Process, input: FileHandle) {
+        self.process = process
+        self.input = input
+    }
+
+    var isRunning: Bool { process.isRunning }
+
+    func send(_ data: Data) throws {
+        try input.write(contentsOf: data)
+    }
+
+    func closeInput() {
+        try? input.close()
+    }
+
+    func terminate() {
+        if process.isRunning {
+            process.terminate()
+        }
+    }
+}
+
+private final class JSONLineBuffer {
+    private let lock = NSLock()
+    private var buffer = Data()
+
+    func append(_ data: Data) -> [Data] {
+        lock.lock()
+        defer { lock.unlock() }
+
+        buffer.append(data)
+        var lines: [Data] = []
+        while let newline = buffer.firstIndex(of: 0x0A) {
+            var line = Data(buffer[..<newline])
+            buffer.removeSubrange(...newline)
+            if line.last == 0x0D {
+                line.removeLast()
+            }
+            lines.append(line)
+        }
+        return lines
+    }
+
+    func finish() -> Data? {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard !buffer.isEmpty else { return nil }
+        defer { buffer.removeAll() }
+        return buffer
+    }
+}

--- a/PorticoTests/HelperProtocolTests.swift
+++ b/PorticoTests/HelperProtocolTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import Portico
+
+final class HelperProtocolTests: XCTestCase {
+    func testDecodesVersionOneHandshakeResponse() throws {
+        let fixture = Data(#"{"version":1,"requestId":"request-1","result":{"protocolVersion":1}}"#.utf8)
+
+        let response = try JSONDecoder().decode(HelperResponse<HandshakeResult>.self, from: fixture)
+
+        XCTAssertEqual(response.version, 1)
+        XCTAssertEqual(response.requestId, "request-1")
+        XCTAssertEqual(response.result?.protocolVersion, 1)
+        XCTAssertNil(response.error)
+    }
+
+    func testDecodesStructuredProtocolError() throws {
+        let fixture = Data(#"{"version":1,"requestId":"request-2","error":{"code":"unknownCommand","message":"unsupported command"}}"#.utf8)
+
+        let response = try JSONDecoder().decode(HelperResponse<HandshakeResult>.self, from: fixture)
+
+        XCTAssertEqual(response.version, 1)
+        XCTAssertEqual(response.requestId, "request-2")
+        XCTAssertNil(response.result)
+        XCTAssertEqual(response.error, HelperProtocolError(code: "unknownCommand", message: "unsupported command"))
+    }
+}

--- a/PorticoTests/HelperShutdownTests.swift
+++ b/PorticoTests/HelperShutdownTests.swift
@@ -1,0 +1,102 @@
+import Foundation
+import XCTest
+@testable import Portico
+
+@MainActor
+final class HelperShutdownTests: XCTestCase {
+    func testWaitsForGracefulHelperExitBeforeCompleting() throws {
+        let launcher = FakeHelperLauncher()
+        var requestIDs = ["handshake-1", "shutdown-1"]
+        let supervisor = HelperSupervisor(
+            helperURL: URL(fileURLWithPath: "/unused/portico-helper"),
+            launcher: launcher,
+            requestIDProvider: { requestIDs.removeFirst() },
+            handshakeTimeout: 1,
+            shutdownGraceInterval: 1
+        )
+        supervisor.start()
+        launcher.receive(line: #"{"version":1,"requestId":"handshake-1","result":{"protocolVersion":1}}"#)
+        var completionCount = 0
+
+        supervisor.shutdown { completionCount += 1 }
+
+        XCTAssertEqual(completionCount, 0)
+        XCTAssertTrue(launcher.process.inputClosed)
+        XCTAssertFalse(launcher.process.terminated)
+        let requestData = try XCTUnwrap(launcher.process.sent.last)
+        let request = try JSONDecoder().decode(HelperRequest<EmptyPayload>.self, from: requestData)
+        XCTAssertEqual(request.requestId, "shutdown-1")
+        XCTAssertEqual(request.command, .shutdown)
+
+        launcher.receive(line: #"{"version":1,"requestId":"shutdown-1","result":{"accepted":true}}"#)
+        XCTAssertEqual(completionCount, 0)
+        launcher.exit(status: 0)
+
+        XCTAssertEqual(completionCount, 1)
+        XCTAssertFalse(launcher.process.terminated)
+    }
+
+    func testTerminatesOwnedProcessAfterGraceTimeout() async throws {
+        let launcher = FakeHelperLauncher()
+        var requestIDs = ["handshake-1", "shutdown-1"]
+        let supervisor = HelperSupervisor(
+            helperURL: URL(fileURLWithPath: "/unused/portico-helper"),
+            launcher: launcher,
+            requestIDProvider: { requestIDs.removeFirst() },
+            handshakeTimeout: 1,
+            shutdownGraceInterval: 0.01
+        )
+        supervisor.start()
+        launcher.receive(line: #"{"version":1,"requestId":"handshake-1","result":{"protocolVersion":1}}"#)
+        var completionCount = 0
+
+        supervisor.shutdown { completionCount += 1 }
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertTrue(launcher.process.terminated)
+        XCTAssertEqual(completionCount, 1)
+    }
+
+    func testAlreadyExitedChildCompletesImmediately() {
+        let launcher = FakeHelperLauncher()
+        let supervisor = HelperSupervisor(
+            helperURL: URL(fileURLWithPath: "/unused/portico-helper"),
+            launcher: launcher,
+            requestIDProvider: { "request-1" }
+        )
+        supervisor.start()
+        launcher.exit(status: 1)
+        var completionCount = 0
+
+        supervisor.shutdown { completionCount += 1 }
+
+        XCTAssertEqual(completionCount, 1)
+        XCTAssertEqual(launcher.process.sent.count, 1)
+    }
+
+    func testRepeatedTerminationRequestsShareOneShutdown() {
+        let launcher = FakeHelperLauncher()
+        var requestIDs = ["handshake-1", "shutdown-1"]
+        let supervisor = HelperSupervisor(
+            helperURL: URL(fileURLWithPath: "/unused/portico-helper"),
+            launcher: launcher,
+            requestIDProvider: { requestIDs.removeFirst() },
+            shutdownGraceInterval: 1
+        )
+        supervisor.start()
+        launcher.receive(line: #"{"version":1,"requestId":"handshake-1","result":{"protocolVersion":1}}"#)
+        var completionCount = 0
+
+        supervisor.shutdown { completionCount += 1 }
+        supervisor.shutdown { completionCount += 1 }
+
+        XCTAssertEqual(launcher.process.sent.count, 2)
+        XCTAssertEqual(completionCount, 0)
+        launcher.exit(status: 0)
+        XCTAssertEqual(completionCount, 2)
+
+        supervisor.shutdown { completionCount += 1 }
+        XCTAssertEqual(completionCount, 3)
+        XCTAssertEqual(launcher.process.sent.count, 2)
+    }
+}

--- a/PorticoTests/HelperSupervisorTests.swift
+++ b/PorticoTests/HelperSupervisorTests.swift
@@ -1,0 +1,126 @@
+import Foundation
+import XCTest
+@testable import Portico
+
+@MainActor
+final class HelperSupervisorTests: XCTestCase {
+    func testConnectsOnlyForCorrelatedHandshake() throws {
+        let launcher = FakeHelperLauncher()
+        let supervisor = HelperSupervisor(
+            helperURL: URL(fileURLWithPath: "/unused/portico-helper"),
+            launcher: launcher,
+            requestIDProvider: { "request-1" },
+            handshakeTimeout: 1
+        )
+
+        supervisor.start()
+
+        XCTAssertEqual(supervisor.availability, .connecting)
+        let requestData = try XCTUnwrap(launcher.process.sent.first)
+        let request = try JSONDecoder().decode(HelperRequest<EmptyPayload>.self, from: requestData)
+        XCTAssertEqual(request.version, 1)
+        XCTAssertEqual(request.requestId, "request-1")
+        XCTAssertEqual(request.command, .handshake)
+
+        launcher.receive(line: #"{"version":1,"requestId":"other","result":{"protocolVersion":1}}"#)
+        XCTAssertEqual(supervisor.availability, .connecting)
+
+        launcher.receive(line: #"{"version":1,"requestId":"request-1","result":{"protocolVersion":1}}"#)
+        XCTAssertEqual(supervisor.availability, .connected)
+    }
+
+    func testHandshakeTimeoutFailsAndTerminatesOwnedProcess() async throws {
+        let launcher = FakeHelperLauncher()
+        let supervisor = HelperSupervisor(
+            helperURL: URL(fileURLWithPath: "/unused/portico-helper"),
+            launcher: launcher,
+            requestIDProvider: { "request-1" },
+            handshakeTimeout: 0.01
+        )
+
+        supervisor.start()
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(supervisor.availability, .failed)
+        XCTAssertTrue(launcher.process.inputClosed)
+        XCTAssertTrue(launcher.process.terminated)
+    }
+
+    func testHandshakeFailuresBecomeUnavailable() {
+        let failures: [(String, (FakeHelperLauncher) -> Void)] = [
+            ("malformed line", { $0.receive(line: "{") }),
+            ("correlated error", { $0.receive(line: #"{"version":1,"requestId":"request-1","error":{"code":"unsupportedVersion","message":"unsupported protocol version"}}"#) }),
+            ("unsupported response version", { $0.receive(line: #"{"version":2,"requestId":"request-1","result":{"protocolVersion":1}}"#) }),
+            ("EOF", { $0.receiveEOF() }),
+            ("nonzero exit", { $0.exit(status: 1) }),
+        ]
+
+        for (name, trigger) in failures {
+            let launcher = FakeHelperLauncher()
+            let supervisor = HelperSupervisor(
+                helperURL: URL(fileURLWithPath: "/unused/portico-helper"),
+                launcher: launcher,
+                requestIDProvider: { "request-1" },
+                handshakeTimeout: 1
+            )
+            supervisor.start()
+
+            trigger(launcher)
+
+            XCTAssertEqual(supervisor.availability, .failed, name)
+            XCTAssertTrue(launcher.process.inputClosed, name)
+        }
+    }
+}
+
+final class FakeHelperLauncher: HelperLaunching {
+    let process = FakeHelperProcess()
+    private var onLine: ((Data) -> Void)?
+    private var onEOF: (() -> Void)?
+    private var onExit: ((Int32) -> Void)?
+
+    func launch(
+        at executableURL: URL,
+        onLine: @escaping (Data) -> Void,
+        onEOF: @escaping () -> Void,
+        onExit: @escaping (Int32) -> Void
+    ) throws -> HelperProcess {
+        self.onLine = onLine
+        self.onEOF = onEOF
+        self.onExit = onExit
+        return process
+    }
+
+    func receive(line: String) {
+        onLine?(Data(line.utf8))
+    }
+
+    func receiveEOF() {
+        onEOF?()
+    }
+
+    func exit(status: Int32) {
+        process.isRunning = false
+        onExit?(status)
+    }
+}
+
+final class FakeHelperProcess: HelperProcess {
+    var isRunning = true
+    var sent: [Data] = []
+    private(set) var inputClosed = false
+    private(set) var terminated = false
+
+    func send(_ data: Data) throws {
+        sent.append(data)
+    }
+
+    func closeInput() {
+        inputClosed = true
+    }
+
+    func terminate() {
+        terminated = true
+        isRunning = false
+    }
+}

--- a/README.md
+++ b/README.md
@@ -4,8 +4,53 @@ Portico gives local web apps stable, private HTTPS addresses on a Tailscale
 tailnet. Each Portal is an independent Tailscale node and proxies its HTTPS
 traffic to one HTTP service on the local Mac.
 
-Portico is currently in the design and executable-spike phase. There is no
-buildable application in the repository yet.
+Portico is currently in the design and executable-spike phase. The repository
+contains a local-only menu bar app and supervised helper process; it does not
+yet implement Portal networking.
+
+## Local development
+
+Prerequisites:
+
+- An Apple silicon Mac running macOS 14 or later
+- Xcode 26.3 selected with `xcode-select`
+- Go 1.26.5
+
+Build the app and its bundled helper:
+
+```shell
+xcodebuild \
+  -project Portico.xcodeproj \
+  -scheme Portico \
+  -destination 'platform=macOS' \
+  -derivedDataPath .build/xcode \
+  build
+```
+
+Launch the result:
+
+```shell
+open .build/xcode/Build/Products/Debug/Portico.app
+```
+
+Run the unit tests:
+
+```shell
+(cd helper && go test ./...)
+xcodebuild \
+  -project Portico.xcodeproj \
+  -scheme Portico \
+  -destination 'platform=macOS' \
+  -derivedDataPath .build/xcode \
+  test
+```
+
+Run the local app smoke test, which builds and launches the app, verifies its
+bundled helper process, and confirms that both stop cleanly:
+
+```shell
+./Scripts/smoke-test-local-app.sh
+```
 
 ## Documentation
 

--- a/Scripts/smoke-test-local-app.sh
+++ b/Scripts/smoke-test-local-app.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/.." && pwd)"
+derived_data="$repo_root/.build/xcode"
+app="$derived_data/Build/Products/Debug/Portico.app"
+app_executable="$app/Contents/MacOS/Portico"
+helper="$app/Contents/Helpers/portico-helper"
+app_pid=""
+helper_pid=""
+
+cleanup() {
+  if [[ -n "$app_pid" ]] && kill -0 "$app_pid" 2>/dev/null; then
+    kill "$app_pid" 2>/dev/null || true
+  fi
+  if [[ -n "$helper_pid" ]] && kill -0 "$helper_pid" 2>/dev/null; then
+    kill "$helper_pid" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+cd "$repo_root"
+xcodebuild \
+  -project Portico.xcodeproj \
+  -scheme Portico \
+  -destination 'platform=macOS,arch=arm64' \
+  -derivedDataPath "$derived_data" \
+  ONLY_ACTIVE_ARCH=YES \
+  ARCHS=arm64 \
+  build
+
+[[ -x "$app_executable" ]] || { echo "Portico app executable is missing" >&2; exit 1; }
+[[ -x "$helper" ]] || { echo "Bundled helper is missing or not executable" >&2; exit 1; }
+[[ "$(/usr/libexec/PlistBuddy -c 'Print :LSUIElement' "$app/Contents/Info.plist")" == "true" ]] || {
+  echo "Built app is not configured as a menu-bar-only application" >&2
+  exit 1
+}
+
+"$app_executable" &
+app_pid=$!
+
+for _ in {1..100}; do
+  helper_pid="$(pgrep -P "$app_pid" -x portico-helper 2>/dev/null || true)"
+  [[ -n "$helper_pid" ]] && break
+  sleep 0.1
+done
+
+[[ "$helper_pid" =~ ^[0-9]+$ ]] || { echo "Expected exactly one helper child PID" >&2; exit 1; }
+sleep 3.5
+kill -0 "$app_pid" 2>/dev/null || { echo "Portico exited before the handshake window completed" >&2; exit 1; }
+kill -0 "$helper_pid" 2>/dev/null || { echo "Bundled helper did not survive the handshake window" >&2; exit 1; }
+
+osascript -e 'tell application id "dev.chrisbanes.Portico" to quit'
+
+for _ in {1..100}; do
+  if ! kill -0 "$app_pid" 2>/dev/null; then
+    break
+  fi
+  sleep 0.1
+done
+
+kill -0 "$app_pid" 2>/dev/null && { echo "Portico did not quit" >&2; exit 1; }
+kill -0 "$helper_pid" 2>/dev/null && { echo "Recorded helper PID survived Portico quit" >&2; exit 1; }
+
+app_pid=""
+helper_pid=""
+echo "Portico local app smoke test passed"

--- a/helper/cmd/portico-helper/main.go
+++ b/helper/cmd/portico-helper/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"os"
+
+	"github.com/chrisbanes/portico/helper/internal/protocol"
+)
+
+func main() {
+	os.Exit(protocol.Serve(os.Stdin, os.Stdout, os.Stderr))
+}

--- a/helper/go.mod
+++ b/helper/go.mod
@@ -1,0 +1,3 @@
+module github.com/chrisbanes/portico/helper
+
+go 1.26

--- a/helper/internal/protocol/server.go
+++ b/helper/internal/protocol/server.go
@@ -1,0 +1,107 @@
+package protocol
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"io"
+)
+
+const Version = 1
+
+const invalidRequestDiagnostic = "portico-helper: invalid request\n"
+
+type request struct {
+	Version   *int            `json:"version"`
+	RequestID string          `json:"requestId"`
+	Command   string          `json:"command"`
+	Payload   json.RawMessage `json:"payload"`
+}
+
+type response struct {
+	Version   int            `json:"version"`
+	RequestID string         `json:"requestId"`
+	Result    any            `json:"result,omitempty"`
+	Error     *protocolError `json:"error,omitempty"`
+}
+
+type protocolError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type handshakeResult struct {
+	ProtocolVersion int `json:"protocolVersion"`
+}
+
+type shutdownResult struct {
+	Accepted bool `json:"accepted"`
+}
+
+func Serve(input io.Reader, output, diagnostics io.Writer) int {
+	scanner := bufio.NewScanner(input)
+	encoder := json.NewEncoder(output)
+	for scanner.Scan() {
+		var request request
+		decoder := json.NewDecoder(bytes.NewReader(scanner.Bytes()))
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&request); err != nil || decoder.Decode(&struct{}{}) != io.EOF || !request.isValid() {
+			_, _ = io.WriteString(diagnostics, invalidRequestDiagnostic)
+			return 1
+		}
+		if requestVersion := *request.Version; requestVersion != Version {
+			if err := encoder.Encode(response{
+				Version:   Version,
+				RequestID: request.RequestID,
+				Error: &protocolError{
+					Code:    "unsupportedVersion",
+					Message: "unsupported protocol version",
+				},
+			}); err != nil {
+				return 1
+			}
+			continue
+		}
+		if request.Command == "handshake" {
+			if err := encoder.Encode(response{
+				Version:   Version,
+				RequestID: request.RequestID,
+				Result:    handshakeResult{ProtocolVersion: Version},
+			}); err != nil {
+				return 1
+			}
+		} else if request.Command == "shutdown" {
+			if err := encoder.Encode(response{
+				Version:   Version,
+				RequestID: request.RequestID,
+				Result:    shutdownResult{Accepted: true},
+			}); err != nil {
+				return 1
+			}
+			return 0
+		} else if err := encoder.Encode(response{
+			Version:   Version,
+			RequestID: request.RequestID,
+			Error: &protocolError{
+				Code:    "unknownCommand",
+				Message: "unsupported command",
+			},
+		}); err != nil {
+			return 1
+		}
+	}
+	if scanner.Err() != nil {
+		_, _ = io.WriteString(diagnostics, invalidRequestDiagnostic)
+		return 1
+	}
+	return 0
+}
+
+func (request request) isValid() bool {
+	if request.Version == nil || request.RequestID == "" || request.Command == "" || len(request.Payload) == 0 {
+		return false
+	}
+
+	var payload map[string]json.RawMessage
+	return json.Unmarshal(request.Payload, &payload) == nil && payload != nil && len(payload) == 0
+}

--- a/helper/internal/protocol/server_test.go
+++ b/helper/internal/protocol/server_test.go
@@ -1,0 +1,165 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestServeCorrelatesHandshakeResponse(t *testing.T) {
+	input := bytes.NewBufferString(`{"version":1,"requestId":"request-1","command":"handshake","payload":{}}` + "\n")
+	var output bytes.Buffer
+	var diagnostics bytes.Buffer
+
+	exitCode := Serve(input, &output, &diagnostics)
+
+	if exitCode != 0 {
+		t.Fatalf("Serve() exit code = %d, want 0", exitCode)
+	}
+	var response struct {
+		Version   int             `json:"version"`
+		RequestID string          `json:"requestId"`
+		Result    json.RawMessage `json:"result"`
+	}
+	if err := json.NewDecoder(&output).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Version != 1 || response.RequestID != "request-1" || string(response.Result) != `{"protocolVersion":1}` {
+		t.Fatalf("response = %+v, want correlated version-one handshake", response)
+	}
+	if diagnostics.Len() != 0 {
+		t.Fatalf("diagnostics = %q, want empty", diagnostics.String())
+	}
+}
+
+func TestServeAcknowledgesShutdownAndStops(t *testing.T) {
+	input := bytes.NewBufferString(
+		`{"version":1,"requestId":"shutdown-1","command":"shutdown","payload":{}}` + "\n" +
+			`{"version":1,"requestId":"ignored","command":"handshake","payload":{}}` + "\n",
+	)
+	var output bytes.Buffer
+	var diagnostics bytes.Buffer
+
+	exitCode := Serve(input, &output, &diagnostics)
+
+	if exitCode != 0 {
+		t.Fatalf("Serve() exit code = %d, want 0", exitCode)
+	}
+	const want = "{\"version\":1,\"requestId\":\"shutdown-1\",\"result\":{\"accepted\":true}}\n"
+	if output.String() != want {
+		t.Fatalf("output = %q, want %q", output.String(), want)
+	}
+	if diagnostics.Len() != 0 {
+		t.Fatalf("diagnostics = %q, want empty", diagnostics.String())
+	}
+}
+
+func TestServeReturnsCorrelatedErrorForUnknownCommand(t *testing.T) {
+	input := bytes.NewBufferString(`{"version":1,"requestId":"unknown-1","command":"surprise","payload":{}}` + "\n")
+	var output bytes.Buffer
+	var diagnostics bytes.Buffer
+
+	exitCode := Serve(input, &output, &diagnostics)
+
+	if exitCode != 0 {
+		t.Fatalf("Serve() exit code = %d, want 0", exitCode)
+	}
+	const want = "{\"version\":1,\"requestId\":\"unknown-1\",\"error\":{\"code\":\"unknownCommand\",\"message\":\"unsupported command\"}}\n"
+	if output.String() != want {
+		t.Fatalf("output = %q, want %q", output.String(), want)
+	}
+	if diagnostics.Len() != 0 {
+		t.Fatalf("diagnostics = %q, want empty", diagnostics.String())
+	}
+}
+
+func TestServeReturnsCorrelatedErrorForUnsupportedVersion(t *testing.T) {
+	input := bytes.NewBufferString(`{"version":2,"requestId":"version-1","command":"handshake","payload":{}}` + "\n")
+	var output bytes.Buffer
+	var diagnostics bytes.Buffer
+
+	exitCode := Serve(input, &output, &diagnostics)
+
+	if exitCode != 0 {
+		t.Fatalf("Serve() exit code = %d, want 0", exitCode)
+	}
+	const want = "{\"version\":1,\"requestId\":\"version-1\",\"error\":{\"code\":\"unsupportedVersion\",\"message\":\"unsupported protocol version\"}}\n"
+	if output.String() != want {
+		t.Fatalf("output = %q, want %q", output.String(), want)
+	}
+	if diagnostics.Len() != 0 {
+		t.Fatalf("diagnostics = %q, want empty", diagnostics.String())
+	}
+}
+
+func TestServeRejectsMalformedInputWithoutLeakingIt(t *testing.T) {
+	const secret = "token=do-not-copy"
+	input := bytes.NewBufferString(`{"version":1,"requestId":"` + secret + `"` + "\n")
+	var output bytes.Buffer
+	var diagnostics bytes.Buffer
+
+	exitCode := Serve(input, &output, &diagnostics)
+
+	if exitCode == 0 {
+		t.Fatal("Serve() exit code = 0, want unsuccessful")
+	}
+	if output.Len() != 0 {
+		t.Fatalf("output = %q, want empty", output.String())
+	}
+	const wantDiagnostic = "portico-helper: invalid request\n"
+	if diagnostics.String() != wantDiagnostic {
+		t.Fatalf("diagnostics = %q, want %q", diagnostics.String(), wantDiagnostic)
+	}
+	if strings.Contains(output.String(), secret) || strings.Contains(diagnostics.String(), secret) {
+		t.Fatal("untrusted input was copied to a protocol or diagnostic stream")
+	}
+}
+
+func TestServeRejectsTrailingContentAfterRequest(t *testing.T) {
+	input := bytes.NewBufferString(`{"version":1,"requestId":"request-1","command":"handshake","payload":{}} trailing` + "\n")
+	var output bytes.Buffer
+	var diagnostics bytes.Buffer
+
+	exitCode := Serve(input, &output, &diagnostics)
+
+	if exitCode == 0 || output.Len() != 0 || diagnostics.String() != "portico-helper: invalid request\n" {
+		t.Fatalf("Serve() = (exit %d, output %q, diagnostics %q), want unsuccessful, empty protocol output, fixed diagnostic", exitCode, output.String(), diagnostics.String())
+	}
+}
+
+func TestServeRejectsStructurallyInvalidRequests(t *testing.T) {
+	fixtures := map[string]string{
+		"missing version":    `{"requestId":"request-1","command":"handshake","payload":{}}`,
+		"missing request ID": `{"version":1,"command":"handshake","payload":{}}`,
+		"missing command":    `{"version":1,"requestId":"request-1","payload":{}}`,
+		"missing payload":    `{"version":1,"requestId":"request-1","command":"handshake"}`,
+		"non-object payload": `{"version":1,"requestId":"request-1","command":"handshake","payload":[]}`,
+		"non-empty payload":  `{"version":1,"requestId":"request-1","command":"handshake","payload":{"unexpected":true}}`,
+		"unknown field":      `{"version":1,"requestId":"request-1","command":"handshake","payload":{},"extra":true}`,
+	}
+
+	for name, fixture := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			var output bytes.Buffer
+			var diagnostics bytes.Buffer
+
+			exitCode := Serve(bytes.NewBufferString(fixture+"\n"), &output, &diagnostics)
+
+			if exitCode == 0 || output.Len() != 0 || diagnostics.String() != "portico-helper: invalid request\n" {
+				t.Fatalf("Serve() = (exit %d, output %q, diagnostics %q), want unsuccessful, empty protocol output, fixed diagnostic", exitCode, output.String(), diagnostics.String())
+			}
+		})
+	}
+}
+
+func TestServeExitsCleanlyOnEOF(t *testing.T) {
+	var output bytes.Buffer
+	var diagnostics bytes.Buffer
+
+	exitCode := Serve(bytes.NewReader(nil), &output, &diagnostics)
+
+	if exitCode != 0 || output.Len() != 0 || diagnostics.Len() != 0 {
+		t.Fatalf("Serve() = (exit %d, output %q, diagnostics %q), want clean EOF", exitCode, output.String(), diagnostics.String())
+	}
+}


### PR DESCRIPTION
## Summary

- add a macOS 14 `LSUIElement` menu-bar app with typed connecting, connected, and unavailable states
- build and embed one local arm64 Go helper with a strict version-one JSON Lines handshake and shutdown protocol
- supervise launch, correlation, timeout, pipe teardown, and bounded app-termination cleanup
- add Go and Swift coverage plus an exact child-PID lifecycle smoke test
- document the local build, test, launch, and smoke commands

## Why

This establishes Portico's first executable vertical seam while preserving the documented boundary: Swift owns the app and process supervision, and one bundled Go process owns helper runtime state. Tailscale, Portal behavior, restart policy, universal packaging, and release signing remain intentionally out of scope.

## Validation

- `cd helper && go test ./...`
- `xcodebuild -project Portico.xcodeproj -scheme Portico -destination 'platform=macOS' -derivedDataPath .build/xcode test` — 9 tests passed
- `./Scripts/smoke-test-local-app.sh` — built and launched the app, observed exactly one bundled helper child, and confirmed the recorded PID was gone after quit

## Review

- Standards and Spec code-review axes: clean after fixing strict end-of-line JSON and typed empty-payload validation
- review-and-simplify: clean after centralizing request framing and removing dead lifecycle/PID indirection
- ponytail-review: `Lean already. Ship.`

## Residual risk

- this is deliberately an unsigned local arm64 developer build; universal slices, signing, notarization, and release packaging remain follow-up work
- the forced termination path is unit-tested through the owned-process seam; the real smoke covers the cooperative bundled helper end to end

Fixes #1
