### PR TITLE
Fix Xcode project ignore verification

### DIFF
--- a/Scripts/verify-xcode-project-generation.sh
+++ b/Scripts/verify-xcode-project-generation.sh
@@ -19,7 +19,7 @@ if [[ -n "$(git ls-files -- Portico.xcodeproj)" ]]; then
   exit 1
 fi
 
-if ! git check-ignore --quiet --no-index Portico.xcodeproj; then
+if ! git check-ignore --quiet --no-index Portico.xcodeproj/; then
   echo "Portico.xcodeproj must be ignored" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

- verify the generated project as a directory when checking its ignore rule
- restore fresh-checkout Xcode project generation verification

## Root cause

The verifier checked an absent bare `Portico.xcodeproj` path even though `.gitignore` explicitly ignores the directory as `/Portico.xcodeproj/`. Git therefore did not report the absent output as ignored.

## Validation

- `./Scripts/verify-xcode-project-generation.sh`
- `(cd helper && go test ./...)`
- `xcodebuild -project Portico.xcodeproj -scheme Portico -destination 'platform=macOS' -derivedDataPath .build/xcode test`
- `./Scripts/smoke-test-local-app.sh`

Fixes #13