### PR TITLE
Add CI for Swift and Go checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  swift:
+    name: Swift
+    runs-on: macos-26
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+
+      - name: Setup Go 1.26.5 for embedded helper
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
+        with:
+          go-version: '1.26.5'
+          cache: false
+
+      - name: Install XcodeGen 2.46.0
+        run: |
+          curl --fail --location --retry 3 --output xcodegen.zip \
+            https://github.com/yonaskolb/XcodeGen/releases/download/2.46.0/xcodegen.zip
+          echo '4d9e34b62172d645eed6457cac13fc222569974098ef4ee9c3368bedf0196806  xcodegen.zip' | shasum -a 256 -c -
+          unzip -q xcodegen.zip
+          xcodegen/bin/xcodegen --version
+          echo "$PWD/xcodegen/bin" >> "$GITHUB_PATH"
+
+      - name: Generate Xcode project
+        run: ./Scripts/generate-xcode-project.sh
+
+      - name: Test Swift application
+        run: >
+          xcodebuild -project Portico.xcodeproj -scheme Portico
+          -destination 'platform=macOS' -derivedDataPath .build/xcode test
+
+  go:
+    name: Go
+    runs-on: macos-26
+    defaults:
+      run:
+        working-directory: helper
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
+        with:
+          go-version: '1.26.5'
+          cache-dependency-path: helper/go.sum
+
+      - name: Build Go helper
+        run: go build ./cmd/portico-helper
+
+      - name: Test Go helper
+        run: go test ./...

--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ xcodebuild \
   test
 ```
 
+Before opening a pull request, run the same checks as the separate Swift and
+Go CI results:
+
+```shell
+./Scripts/generate-xcode-project.sh
+xcodebuild \
+  -project Portico.xcodeproj \
+  -scheme Portico \
+  -destination 'platform=macOS' \
+  -derivedDataPath .build/xcode \
+  test
+(cd helper && go build ./cmd/portico-helper && go test ./...)
+```
+
 Verify that a fresh generated project is ignored, deterministic, and visible to
 Xcode before running the generated-project tests:
 


### PR DESCRIPTION
## Summary
- add secret-free, pinned GitHub Actions Swift and Go CI jobs
- document the equivalent pre-PR checks

## Validation
- `./Scripts/verify-xcode-project-generation.sh && (cd helper && go build ./cmd/portico-helper && go test ./...) && xcodebuild -project Portico.xcodeproj -scheme Portico -destination platform=macOS -derivedDataPath .build/xcode test`
- workflow YAML contract check and `actionlint .github/workflows/ci.yml`

## Workflow evidence
- [Final restored green run](https://github.com/chrisbanes/portico/actions/runs/30845598889)
- [Controlled Swift failure: Swift red, Go green](https://github.com/chrisbanes/portico/actions/runs/30845106183)
- [Controlled Go failure: Go red, Swift green](https://github.com/chrisbanes/portico/actions/runs/30845312645)
- [Same-PR superseded run cancelled](https://github.com/chrisbanes/portico/actions/runs/30845486606)

Fixes #14