### PR TITLE
Make Portal HTTP proxying production-safe

### DIFF
--- a/helper/go.mod
+++ b/helper/go.mod
@@ -2,13 +2,15 @@ module github.com/chrisbanes/portico/helper
 
 go 1.26.5
 
-require tailscale.com v1.102.0
+require (
+	github.com/coder/websocket v1.8.14
+	tailscale.com v1.102.0
+)
 
 require (
 	filippo.io/edwards25519 v1.2.0 // indirect
 	github.com/akutz/memconn v0.1.0 // indirect
 	github.com/alexbrainman/sspi v0.0.0-20231016080023-1a75b4708caa // indirect
-	github.com/coder/websocket v1.8.14 // indirect
 	github.com/creachadair/msync v0.8.1 // indirect
 	github.com/dblohm7/wingoes v0.0.0-20240119213807-a09d6be7affa // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect

--- a/helper/internal/portal/proxy.go
+++ b/helper/internal/portal/proxy.go
@@ -1,23 +1,34 @@
 package portal
 
 import (
+	"context"
 	"errors"
+	"io"
+	"log"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"strconv"
+	"sync"
+	"time"
 )
+
+const proxyShutdownTimeout = 500 * time.Millisecond
 
 func newLoopbackProxy(port int) (http.Handler, error) {
 	if port < 1 || port > 65535 {
 		return nil, errors.New("invalid Local App port")
 	}
 	target := loopbackDestination(port)
-	proxy := httputil.NewSingleHostReverseProxy(target)
-	director := proxy.Director
-	proxy.Director = func(request *http.Request) {
-		director(request)
-		request.Host = target.Host
+	proxy := &httputil.ReverseProxy{
+		Rewrite: func(request *httputil.ProxyRequest) {
+			request.SetURL(target)
+			request.SetXForwarded()
+			request.Out.Header.Set("X-Forwarded-Proto", "https")
+		},
+		FlushInterval: -1,
+		ErrorLog:      log.New(io.Discard, "", 0),
 	}
 	proxy.ErrorHandler = func(writer http.ResponseWriter, _ *http.Request, _ error) {
 		http.Error(writer, http.StatusText(http.StatusBadGateway), http.StatusBadGateway)
@@ -27,4 +38,87 @@ func newLoopbackProxy(port int) (http.Handler, error) {
 
 func loopbackDestination(port int) *url.URL {
 	return &url.URL{Scheme: "http", Host: "127.0.0.1:" + strconv.Itoa(port)}
+}
+
+type proxyServer struct {
+	cancel   context.CancelFunc
+	server   *http.Server
+	listener net.Listener
+	handler  *trackedHandler
+	done     chan error
+}
+
+func startProxyServer(ctx context.Context, listener net.Listener, handler http.Handler) *proxyServer {
+	serveContext, cancel := context.WithCancel(ctx)
+	tracked := &trackedHandler{handler: handler, isAccepting: true}
+	server := &http.Server{
+		Handler: tracked,
+		BaseContext: func(net.Listener) context.Context {
+			return serveContext
+		},
+		ErrorLog: log.New(io.Discard, "", 0),
+	}
+	proxy := &proxyServer{
+		cancel:   cancel,
+		server:   server,
+		listener: listener,
+		handler:  tracked,
+		done:     make(chan error, 1),
+	}
+	go func() {
+		proxy.done <- server.Serve(listener)
+	}()
+	return proxy
+}
+
+func (p *proxyServer) close() error {
+	p.cancel()
+	p.handler.stopAccepting()
+	shutdownContext, cancel := context.WithTimeout(context.Background(), proxyShutdownTimeout)
+	shutdownErr := p.server.Shutdown(shutdownContext)
+	cancel()
+	closeErr := p.server.Close()
+	listenerErr := p.listener.Close()
+	p.handler.wait()
+	serveErr := <-p.done
+	if errors.Is(closeErr, http.ErrServerClosed) || errors.Is(closeErr, net.ErrClosed) {
+		closeErr = nil
+	}
+	if errors.Is(listenerErr, net.ErrClosed) {
+		listenerErr = nil
+	}
+	if errors.Is(serveErr, http.ErrServerClosed) || errors.Is(serveErr, net.ErrClosed) {
+		serveErr = nil
+	}
+	return errors.Join(shutdownErr, closeErr, listenerErr, serveErr)
+}
+
+type trackedHandler struct {
+	mu          sync.Mutex
+	handler     http.Handler
+	isAccepting bool
+	active      sync.WaitGroup
+}
+
+func (h *trackedHandler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	h.mu.Lock()
+	if !h.isAccepting {
+		h.mu.Unlock()
+		http.Error(writer, http.StatusText(http.StatusServiceUnavailable), http.StatusServiceUnavailable)
+		return
+	}
+	h.active.Add(1)
+	h.mu.Unlock()
+	defer h.active.Done()
+	h.handler.ServeHTTP(writer, request)
+}
+
+func (h *trackedHandler) stopAccepting() {
+	h.mu.Lock()
+	h.isAccepting = false
+	h.mu.Unlock()
+}
+
+func (h *trackedHandler) wait() {
+	h.active.Wait()
 }

--- a/helper/internal/portal/proxy_test.go
+++ b/helper/internal/portal/proxy_test.go
@@ -1,13 +1,19 @@
 package portal
 
 import (
+	"bytes"
+	"context"
 	"io"
+	"log"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/coder/websocket"
 )
 
 func TestLoopbackProxyPreservesPublicPathAndQuery(t *testing.T) {
@@ -16,11 +22,7 @@ func TestLoopbackProxyPreservesPublicPathAndQuery(t *testing.T) {
 		_, _ = io.WriteString(writer, request.URL.RequestURI())
 	}))
 	defer localApp.Close()
-	_, portText, err := net.SplitHostPort(strings.TrimPrefix(localApp.URL, "http://"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	port, _ := strconv.Atoi(portText)
+	port, portText := localAppPort(t, localApp.URL)
 	proxy, err := newLoopbackProxy(port)
 	if err != nil {
 		t.Fatalf("newLoopbackProxy: %v", err)
@@ -37,6 +39,249 @@ func TestLoopbackProxyPreservesPublicPathAndQuery(t *testing.T) {
 	if response.Header().Get("X-Local-App-Host") != wantAuthority {
 		t.Fatalf("Local App Host = %q, want %q", response.Header().Get("X-Local-App-Host"), wantAuthority)
 	}
+}
+
+func TestLoopbackProxyReplacesForwardingHeadersAndAuthority(t *testing.T) {
+	received := make(chan *http.Request, 1)
+	localApp := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		received <- request.Clone(request.Context())
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	defer localApp.Close()
+	port, portText := localAppPort(t, localApp.URL)
+	proxy, err := newLoopbackProxy(port)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request := httptest.NewRequest(http.MethodGet, "https://portal.example.ts.net/app", nil)
+	request.RemoteAddr = "100.64.0.7:54321"
+	request.Header.Set("Forwarded", "for=attacker;host=attacker.example;proto=http")
+	request.Header.Set("X-Forwarded-For", "192.0.2.1")
+	request.Header.Set("X-Forwarded-Host", "attacker.example")
+	request.Header.Set("X-Forwarded-Proto", "http")
+	proxy.ServeHTTP(httptest.NewRecorder(), request)
+
+	got := <-received
+	if got.Host != "127.0.0.1:"+portText {
+		t.Fatalf("Local App Host = %q, want loopback authority", got.Host)
+	}
+	if forwarded := got.Header.Get("Forwarded"); forwarded != "" {
+		t.Fatalf("Forwarded = %q, want removed", forwarded)
+	}
+	if forwardedFor := got.Header.Values("X-Forwarded-For"); len(forwardedFor) != 1 || forwardedFor[0] != "100.64.0.7" {
+		t.Fatalf("X-Forwarded-For = %q, want actual client address", forwardedFor)
+	}
+	if forwardedHost := got.Header.Values("X-Forwarded-Host"); len(forwardedHost) != 1 || forwardedHost[0] != "portal.example.ts.net" {
+		t.Fatalf("X-Forwarded-Host = %q, want public host", forwardedHost)
+	}
+	if forwardedProto := got.Header.Values("X-Forwarded-Proto"); len(forwardedProto) != 1 || forwardedProto[0] != "https" {
+		t.Fatalf("X-Forwarded-Proto = %q, want canonical HTTPS scheme", forwardedProto)
+	}
+}
+
+func TestLoopbackProxyDoesNotLogTrafficSecrets(t *testing.T) {
+	const (
+		requestSecret  = "request-body-do-not-log"
+		responseSecret = "response-body-do-not-log"
+		cookieSecret   = "cookie-do-not-log"
+		authSecret     = "authorization-do-not-log"
+	)
+	localApp := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		_, _ = io.Copy(io.Discard, request.Body)
+		writer.Header().Set("Set-Cookie", "session="+cookieSecret)
+		_, _ = io.WriteString(writer, responseSecret)
+	}))
+	defer localApp.Close()
+	port, _ := localAppPort(t, localApp.URL)
+
+	var logs bytes.Buffer
+	previousWriter := log.Writer()
+	previousFlags := log.Flags()
+	previousPrefix := log.Prefix()
+	log.SetOutput(&logs)
+	log.SetFlags(0)
+	log.SetPrefix("")
+	t.Cleanup(func() {
+		log.SetOutput(previousWriter)
+		log.SetFlags(previousFlags)
+		log.SetPrefix(previousPrefix)
+	})
+
+	proxy, err := newLoopbackProxy(port)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodPost, "https://portal.example.ts.net/", strings.NewReader(requestSecret))
+	request.Header.Set("Cookie", "session="+cookieSecret)
+	request.Header.Set("Authorization", "Bearer "+authSecret)
+	request.Header.Set("Proxy-Authorization", "Bearer "+authSecret)
+	proxy.ServeHTTP(httptest.NewRecorder(), request)
+
+	unavailable, err := newLoopbackProxy(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	failedRequest := httptest.NewRequest(http.MethodPost, "https://portal.example.ts.net/", strings.NewReader(requestSecret))
+	failedRequest.Header.Set("Cookie", "session="+cookieSecret)
+	failedRequest.Header.Set("Authorization", "Bearer "+authSecret)
+	unavailable.ServeHTTP(httptest.NewRecorder(), failedRequest)
+
+	for _, secret := range []string{requestSecret, responseSecret, cookieSecret, authSecret} {
+		if strings.Contains(logs.String(), secret) {
+			t.Fatalf("traffic secret appeared in logs")
+		}
+	}
+}
+
+func TestLoopbackProxyStreamsImmediately(t *testing.T) {
+	testLoopbackProxyImmediateWrite(t, "application/octet-stream", "first chunk\n", true)
+}
+
+func TestLoopbackProxyFlushesSSEImmediately(t *testing.T) {
+	testLoopbackProxyImmediateWrite(t, "text/event-stream", "data: first\n\n", false)
+}
+
+func testLoopbackProxyImmediateWrite(t *testing.T, contentType, firstWrite string, fixedLength bool) {
+	t.Helper()
+	release := make(chan struct{})
+	localApp := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("Content-Type", contentType)
+		if fixedLength {
+			writer.Header().Set("Content-Length", strconv.Itoa(len(firstWrite)+len("finished\n")))
+		}
+		_, _ = io.WriteString(writer, firstWrite)
+		writer.(http.Flusher).Flush()
+		<-release
+		_, _ = io.WriteString(writer, "finished\n")
+	}))
+	defer localApp.Close()
+	proxy := newTestProxyServer(t, localApp.URL)
+	defer proxy.Close()
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	response, err := client.Get(proxy.URL)
+	if err != nil {
+		close(release)
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	delivered := make([]byte, len(firstWrite))
+	_, err = io.ReadFull(response.Body, delivered)
+	if err != nil {
+		close(release)
+		t.Fatal(err)
+	}
+	if string(delivered) != firstWrite {
+		close(release)
+		t.Fatalf("first delivery = %q, want response before Local App completion", delivered)
+	}
+	close(release)
+}
+
+func TestLoopbackProxyProxiesWebSocketBidirectionally(t *testing.T) {
+	localApp := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		connection, err := websocket.Accept(writer, request, nil)
+		if err != nil {
+			return
+		}
+		defer connection.CloseNow()
+		messageType, message, err := connection.Read(request.Context())
+		if err != nil {
+			return
+		}
+		_ = connection.Write(request.Context(), messageType, append([]byte("app-to-client:"), message...))
+	}))
+	defer localApp.Close()
+	proxy := newTestProxyServer(t, localApp.URL)
+	defer proxy.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	connection, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(proxy.URL, "http"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer connection.CloseNow()
+	if err := connection.Write(ctx, websocket.MessageText, []byte("client-to-app")); err != nil {
+		t.Fatal(err)
+	}
+	messageType, message, err := connection.Read(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if messageType != websocket.MessageText || string(message) != "app-to-client:client-to-app" {
+		t.Fatalf("WebSocket response = (%v, %q), want distinct bidirectional messages", messageType, message)
+	}
+}
+
+func TestLoopbackProxyPropagatesCancellation(t *testing.T) {
+	requestEntered := make(chan struct{})
+	requestCanceled := make(chan struct{})
+	localApp := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, request *http.Request) {
+		close(requestEntered)
+		<-request.Context().Done()
+		close(requestCanceled)
+	}))
+	defer localApp.Close()
+	proxy := newTestProxyServer(t, localApp.URL)
+	defer proxy.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, proxy.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requestDone := make(chan error, 1)
+	go func() {
+		response, err := http.DefaultClient.Do(request)
+		if response != nil {
+			_ = response.Body.Close()
+		}
+		requestDone <- err
+	}()
+	select {
+	case <-requestEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Local App request did not start")
+	}
+	cancel()
+	select {
+	case <-requestCanceled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("client cancellation did not reach Local App")
+	}
+	select {
+	case err := <-requestDone:
+		if err == nil {
+			t.Fatal("client request completed without cancellation error")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("client request did not finish after cancellation")
+	}
+}
+
+func newTestProxyServer(t *testing.T, localAppURL string) *httptest.Server {
+	t.Helper()
+	port, _ := localAppPort(t, localAppURL)
+	proxy, err := newLoopbackProxy(port)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return httptest.NewServer(proxy)
+}
+
+func localAppPort(t *testing.T, localAppURL string) (int, string) {
+	t.Helper()
+	_, portText, err := net.SplitHostPort(strings.TrimPrefix(localAppURL, "http://"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return port, portText
 }
 
 func TestLoopbackProxyReturnsBadGatewayWhenLocalAppUnavailable(t *testing.T) {

--- a/helper/internal/portal/runtime.go
+++ b/helper/internal/portal/runtime.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net"
-	"net/http"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -95,12 +94,11 @@ type Runtime struct {
 	node                  Node
 	watcher               Watcher
 	cancel                context.CancelFunc
+	runContext            context.Context
 	watchDone             sync.WaitGroup
-	serveDone             sync.WaitGroup
 	emit                  func(Event)
 	authenticationPending bool
-	httpServer            *http.Server
-	listener              net.Listener
+	proxy                 *proxyServer
 }
 
 func NewRuntime(stateRoot string, factory NodeFactory) *Runtime {
@@ -133,6 +131,7 @@ func (r *Runtime) Start(ctx context.Context, config Config, emit func(Event)) er
 	r.node = node
 	r.watcher = watcher
 	r.cancel = cancel
+	r.runContext = watchContext
 	r.emit = emit
 	if err := r.emitStatusLocked(ctx); err != nil {
 		r.closeLocked()
@@ -161,36 +160,33 @@ func (r *Runtime) Close() error {
 	err := r.closeLocked()
 	r.mu.Unlock()
 	r.watchDone.Wait()
-	r.serveDone.Wait()
 	return err
 }
 
 func (r *Runtime) closeLocked() error {
+	var proxyErr error
 	if r.cancel != nil {
 		r.cancel()
 	}
 	if r.watcher != nil {
 		_ = r.watcher.Close()
 	}
-	if r.httpServer != nil {
-		_ = r.httpServer.Close()
+	if r.proxy != nil {
+		proxyErr = r.proxy.close()
 	}
-	if r.listener != nil {
-		_ = r.listener.Close()
-	}
-	var err error
+	var nodeErr error
 	if r.node != nil {
-		err = r.node.Close()
+		nodeErr = r.node.Close()
 	}
 	r.config = nil
 	r.node = nil
 	r.watcher = nil
 	r.cancel = nil
+	r.runContext = nil
 	r.emit = nil
 	r.authenticationPending = false
-	r.httpServer = nil
-	r.listener = nil
-	return err
+	r.proxy = nil
+	return errors.Join(proxyErr, nodeErr)
 }
 
 func (r *Runtime) watch(ctx context.Context, watcher Watcher) {
@@ -231,7 +227,7 @@ func (r *Runtime) emitStatusLocked(ctx context.Context) error {
 }
 
 func (r *Runtime) ensureProxyLocked() error {
-	if r.httpServer != nil {
+	if r.proxy != nil {
 		return nil
 	}
 	handler, err := newLoopbackProxy(int(r.config.Port))
@@ -242,14 +238,7 @@ func (r *Runtime) ensureProxyLocked() error {
 	if err != nil {
 		return errors.New("listen for portal HTTPS")
 	}
-	server := &http.Server{Handler: handler}
-	r.listener = listener
-	r.httpServer = server
-	r.serveDone.Add(1)
-	go func() {
-		defer r.serveDone.Done()
-		_ = server.Serve(listener)
-	}()
+	r.proxy = startProxyServer(r.runContext, listener, handler)
 	return nil
 }
 

--- a/helper/internal/portal/runtime_test.go
+++ b/helper/internal/portal/runtime_test.go
@@ -3,10 +3,17 @@ package portal
 import (
 	"context"
 	"errors"
+	"io"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
+	"time"
+
+	"github.com/coder/websocket"
 )
 
 const testPortalID = "9f55ca93-d7b3-4eab-a871-310ea576005a"
@@ -176,6 +183,181 @@ func TestOnlineRuntimeListensTLSAndClosesListenerBeforeNode(t *testing.T) {
 	}
 }
 
+func TestRuntimeCloseReturnsListenerFailure(t *testing.T) {
+	factory := newFakeFactory()
+	factory.status = Status{
+		BackendState: "Running",
+		DNSName:      "hermes.example.ts.net.",
+		CertDomains:  []string{"hermes.example.ts.net"},
+	}
+	runtime := NewRuntime(t.TempDir(), factory.New)
+	if err := runtime.Start(context.Background(), Config{ID: testPortalID, Name: "hermes", Port: 8787}, func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+	factory.node.listener.closeErr = errors.New("close failed")
+
+	if err := runtime.Close(); err == nil {
+		t.Fatal("Runtime.Close error = nil, want listener shutdown failure")
+	}
+	if !factory.node.listenerClosedBeforeNode {
+		t.Fatal("tsnet node did not close after the listener failure")
+	}
+}
+
+func TestRuntimeCloseCancelsActiveRequest(t *testing.T) {
+	requestEntered := make(chan struct{})
+	handlerExited := make(chan struct{})
+	runtime, proxyURL, factory := newOnlineRuntimeWithLocalApp(t, http.HandlerFunc(func(_ http.ResponseWriter, request *http.Request) {
+		close(requestEntered)
+		<-request.Context().Done()
+		close(handlerExited)
+	}))
+	factory.node.observeClose = func() {
+		select {
+		case <-handlerExited:
+			factory.node.handlersExitedBeforeNode = true
+		default:
+		}
+	}
+
+	requestDone := make(chan error, 1)
+	go func() {
+		response, err := http.Get(proxyURL)
+		if response != nil {
+			_ = response.Body.Close()
+		}
+		requestDone <- err
+	}()
+	waitForSignal(t, requestEntered, "active Local App request")
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- runtime.Close() }()
+	waitForSignal(t, handlerExited, "active Local App handler exit")
+	if err := waitForRuntimeClose(t, closeDone); err != nil {
+		t.Fatal(err)
+	}
+	_ = waitForError(t, requestDone, "client request")
+	if !factory.node.handlersExitedBeforeNode {
+		t.Fatal("tsnet node closed before the active proxy handler exited")
+	}
+}
+
+func TestRuntimeCloseClosesIdleConnection(t *testing.T) {
+	runtime, proxyURL, factory := newOnlineRuntimeWithLocalApp(t, http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(writer, "ok")
+	}))
+	transport := &http.Transport{}
+	defer transport.CloseIdleConnections()
+	client := &http.Client{Transport: transport, Timeout: 2 * time.Second}
+	response, err := client.Get(proxyURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = io.Copy(io.Discard, response.Body)
+	_ = response.Body.Close()
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- runtime.Close() }()
+	if err := waitForRuntimeClose(t, closeDone); err != nil {
+		t.Fatal(err)
+	}
+	if response, err = client.Get(proxyURL); err == nil {
+		_ = response.Body.Close()
+		t.Fatal("idle client connection remained reusable after Runtime.Close")
+	}
+	if !factory.node.listenerClosedBeforeNode {
+		t.Fatal("TLS listener was not closed before the tsnet node")
+	}
+}
+
+func TestRuntimeCloseClosesWebSocket(t *testing.T) {
+	handlerEntered := make(chan struct{})
+	handlerExited := make(chan struct{})
+	runtime, proxyURL, _ := newOnlineRuntimeWithLocalApp(t, http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		connection, err := websocket.Accept(writer, request, nil)
+		if err != nil {
+			return
+		}
+		defer connection.CloseNow()
+		close(handlerEntered)
+		_, _, _ = connection.Read(request.Context())
+		close(handlerExited)
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	connection, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(proxyURL, "http"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer connection.CloseNow()
+	waitForSignal(t, handlerEntered, "Local App WebSocket handler")
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- runtime.Close() }()
+	waitForSignal(t, handlerExited, "Local App WebSocket handler exit")
+	if _, _, err := connection.Read(ctx); err == nil {
+		t.Fatal("client WebSocket remained open after Runtime.Close")
+	}
+	if err := waitForRuntimeClose(t, closeDone); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func newOnlineRuntimeWithLocalApp(t *testing.T, handler http.Handler) (*Runtime, string, *fakeFactory) {
+	t.Helper()
+	localApp := httptest.NewServer(handler)
+	t.Cleanup(localApp.Close)
+	port, _ := localAppPort(t, localApp.URL)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	factory := newFakeFactory()
+	factory.status = Status{
+		BackendState: "Running",
+		DNSName:      "hermes.example.ts.net.",
+		CertDomains:  []string{"hermes.example.ts.net"},
+	}
+	factory.node.realListener = listener
+	runtime := NewRuntime(t.TempDir(), factory.New)
+	if err := runtime.Start(context.Background(), Config{ID: testPortalID, Name: "hermes", Port: uint16(port)}, func(Event) {}); err != nil {
+		_ = listener.Close()
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = runtime.Close() })
+	return runtime, "http://" + listener.Addr().String(), factory
+}
+
+func waitForSignal(t *testing.T, signal <-chan struct{}, description string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for %s", description)
+	}
+}
+
+func waitForError(t *testing.T, result <-chan error, description string) error {
+	t.Helper()
+	select {
+	case err := <-result:
+		return err
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for %s", description)
+		return nil
+	}
+}
+
+func waitForRuntimeClose(t *testing.T, result <-chan error) error {
+	t.Helper()
+	select {
+	case err := <-result:
+		return err
+	case <-time.After(900 * time.Millisecond):
+		t.Fatal("Runtime.Close exceeded the native supervisor's one-second grace period")
+		return nil
+	}
+}
+
 type fakeFactory struct {
 	mu      sync.Mutex
 	created []createdNode
@@ -225,7 +407,10 @@ type fakeNode struct {
 	listenNetwork             string
 	listenAddress             string
 	listener                  *fakeListener
+	realListener              net.Listener
 	listenerClosedBeforeNode  bool
+	observeClose              func()
+	handlersExitedBeforeNode  bool
 }
 
 func (n *fakeNode) clone() *fakeNode {
@@ -255,23 +440,36 @@ func (n *fakeNode) StartLoginInteractive(context.Context) error {
 func (n *fakeNode) ListenTLS(network, address string) (net.Listener, error) {
 	n.listenNetwork = network
 	n.listenAddress = address
+	if n.realListener != nil {
+		return n.realListener, nil
+	}
 	n.listener = newFakeListener()
 	return n.listener, nil
 }
 func (n *fakeNode) Close() error {
 	n.mu.Lock()
 	defer n.mu.Unlock()
+	if n.observeClose != nil {
+		n.observeClose()
+	}
 	n.closedBeforeStartReturned = !n.startReturned
 	if n.listener != nil {
 		n.listenerClosedBeforeNode = n.listener.closed
+	} else if n.realListener != nil {
+		connection, err := net.DialTimeout(n.realListener.Addr().Network(), n.realListener.Addr().String(), 50*time.Millisecond)
+		if err == nil {
+			_ = connection.Close()
+		}
+		n.listenerClosedBeforeNode = err != nil
 	}
 	return nil
 }
 
 type fakeListener struct {
-	mu     sync.Mutex
-	closed bool
-	done   chan struct{}
+	mu       sync.Mutex
+	closed   bool
+	done     chan struct{}
+	closeErr error
 }
 
 func newFakeListener() *fakeListener { return &fakeListener{done: make(chan struct{})} }
@@ -286,7 +484,7 @@ func (l *fakeListener) Close() error {
 		l.closed = true
 		close(l.done)
 	}
-	return nil
+	return l.closeErr
 }
 func (l *fakeListener) Addr() net.Addr { return fakeAddr("tailnet") }
 

--- a/helper/internal/protocol/server_test.go
+++ b/helper/internal/protocol/server_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/chrisbanes/portico/helper/internal/portal"
@@ -109,6 +110,28 @@ func TestServeRejectsInvalidPortalPayloadWithoutLeakingIt(t *testing.T) {
 	}
 }
 
+func TestServeRejectsDestinationFields(t *testing.T) {
+	for _, field := range []string{"host", "scheme", "path", "url"} {
+		t.Run(field, func(t *testing.T) {
+			const secret = "untrusted-destination-do-not-copy"
+			input := bytes.NewBufferString(
+				`{"version":1,"requestId":"start-1","command":"startPortal","payload":{"portalId":"9f55ca93-d7b3-4eab-a871-310ea576005a","portalName":"hermes","localAppPort":8787,"` + field + `":"` + secret + `"}}` + "\n",
+			)
+			var output bytes.Buffer
+			var diagnostics bytes.Buffer
+
+			exitCode := ServeWithRuntime(input, &output, &diagnostics, &fakeRuntime{})
+
+			if exitCode != 0 || !strings.Contains(output.String(), `"code":"invalidPayload"`) {
+				t.Fatalf("ServeWithRuntime = (exit %d, output %q), want invalid-payload response", exitCode, output.String())
+			}
+			if strings.Contains(output.String(), secret) || strings.Contains(diagnostics.String(), secret) {
+				t.Fatal("untrusted destination leaked to protocol or diagnostic output")
+			}
+		})
+	}
+}
+
 func TestServeClosesRuntimeOnShutdown(t *testing.T) {
 	runtime := &fakeRuntime{}
 	input := bytes.NewBufferString(`{"version":1,"requestId":"shutdown-1","command":"shutdown","payload":{}}` + "\n")
@@ -119,11 +142,34 @@ func TestServeClosesRuntimeOnShutdown(t *testing.T) {
 	}
 }
 
+func TestServeAcknowledgesShutdownAfterRuntimeCloseCompletes(t *testing.T) {
+	runtime := &fakeRuntime{closeEntered: make(chan struct{}), releaseClose: make(chan struct{})}
+	input := bytes.NewBufferString(`{"version":1,"requestId":"shutdown-1","command":"shutdown","payload":{}}` + "\n")
+	var output bytes.Buffer
+	done := make(chan int, 1)
+	go func() { done <- ServeWithRuntime(input, &output, &bytes.Buffer{}, runtime) }()
+
+	<-runtime.closeEntered
+	if output.Len() != 0 {
+		t.Fatalf("output = %q, want no shutdown acknowledgement before close completes", output.String())
+	}
+	close(runtime.releaseClose)
+	if exitCode := <-done; exitCode != 0 {
+		t.Fatalf("ServeWithRuntime exit code = %d, want success", exitCode)
+	}
+	if !strings.Contains(output.String(), `"requestId":"shutdown-1","result":{"accepted":true}`) {
+		t.Fatalf("output = %q, want shutdown acknowledgement after close", output.String())
+	}
+}
+
 type fakeRuntime struct {
 	started       portal.Config
 	authenticated string
 	closed        bool
 	emit          func(portal.Event)
+	closeEntered  chan struct{}
+	releaseClose  chan struct{}
+	closeOnce     sync.Once
 }
 
 func (r *fakeRuntime) Start(_ context.Context, config portal.Config, emit func(portal.Event)) error {
@@ -142,6 +188,12 @@ func (r *fakeRuntime) Authenticate(_ context.Context, portalID string) error {
 }
 
 func (r *fakeRuntime) Close() error {
+	r.closeOnce.Do(func() {
+		if r.closeEntered != nil {
+			close(r.closeEntered)
+			<-r.releaseClose
+		}
+	})
 	r.closed = true
 	return nil
 }


### PR DESCRIPTION
## Summary
- confine proxy destinations to internally constructed loopback targets and replace spoofable forwarding metadata
- flush HTTP/SSE immediately and support real bidirectional WebSockets with cancellation
- own active, idle, and upgraded connections through bounded graceful shutdown
- keep proxy and protocol errors fixed and secret-safe

## Validation
- `cd helper && go test -race ./...` (passed)
- `cd helper && go vet ./...` (passed)
- focused security/lifecycle cases and 25x runtime-close race stress (passed)

## Review
- Standards and spec review: 0 remaining findings
- review-and-simplify-changes: clean
- ponytail-review: Lean already. Ship.

Fixes #4