### PR TITLE
Discover Local Apps and suggest safe Portal Names

### DIFF
--- a/Portico/HelperProtocol.swift
+++ b/Portico/HelperProtocol.swift
@@ -7,6 +7,7 @@ enum HelperCommand: String, Codable {
     case shutdown
     case startPortal
     case authenticatePortal
+    case discoverLocalApps
 }
 
 struct EmptyPayload: Codable, Equatable {}
@@ -49,6 +50,16 @@ struct AuthenticatePortalPayload: Codable, Equatable {
 
 struct AuthenticatePortalResult: Codable, Equatable {
     let accepted: Bool
+}
+
+struct LocalAppCandidatePayload: Codable, Equatable {
+    let localAppPort: UInt16
+    let processLabel: String
+    let suggestedPortalName: String?
+}
+
+struct DiscoverLocalAppsResult: Codable, Equatable {
+    let candidates: [LocalAppCandidatePayload]
 }
 
 enum HelperEventType: String, Codable {

--- a/Portico/HelperSupervisor.swift
+++ b/Portico/HelperSupervisor.swift
@@ -25,6 +25,7 @@ protocol PortalHelperClient: AnyObject {
 
     func startPortal(_ portal: PortalConfiguration, completion: @escaping (Result<Void, Error>) -> Void)
     func authenticatePortal(id: UUID, completion: @escaping (Result<Void, Error>) -> Void)
+    func discoverLocalApps(completion: @escaping (Result<[LocalAppCandidatePayload], Error>) -> Void)
 }
 
 protocol HelperProcess: AnyObject {
@@ -135,6 +136,20 @@ final class HelperSupervisor: ObservableObject, PortalHelperClient {
         do {
             try sendRequest(command: .authenticatePortal, payload: AuthenticatePortalPayload(portalId: id)) { (result: Result<AuthenticatePortalResult, Error>) in
                 completion(result.map { _ in () })
+            }
+        } catch {
+            completion(.failure(error))
+        }
+    }
+
+    func discoverLocalApps(completion: @escaping (Result<[LocalAppCandidatePayload], Error>) -> Void) {
+        guard availability == .connected else {
+            completion(.failure(HelperClientError.unavailable))
+            return
+        }
+        do {
+            try sendRequest(command: .discoverLocalApps, payload: EmptyPayload()) { (result: Result<DiscoverLocalAppsResult, Error>) in
+                completion(result.map(\.candidates))
             }
         } catch {
             completion(.failure(error))

--- a/Portico/PortalController.swift
+++ b/Portico/PortalController.swift
@@ -7,6 +7,9 @@ final class PortalController: ObservableObject {
     @Published private(set) var portal: PortalConfiguration?
     @Published private(set) var status: PortalStatusPayload?
     @Published private(set) var message: String?
+    @Published private(set) var localApps: [LocalAppCandidatePayload] = []
+    @Published private(set) var isRefreshingLocalApps = false
+    @Published private(set) var localAppsMessage: String?
 
     private let store: PortalStore
     private let helper: PortalHelperClient
@@ -14,6 +17,7 @@ final class PortalController: ObservableObject {
     private let dateProvider: () -> Date
     private let openURL: (URL) -> Void
     private var authenticationPending = false
+    private var discoveryGeneration = 0
 
     init(
         store: PortalStore,
@@ -32,10 +36,36 @@ final class PortalController: ObservableObject {
         } catch {
             message = "Saved Portal configuration could not be loaded."
         }
-        helper.onConnected = { [weak self] in self?.startSavedPortal() }
+        helper.onConnected = { [weak self] in self?.helperConnected() }
         helper.onEvent = { [weak self] event in self?.receive(event) }
         if helper.availability == .connected {
-            startSavedPortal()
+            helperConnected()
+        }
+    }
+
+    func refreshLocalApps() {
+        guard portal == nil else { return }
+        discoveryGeneration += 1
+        let generation = discoveryGeneration
+        isRefreshingLocalApps = true
+        localAppsMessage = nil
+        helper.discoverLocalApps { [weak self] result in
+            guard let self, self.portal == nil, self.discoveryGeneration == generation else { return }
+            self.isRefreshingLocalApps = false
+            switch result {
+            case let .success(candidates):
+                self.localApps = candidates
+            case .failure:
+                self.localAppsMessage = "Local Apps could not be refreshed."
+            }
+        }
+    }
+
+    func selectLocalApp(_ candidate: LocalAppCandidatePayload) {
+        guard portal == nil, localApps.contains(candidate) else { return }
+        localAppPort = String(candidate.localAppPort)
+        if portalName.isEmpty, let suggestion = candidate.suggestedPortalName {
+            portalName = suggestion
         }
     }
 
@@ -58,6 +88,10 @@ final class PortalController: ObservableObject {
             try store.save(configuration)
             portal = configuration
             message = nil
+            discoveryGeneration += 1
+            localApps = []
+            isRefreshingLocalApps = false
+            localAppsMessage = nil
             startSavedPortal()
         } catch {
             message = "The Portal could not be saved."
@@ -81,6 +115,14 @@ final class PortalController: ObservableObject {
             if case .failure = result {
                 self?.message = "The Portal could not be started."
             }
+        }
+    }
+
+    private func helperConnected() {
+        if portal == nil {
+            refreshLocalApps()
+        } else {
+            startSavedPortal()
         }
     }
 

--- a/Portico/PorticoApp.swift
+++ b/Portico/PorticoApp.swift
@@ -44,6 +44,34 @@ private struct PortalView: View {
     private var addPortalForm: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Add Portal").font(.headline)
+            HStack {
+                Text("Detected Local Apps").font(.subheadline)
+                Spacer()
+                Button("Refresh") { controller.refreshLocalApps() }
+                    .disabled(controller.isRefreshingLocalApps)
+            }
+            if controller.isRefreshingLocalApps {
+                ProgressView()
+                    .controlSize(.small)
+            }
+            ForEach(controller.localApps, id: \.localAppPort) { candidate in
+                Button {
+                    controller.selectLocalApp(candidate)
+                } label: {
+                    HStack {
+                        Text(candidate.processLabel)
+                        Spacer()
+                        Text(String(candidate.localAppPort))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .buttonStyle(.plain)
+            }
+            if let message = controller.localAppsMessage {
+                Text(message)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
             TextField("Portal Name", text: $controller.portalName)
             TextField("Local App Port", text: $controller.localAppPort)
             Button("Add Portal") { controller.addPortal() }

--- a/PorticoTests/HelperProtocolTests.swift
+++ b/PorticoTests/HelperProtocolTests.swift
@@ -45,6 +45,21 @@ final class HelperProtocolTests: XCTestCase {
         try assertRoundTrip(authenticationFixture, as: HelperEvent<AuthenticationURLPayload>.self)
     }
 
+    func testDecodesVersionOneDiscoverLocalAppsResult() throws {
+        let fixture = Data(#"{"version":1,"requestId":"discover-1","result":{"candidates":[{"localAppPort":3000,"processLabel":"node","suggestedPortalName":"hermes"},{"localAppPort":8787,"processLabel":"python3"}]}}"#.utf8)
+
+        let response = try JSONDecoder().decode(HelperResponse<DiscoverLocalAppsResult>.self, from: fixture)
+
+        XCTAssertEqual(
+            response.result?.candidates,
+            [
+                LocalAppCandidatePayload(localAppPort: 3000, processLabel: "node", suggestedPortalName: "hermes"),
+                LocalAppCandidatePayload(localAppPort: 8787, processLabel: "python3", suggestedPortalName: nil),
+            ]
+        )
+        XCTAssertNil(response.error)
+    }
+
     private func assertRoundTrip<Value: Codable>(_ fixture: String, as type: Value.Type) throws {
         let decoder = JSONDecoder()
         let value = try decoder.decode(type, from: Data(fixture.utf8))

--- a/PorticoTests/HelperSupervisorTests.swift
+++ b/PorticoTests/HelperSupervisorTests.swift
@@ -102,6 +102,54 @@ final class HelperSupervisorTests: XCTestCase {
         launcher.receive(line: #"{"version":1,"requestId":"start-1","result":{"accepted":true}}"#)
         XCTAssertNoThrow(try result?.get())
     }
+
+    func testRequestsAndCorrelatesLocalAppDiscovery() throws {
+        let launcher = FakeHelperLauncher()
+        var requestIDs = ["handshake-1", "discover-1"]
+        let supervisor = HelperSupervisor(
+            helperURL: URL(fileURLWithPath: "/unused/portico-helper"),
+            launcher: launcher,
+            requestIDProvider: { requestIDs.removeFirst() },
+            handshakeTimeout: 1
+        )
+        supervisor.start()
+        launcher.receive(line: #"{"version":1,"requestId":"handshake-1","result":{"protocolVersion":1}}"#)
+        var result: Result<[LocalAppCandidatePayload], Error>?
+
+        supervisor.discoverLocalApps { result = $0 }
+
+        let requestData = try XCTUnwrap(launcher.process.sent.last)
+        let request = try JSONDecoder().decode(HelperRequest<EmptyPayload>.self, from: requestData)
+        XCTAssertEqual(request.command, .discoverLocalApps)
+        XCTAssertEqual(request.requestId, "discover-1")
+        launcher.receive(line: #"{"version":1,"requestId":"discover-1","result":{"candidates":[{"localAppPort":3000,"processLabel":"node","suggestedPortalName":"hermes"}]}}"#)
+        XCTAssertEqual(
+            try result?.get(),
+            [LocalAppCandidatePayload(localAppPort: 3000, processLabel: "node", suggestedPortalName: "hermes")]
+        )
+    }
+
+    func testReturnsFixedHelperDiscoveryFailure() throws {
+        let launcher = FakeHelperLauncher()
+        var requestIDs = ["handshake-1", "discover-1"]
+        let supervisor = HelperSupervisor(
+            helperURL: URL(fileURLWithPath: "/unused/portico-helper"),
+            launcher: launcher,
+            requestIDProvider: { requestIDs.removeFirst() },
+            handshakeTimeout: 1
+        )
+        supervisor.start()
+        launcher.receive(line: #"{"version":1,"requestId":"handshake-1","result":{"protocolVersion":1}}"#)
+        var result: Result<[LocalAppCandidatePayload], Error>?
+
+        supervisor.discoverLocalApps { result = $0 }
+        launcher.receive(line: #"{"version":1,"requestId":"discover-1","error":{"code":"discoveryFailure","message":"local app discovery failed"}}"#)
+
+        guard case let .failure(HelperClientError.helper(error)) = result else {
+            return XCTFail("expected fixed helper discovery failure")
+        }
+        XCTAssertEqual(error, HelperProtocolError(code: "discoveryFailure", message: "local app discovery failed"))
+    }
 }
 
 final class FakeHelperLauncher: HelperLaunching {

--- a/PorticoTests/PortalControllerTests.swift
+++ b/PorticoTests/PortalControllerTests.swift
@@ -39,6 +39,106 @@ final class PortalControllerTests: XCTestCase {
         XCTAssertEqual(client.started.count, 1)
     }
 
+    func testInitialDiscoveryAfterConnectionDoesNotChangeManualFields() {
+        let client = FakePortalHelperClient(availability: .connecting)
+        let controller = PortalController(store: PortalStore(rootURL: temporaryRoot()), helper: client, openURL: { _ in })
+        controller.portalName = "manual-name"
+        controller.localAppPort = "4321"
+
+        XCTAssertTrue(client.discoveryCompletions.isEmpty)
+        client.connect()
+        XCTAssertEqual(client.discoveryCompletions.count, 1)
+        XCTAssertTrue(controller.isRefreshingLocalApps)
+        let candidates = [
+            LocalAppCandidatePayload(localAppPort: 3000, processLabel: "node", suggestedPortalName: "detected")
+        ]
+        client.completeDiscovery(.success(candidates))
+
+        XCTAssertEqual(controller.localApps, candidates)
+        XCTAssertFalse(controller.isRefreshingLocalApps)
+        XCTAssertEqual(controller.portalName, "manual-name")
+        XCTAssertEqual(controller.localAppPort, "4321")
+    }
+
+    func testSelectingLocalAppUpdatesPortAndOnlyFillsBlankName() {
+        let client = FakePortalHelperClient()
+        let controller = PortalController(store: PortalStore(rootURL: temporaryRoot()), helper: client, openURL: { _ in })
+        let hinted = LocalAppCandidatePayload(localAppPort: 3000, processLabel: "node", suggestedPortalName: "hermes")
+        let generic = LocalAppCandidatePayload(localAppPort: 8787, processLabel: "Port 8787", suggestedPortalName: nil)
+        client.completeDiscovery(.success([hinted, generic]))
+
+        controller.selectLocalApp(hinted)
+        XCTAssertEqual(controller.localAppPort, "3000")
+        XCTAssertEqual(controller.portalName, "hermes")
+
+        controller.portalName = "manual-name"
+        controller.selectLocalApp(generic)
+        XCTAssertEqual(controller.localAppPort, "8787")
+        XCTAssertEqual(controller.portalName, "manual-name")
+
+        controller.selectLocalApp(hinted)
+        XCTAssertEqual(controller.portalName, "manual-name")
+    }
+
+    func testExplicitRefreshReplacesCandidatesAndPresentsOnlyFixedFailure() {
+        let client = FakePortalHelperClient()
+        let controller = PortalController(store: PortalStore(rootURL: temporaryRoot()), helper: client, openURL: { _ in })
+        let first = LocalAppCandidatePayload(localAppPort: 3000, processLabel: "node", suggestedPortalName: "first")
+        let replacement = LocalAppCandidatePayload(localAppPort: 8787, processLabel: "python3", suggestedPortalName: "replacement")
+        client.completeDiscovery(.success([first]))
+        controller.portalName = "manual-name"
+        controller.localAppPort = "4321"
+
+        controller.refreshLocalApps()
+        XCTAssertTrue(controller.isRefreshingLocalApps)
+        XCTAssertEqual(controller.localApps, [first])
+        client.completeDiscovery(.success([replacement]), at: 1)
+        XCTAssertEqual(controller.localApps, [replacement])
+        XCTAssertNil(controller.localAppsMessage)
+
+        controller.refreshLocalApps()
+        client.completeDiscovery(.failure(NSError(domain: "secret=do-not-copy", code: 1)), at: 2)
+        XCTAssertEqual(controller.localApps, [replacement])
+        XCTAssertEqual(controller.localAppsMessage, "Local Apps could not be refreshed.")
+        XCTAssertFalse(controller.localAppsMessage?.contains("do-not-copy") ?? true)
+        XCTAssertEqual(controller.portalName, "manual-name")
+        XCTAssertEqual(controller.localAppPort, "4321")
+    }
+
+    func testAddPersistsFinalEditableFieldsAndIgnoresStaleDiscovery() throws {
+        let client = FakePortalHelperClient()
+        let store = PortalStore(rootURL: temporaryRoot())
+        let controller = PortalController(
+            store: store,
+            helper: client,
+            uuidProvider: { self.portalID },
+            dateProvider: { Date(timeIntervalSince1970: 1_786_000_000) },
+            openURL: { _ in }
+        )
+        let candidate = LocalAppCandidatePayload(localAppPort: 3000, processLabel: "node", suggestedPortalName: "hint")
+        client.completeDiscovery(.success([candidate]))
+        controller.selectLocalApp(candidate)
+        controller.portalName = "final-name"
+        controller.localAppPort = "4321"
+        controller.refreshLocalApps()
+
+        controller.addPortal()
+
+        let portal = try XCTUnwrap(controller.portal)
+        XCTAssertEqual(portal.name, "final-name")
+        XCTAssertEqual(portal.localAppPort, 4321)
+        XCTAssertEqual(try store.load(), portal)
+        XCTAssertTrue(controller.localApps.isEmpty)
+        XCTAssertFalse(controller.isRefreshingLocalApps)
+        XCTAssertNil(controller.localAppsMessage)
+
+        client.completeDiscovery(.success([
+            LocalAppCandidatePayload(localAppPort: 9999, processLabel: "stale", suggestedPortalName: "stale")
+        ]), at: 1)
+        XCTAssertTrue(controller.localApps.isEmpty)
+        XCTAssertNil(controller.localAppsMessage)
+    }
+
     func testStartsSavedPortalAfterHandshakeWithSameDefinition() throws {
         let store = PortalStore(rootURL: temporaryRoot())
         let saved = PortalConfiguration(id: portalID, name: "hermes", localAppPort: 8787, createdAt: Date(timeIntervalSince1970: 1_786_000_000))
@@ -51,6 +151,7 @@ final class PortalControllerTests: XCTestCase {
 
         client.connect()
         XCTAssertEqual(client.started, [saved])
+        XCTAssertTrue(client.discoveryCompletions.isEmpty)
     }
 
     func testPresentsOnlyMatchingStructuredStatus() throws {
@@ -108,6 +209,7 @@ final class FakePortalHelperClient: PortalHelperClient {
     var onEvent: ((PortalHelperEvent) -> Void)?
     private(set) var started: [PortalConfiguration] = []
     private(set) var authenticated: [UUID] = []
+    private(set) var discoveryCompletions: [(Result<[LocalAppCandidatePayload], Error>) -> Void] = []
 
     init(availability: HelperAvailability = .connected) {
         self.availability = availability
@@ -123,10 +225,18 @@ final class FakePortalHelperClient: PortalHelperClient {
         completion(.success(()))
     }
 
+    func discoverLocalApps(completion: @escaping (Result<[LocalAppCandidatePayload], Error>) -> Void) {
+        discoveryCompletions.append(completion)
+    }
+
     func connect() {
         availability = .connected
         onConnected?()
     }
 
     func send(_ event: PortalHelperEvent) { onEvent?(event) }
+
+    func completeDiscovery(_ result: Result<[LocalAppCandidatePayload], Error>, at index: Int = 0) {
+        discoveryCompletions[index](result)
+    }
 }

--- a/helper/cmd/portico-helper/main.go
+++ b/helper/cmd/portico-helper/main.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/chrisbanes/portico/helper/internal/discovery"
 	"github.com/chrisbanes/portico/helper/internal/portal"
 	"github.com/chrisbanes/portico/helper/internal/protocol"
 )
@@ -19,5 +20,8 @@ func main() {
 		os.Exit(2)
 	}
 	runtime := portal.NewRuntime(stateRoot, portal.NewTSNetNode)
-	os.Exit(protocol.ServeWithRuntime(os.Stdin, os.Stdout, os.Stderr, runtime))
+	os.Exit(protocol.ServeWithServices(os.Stdin, os.Stdout, os.Stderr, protocol.Services{
+		PortalRuntime:      runtime,
+		LocalAppDiscoverer: discovery.New(),
+	}))
 }

--- a/helper/internal/discovery/darwin.go
+++ b/helper/internal/discovery/darwin.go
@@ -1,0 +1,209 @@
+//go:build darwin && cgo
+
+package discovery
+
+/*
+#cgo LDFLAGS: -lproc
+#include <arpa/inet.h>
+#include <libproc.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <sys/proc_info.h>
+#include <sys/sysctl.h>
+#include <sys/types.h>
+
+static int portico_list_pids(uid_t uid, int *buffer, int bytes) {
+	return proc_listpids(PROC_UID_ONLY, (uint32_t)uid, buffer, bytes);
+}
+
+static int portico_list_fds(int pid, struct proc_fdinfo *buffer, int bytes) {
+	return proc_pidinfo(pid, PROC_PIDLISTFDS, 0, buffer, bytes);
+}
+
+struct portico_process_identity {
+	uid_t uid;
+	uint64_t start_seconds;
+	uint64_t start_microseconds;
+};
+
+static int portico_process_identity(int pid, struct portico_process_identity *identity) {
+	struct proc_bsdinfo info;
+	int size = proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &info, sizeof(info));
+	if (size != sizeof(info)) {
+		return 0;
+	}
+	identity->uid = info.pbi_uid;
+	identity->start_seconds = info.pbi_start_tvsec;
+	identity->start_microseconds = info.pbi_start_tvusec;
+	return 1;
+}
+
+static int portico_tcp_listen_port(int pid, int fd, uint16_t *port) {
+	struct socket_fdinfo info;
+	int size = proc_pidfdinfo(pid, fd, PROC_PIDFDSOCKETINFO, &info, sizeof(info));
+	if (size != sizeof(info) || info.psi.soi_kind != SOCKINFO_TCP ||
+		info.psi.soi_proto.pri_tcp.tcpsi_state != TSI_S_LISTEN) {
+		return 0;
+	}
+	*port = ntohs((uint16_t)info.psi.soi_proto.pri_tcp.tcpsi_ini.insi_lport);
+	return *port != 0;
+}
+
+static int portico_process_args(int pid, void *buffer, size_t *size) {
+	int mib[3] = {CTL_KERN, KERN_PROCARGS2, pid};
+	return sysctl(mib, 3, buffer, size, NULL, 0);
+}
+*/
+import "C"
+
+import (
+	"context"
+	"encoding/binary"
+	"os"
+	"unsafe"
+)
+
+const maxProcessArgsBuffer = 1 << 20
+
+type darwinSource struct{}
+
+func New() *Discoverer {
+	return newDiscoverer(darwinSource{}, loopbackProber{})
+}
+
+func (darwinSource) listeners(ctx context.Context) ([]Candidate, error) {
+	uid := C.uid_t(os.Getuid())
+	pids, ok := currentUserPIDs(uid)
+	if !ok {
+		return nil, errDiscoveryUnavailable
+	}
+	result := make([]Candidate, 0)
+	for _, pid := range pids {
+		if ctx.Err() != nil {
+			return nil, errDiscoveryUnavailable
+		}
+		identity, ok := processIdentity(pid)
+		if !ok || identity.uid != uid {
+			continue
+		}
+		ports := listeningPorts(pid)
+		if len(ports) == 0 {
+			continue
+		}
+		executable, argv := processArguments(pid)
+		if current, ok := processIdentity(pid); !ok || current != identity {
+			continue
+		}
+		for _, port := range ports {
+			result = append(result, reduce(port, executable, argv))
+		}
+	}
+	return result, nil
+}
+
+func currentUserPIDs(uid C.uid_t) ([]C.int, bool) {
+	bytesNeeded := int(C.portico_list_pids(uid, nil, 0))
+	if bytesNeeded <= 0 {
+		return nil, false
+	}
+	count := bytesNeeded/int(C.sizeof_int) + 64
+	buffer := make([]C.int, count)
+	written := int(C.portico_list_pids(uid, &buffer[0], C.int(len(buffer)*int(C.sizeof_int))))
+	if written <= 0 {
+		return nil, false
+	}
+	buffer = buffer[:min(len(buffer), written/int(C.sizeof_int))]
+	result := buffer[:0]
+	for _, pid := range buffer {
+		if pid > 0 {
+			result = append(result, pid)
+		}
+	}
+	return result, true
+}
+
+type processIdentityValue struct {
+	uid               C.uid_t
+	startSeconds      C.uint64_t
+	startMicroseconds C.uint64_t
+}
+
+func processIdentity(pid C.int) (processIdentityValue, bool) {
+	var identity C.struct_portico_process_identity
+	if C.portico_process_identity(pid, &identity) == 0 {
+		return processIdentityValue{}, false
+	}
+	return processIdentityValue{
+		uid:               identity.uid,
+		startSeconds:      identity.start_seconds,
+		startMicroseconds: identity.start_microseconds,
+	}, true
+}
+
+func listeningPorts(pid C.int) []uint16 {
+	bytesNeeded := int(C.portico_list_fds(pid, nil, 0))
+	if bytesNeeded <= 0 {
+		return nil
+	}
+	count := bytesNeeded/int(C.sizeof_struct_proc_fdinfo) + 32
+	buffer := make([]C.struct_proc_fdinfo, count)
+	written := int(C.portico_list_fds(pid, &buffer[0], C.int(len(buffer)*int(C.sizeof_struct_proc_fdinfo))))
+	if written <= 0 {
+		return nil
+	}
+	buffer = buffer[:min(len(buffer), written/int(C.sizeof_struct_proc_fdinfo))]
+	ports := make([]uint16, 0)
+	for _, descriptor := range buffer {
+		if descriptor.proc_fdtype != C.PROX_FDTYPE_SOCKET {
+			continue
+		}
+		var port C.uint16_t
+		if C.portico_tcp_listen_port(pid, descriptor.proc_fd, &port) != 0 {
+			ports = append(ports, uint16(port))
+		}
+	}
+	return ports
+}
+
+func processArguments(pid C.int) (string, []string) {
+	var size C.size_t
+	if C.portico_process_args(pid, nil, &size) != 0 || size <= C.size_t(C.sizeof_int) || size > maxProcessArgsBuffer {
+		return "", nil
+	}
+	buffer := make([]byte, int(size))
+	if C.portico_process_args(pid, unsafe.Pointer(&buffer[0]), &size) != 0 || size <= C.size_t(C.sizeof_int) {
+		return "", nil
+	}
+	buffer = buffer[:int(size)]
+	argc := int(int32(binary.NativeEndian.Uint32(buffer[:C.sizeof_int])))
+	if argc <= 0 || argc > len(buffer) {
+		return "", nil
+	}
+	position := int(C.sizeof_int)
+	executable, position, ok := readNullTerminated(buffer, position)
+	if !ok {
+		return "", nil
+	}
+	for position < len(buffer) && buffer[position] == 0 {
+		position++
+	}
+	argv := make([]string, 0, argc)
+	for len(argv) < argc && position < len(buffer) {
+		argument, next, valid := readNullTerminated(buffer, position)
+		if !valid {
+			break
+		}
+		argv = append(argv, argument)
+		position = next
+	}
+	return executable, argv
+}
+
+func readNullTerminated(buffer []byte, start int) (string, int, bool) {
+	for end := start; end < len(buffer); end++ {
+		if buffer[end] == 0 {
+			return string(buffer[start:end]), end + 1, true
+		}
+	}
+	return "", start, false
+}

--- a/helper/internal/discovery/darwin_test.go
+++ b/helper/internal/discovery/darwin_test.go
@@ -1,0 +1,43 @@
+//go:build darwin && cgo
+
+package discovery
+
+import (
+	"context"
+	"net"
+	"reflect"
+	"testing"
+)
+
+func TestDarwinDiscoveryObservesCurrentProcessListenerWithoutSensitiveFields(t *testing.T) {
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	port := uint16(listener.Addr().(*net.TCPAddr).Port)
+
+	candidates, err := New().Discover(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, candidate := range candidates {
+		if candidate.LocalAppPort == port {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("current-process listener on port %d was not discovered", port)
+	}
+
+	typeOfCandidate := reflect.TypeOf(Candidate{})
+	if typeOfCandidate.NumField() != 3 {
+		t.Fatalf("Candidate has %d fields, want only sanitized port, label, and hint", typeOfCandidate.NumField())
+	}
+	for _, forbidden := range []string{"PID", "Path", "Argv", "CommandLine"} {
+		if _, present := typeOfCandidate.FieldByName(forbidden); present {
+			t.Fatalf("Candidate exposes sensitive field %q", forbidden)
+		}
+	}
+}

--- a/helper/internal/discovery/discovery.go
+++ b/helper/internal/discovery/discovery.go
@@ -1,0 +1,302 @@
+package discovery
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+)
+
+const (
+	probeTimeout      = 200 * time.Millisecond
+	maxProbeWorkers   = 8
+	maxProcessLabel   = 64
+	maxPortalNameSize = 63
+)
+
+var errDiscoveryUnavailable = errors.New("local app discovery unavailable")
+
+// Candidate is the complete privacy boundary for Local App discovery.
+// Sensitive host-process details cannot be represented by this type.
+type Candidate struct {
+	LocalAppPort        uint16 `json:"localAppPort"`
+	ProcessLabel        string `json:"processLabel"`
+	SuggestedPortalName string `json:"suggestedPortalName,omitempty"`
+}
+
+type listenerSource interface {
+	listeners(context.Context) ([]Candidate, error)
+}
+
+type reachabilityProber interface {
+	reachableAtLoopback(context.Context, uint16) bool
+}
+
+type Discoverer struct {
+	source listenerSource
+	prober reachabilityProber
+}
+
+func newDiscoverer(source listenerSource, prober reachabilityProber) *Discoverer {
+	return &Discoverer{source: source, prober: prober}
+}
+
+func (d *Discoverer) Discover(ctx context.Context) ([]Candidate, error) {
+	candidates, err := d.source.listeners(ctx)
+	if err != nil {
+		return nil, errDiscoveryUnavailable
+	}
+
+	byPort := make(map[uint16]Candidate)
+	disagreed := make(map[uint16]bool)
+	for _, candidate := range candidates {
+		if candidate.LocalAppPort == 0 {
+			continue
+		}
+		if previous, exists := byPort[candidate.LocalAppPort]; !exists {
+			byPort[candidate.LocalAppPort] = candidate
+		} else if previous.ProcessLabel != candidate.ProcessLabel || previous.SuggestedPortalName != candidate.SuggestedPortalName {
+			disagreed[candidate.LocalAppPort] = true
+		}
+	}
+	for port := range disagreed {
+		byPort[port] = genericCandidate(port)
+	}
+
+	ports := make([]uint16, 0, len(byPort))
+	for port := range byPort {
+		ports = append(ports, port)
+	}
+	sort.Slice(ports, func(i, j int) bool { return ports[i] < ports[j] })
+	reachable := d.reachablePorts(ctx, ports)
+
+	result := make([]Candidate, 0, len(reachable))
+	for _, port := range ports {
+		if reachable[port] {
+			result = append(result, byPort[port])
+		}
+	}
+	return result, nil
+}
+
+func (d *Discoverer) reachablePorts(ctx context.Context, ports []uint16) map[uint16]bool {
+	result := make(map[uint16]bool, len(ports))
+	if len(ports) == 0 {
+		return result
+	}
+
+	type probeResult struct {
+		port      uint16
+		reachable bool
+	}
+	jobs := make(chan uint16)
+	results := make(chan probeResult, len(ports))
+	workers := min(maxProbeWorkers, len(ports))
+	var group sync.WaitGroup
+	for range workers {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			for port := range jobs {
+				probeContext, cancel := context.WithTimeout(ctx, probeTimeout)
+				reachable := d.prober.reachableAtLoopback(probeContext, port)
+				cancel()
+				results <- probeResult{port: port, reachable: reachable}
+			}
+		}()
+	}
+	go func() {
+		for _, port := range ports {
+			jobs <- port
+		}
+		close(jobs)
+		group.Wait()
+		close(results)
+	}()
+	for probe := range results {
+		result[probe.port] = probe.reachable
+	}
+	return result
+}
+
+type loopbackProber struct{}
+
+func (loopbackProber) reachableAtLoopback(ctx context.Context, port uint16) bool {
+	dialer := net.Dialer{}
+	connection, err := dialer.DialContext(ctx, "tcp4", net.JoinHostPort("127.0.0.1", fmt.Sprint(port)))
+	if err != nil {
+		return false
+	}
+	_ = connection.Close()
+	return true
+}
+
+func reduce(port uint16, executable string, argv []string) Candidate {
+	label := sanitizeProcessLabel(filepath.Base(executable))
+	if label == "" {
+		label = genericCandidate(port).ProcessLabel
+	}
+	return Candidate{
+		LocalAppPort:        port,
+		ProcessLabel:        label,
+		SuggestedPortalName: classifyPortalName(filepath.Base(executable), argv),
+	}
+}
+
+func genericCandidate(port uint16) Candidate {
+	return Candidate{LocalAppPort: port, ProcessLabel: fmt.Sprintf("Port %d", port)}
+}
+
+func sanitizeProcessLabel(value string) string {
+	if value == "." || value == ".." {
+		return ""
+	}
+	var builder strings.Builder
+	lastWasSeparator := false
+	for _, char := range value {
+		allowed := char <= unicode.MaxASCII && (unicode.IsLetter(char) || unicode.IsDigit(char) || strings.ContainsRune("._+-", char))
+		if allowed {
+			builder.WriteRune(char)
+			lastWasSeparator = false
+		} else if !lastWasSeparator {
+			builder.WriteByte('-')
+			lastWasSeparator = true
+		}
+		if builder.Len() > maxProcessLabel {
+			return ""
+		}
+	}
+	return strings.Trim(builder.String(), "-._+")
+}
+
+func classifyPortalName(executable string, argv []string) string {
+	runtimeName := strings.ToLower(executable)
+	if runtimeName == "" || isShellOrLauncher(runtimeName) {
+		return ""
+	}
+	if runtimeName == "java" {
+		if len(argv) >= 3 && argv[1] == "-jar" && !strings.HasPrefix(argv[2], "-") && strings.EqualFold(filepath.Ext(argv[2]), ".jar") {
+			return normalizePortalName(filepath.Base(argv[2]), ".jar")
+		}
+		return ""
+	}
+	if isPython(runtimeName) {
+		if len(argv) < 2 {
+			return ""
+		}
+		if argv[1] == "-m" && len(argv) >= 3 && isPythonModule(argv[2]) {
+			parts := strings.Split(argv[2], ".")
+			return normalizePortalName(parts[len(parts)-1], "")
+		}
+		if strings.HasPrefix(argv[1], "-") {
+			return ""
+		}
+		if strings.EqualFold(filepath.Ext(argv[1]), ".py") {
+			return normalizePortalName(filepath.Base(argv[1]), ".py")
+		}
+		return ""
+	}
+	if runtimeName == "node" || runtimeName == "nodejs" {
+		if len(argv) < 2 || argv[1] == "" || strings.HasPrefix(argv[1], "-") {
+			return ""
+		}
+		return normalizePortalName(filepath.Base(argv[1]), recognizedNodeExtension(argv[1]))
+	}
+	return normalizePortalName(executable, "")
+}
+
+func isPython(value string) bool {
+	if value == "python" || value == "python2" || value == "python3" {
+		return true
+	}
+	for _, prefix := range []string{"python2.", "python3."} {
+		if strings.HasPrefix(value, prefix) && onlyASCIIDigits(strings.TrimPrefix(value, prefix)) {
+			return true
+		}
+	}
+	return false
+}
+
+func isShellOrLauncher(value string) bool {
+	switch value {
+	case "sh", "bash", "dash", "zsh", "fish", "csh", "tcsh",
+		"env", "xcrun", "nohup", "open", "launchctl",
+		"ruby", "perl", "php", "swift", "go", "cargo", "dotnet", "mono",
+		"npm", "npx", "yarn", "pnpm", "bun", "deno":
+		return true
+	default:
+		return false
+	}
+}
+
+func onlyASCIIDigits(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, char := range value {
+		if char < '0' || char > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func isPythonModule(value string) bool {
+	if value == "" || strings.HasPrefix(value, ".") || strings.HasSuffix(value, ".") {
+		return false
+	}
+	for _, component := range strings.Split(value, ".") {
+		if component == "" {
+			return false
+		}
+		for index, char := range component {
+			if char > unicode.MaxASCII || !(char == '_' || unicode.IsLetter(char) || (index > 0 && unicode.IsDigit(char))) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func recognizedNodeExtension(value string) string {
+	switch extension := strings.ToLower(filepath.Ext(value)); extension {
+	case ".js", ".mjs", ".cjs", ".ts":
+		return extension
+	default:
+		return ""
+	}
+}
+
+func normalizePortalName(value, extension string) string {
+	if extension != "" && strings.EqualFold(filepath.Ext(value), extension) {
+		value = strings.TrimSuffix(value, filepath.Ext(value))
+	}
+	var builder strings.Builder
+	lastWasSeparator := false
+	for _, char := range value {
+		if char >= 'A' && char <= 'Z' {
+			char += 'a' - 'A'
+		}
+		if (char >= 'a' && char <= 'z') || (char >= '0' && char <= '9') {
+			builder.WriteRune(char)
+			lastWasSeparator = false
+		} else if !lastWasSeparator {
+			builder.WriteByte('-')
+			lastWasSeparator = true
+		}
+		if builder.Len() > maxPortalNameSize {
+			return ""
+		}
+	}
+	result := strings.Trim(builder.String(), "-")
+	if result == "" || len(result) > maxPortalNameSize {
+		return ""
+	}
+	return result
+}

--- a/helper/internal/discovery/discovery_test.go
+++ b/helper/internal/discovery/discovery_test.go
@@ -1,0 +1,153 @@
+package discovery
+
+import (
+	"context"
+	"net"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestDiscoverSuggestsConservativePortalNames(t *testing.T) {
+	tests := []struct {
+		name       string
+		executable string
+		argv       []string
+		wantLabel  string
+		wantHint   string
+	}{
+		{"Java jar", "/usr/bin/java", []string{"java", "-jar", "/private/tools/Hermes Server.jar", "--token", "do-not-copy"}, "java", "hermes-server"},
+		{"Python module", "/usr/bin/python3", []string{"python3", "-m", "package.Hermes_Server", "--secret", "do-not-copy"}, "python3", "hermes-server"},
+		{"Python script", "/usr/bin/python3", []string{"python3", "/private/tools/Hermes.py", "--secret", "do-not-copy"}, "python3", "hermes"},
+		{"Node entry", "/opt/homebrew/bin/node", []string{"node", "/private/tools/Hermes Server.mjs", "--secret", "do-not-copy"}, "node", "hermes-server"},
+		{"Direct executable", "/Applications/Tools/Hermes_Server", []string{"Hermes_Server", "--secret", "do-not-copy"}, "Hermes_Server", "hermes-server"},
+		{"Bare Java", "/usr/bin/java", []string{"java"}, "java", ""},
+		{"Bare Python", "/usr/bin/python3", []string{"python3"}, "python3", ""},
+		{"Bare Node", "/usr/bin/node", []string{"node"}, "node", ""},
+		{"Shell", "/bin/zsh", []string{"zsh", "/private/tools/hermes"}, "zsh", ""},
+		{"Launcher", "/usr/bin/env", []string{"env", "SECRET=do-not-copy", "/private/tools/hermes"}, "env", ""},
+		{"Generic runtime", "/usr/bin/ruby", []string{"ruby", "/private/tools/hermes.rb"}, "ruby", ""},
+		{"Java leading flag", "/usr/bin/java", []string{"java", "-Xmx1g", "-jar", "/private/tools/hermes.jar"}, "java", ""},
+		{"Python leading flag", "/usr/bin/python3", []string{"python3", "-u", "/private/tools/hermes.py"}, "python3", ""},
+		{"Node leading flag", "/usr/bin/node", []string{"node", "--inspect", "/private/tools/hermes.js"}, "node", ""},
+	}
+
+	for index, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			port := uint16(8000 + index)
+			got := reduce(port, test.executable, test.argv)
+			want := Candidate{LocalAppPort: port, ProcessLabel: test.wantLabel, SuggestedPortalName: test.wantHint}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("Discover() = %+v, want %+v", got, want)
+			}
+			for _, forbidden := range []string{"--secret", "do-not-copy", "/private/tools"} {
+				if strings.Contains(got.ProcessLabel, forbidden) || strings.Contains(got.SuggestedPortalName, forbidden) {
+					t.Fatal("sensitive argument data escaped the discovery boundary")
+				}
+			}
+		})
+	}
+}
+
+func TestDiscoverRejectsInvalidSuggestionsAndSanitizesLabels(t *testing.T) {
+	overlong := strings.Repeat("a", 64)
+	discoverer := newDiscoverer(
+		fakeSource{candidates: []Candidate{
+			reduce(9001, "/tmp/../", []string{""}),
+			reduce(9002, "/tmp/python", []string{"python", "-m", "package.!!!"}),
+			reduce(9003, "/tmp/node", []string{"node", overlong + ".js"}),
+			reduce(9004, "/tmp/<unsafe process>", []string{"unsafe"}),
+		}},
+		fakeProber{reachable: map[uint16]bool{9001: true, 9002: true, 9003: true, 9004: true}},
+	)
+
+	got, err := discoverer.Discover(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []Candidate{
+		{LocalAppPort: 9001, ProcessLabel: "Port 9001"},
+		{LocalAppPort: 9002, ProcessLabel: "python"},
+		{LocalAppPort: 9003, ProcessLabel: "node"},
+		{LocalAppPort: 9004, ProcessLabel: "unsafe-process", SuggestedPortalName: "unsafe-process"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Discover() = %+v, want %+v", got, want)
+	}
+}
+
+func TestDiscoverDeduplicatesAndSortsByPort(t *testing.T) {
+	discoverer := newDiscoverer(
+		fakeSource{candidates: []Candidate{
+			reduce(9000, "/tmp/hermes", []string{"hermes"}),
+			reduce(8000, "/tmp/atlas", []string{"atlas"}),
+			reduce(9000, "/other/hermes", []string{"hermes", "--secret", "do-not-copy"}),
+			reduce(7000, "/tmp/first", []string{"first"}),
+			reduce(8000, "/tmp/different", []string{"different"}),
+		}},
+		fakeProber{reachable: map[uint16]bool{7000: true, 8000: true, 9000: true}},
+	)
+
+	got, err := discoverer.Discover(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []Candidate{
+		{LocalAppPort: 7000, ProcessLabel: "first", SuggestedPortalName: "first"},
+		{LocalAppPort: 8000, ProcessLabel: "Port 8000"},
+		{LocalAppPort: 9000, ProcessLabel: "hermes", SuggestedPortalName: "hermes"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Discover() = %+v, want %+v", got, want)
+	}
+}
+
+func TestDiscoverIncludesOnlyAcceptingLoopbackPort(t *testing.T) {
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	openPort := uint16(listener.Addr().(*net.TCPAddr).Port)
+
+	closedListener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	closedPort := uint16(closedListener.Addr().(*net.TCPAddr).Port)
+	closedListener.Close()
+
+	discoverer := newDiscoverer(
+		fakeSource{candidates: []Candidate{
+			reduce(closedPort, "/tmp/closed", []string{"closed"}),
+			reduce(openPort, "/tmp/accepting", []string{"accepting"}),
+		}},
+		loopbackProber{},
+	)
+
+	got, err := discoverer.Discover(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []Candidate{{LocalAppPort: openPort, ProcessLabel: "accepting", SuggestedPortalName: "accepting"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Discover() = %+v, want %+v", got, want)
+	}
+}
+
+type fakeSource struct {
+	candidates []Candidate
+	err        error
+}
+
+func (s fakeSource) listeners(context.Context) ([]Candidate, error) {
+	return s.candidates, s.err
+}
+
+type fakeProber struct {
+	reachable map[uint16]bool
+}
+
+func (p fakeProber) reachableAtLoopback(_ context.Context, port uint16) bool {
+	return p.reachable[port]
+}

--- a/helper/internal/protocol/server.go
+++ b/helper/internal/protocol/server.go
@@ -5,10 +5,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 
+	"github.com/chrisbanes/portico/helper/internal/discovery"
 	"github.com/chrisbanes/portico/helper/internal/portal"
 )
 
@@ -20,6 +24,15 @@ type PortalRuntime interface {
 	Start(context.Context, portal.Config, func(portal.Event)) error
 	Authenticate(context.Context, string) error
 	Close() error
+}
+
+type LocalAppDiscoverer interface {
+	Discover(context.Context) ([]discovery.Candidate, error)
+}
+
+type Services struct {
+	PortalRuntime      PortalRuntime
+	LocalAppDiscoverer LocalAppDiscoverer
 }
 
 type request struct {
@@ -47,6 +60,10 @@ type handshakeResult struct {
 
 type acceptedResult struct {
 	Accepted bool `json:"accepted"`
+}
+
+type discoverLocalAppsResult struct {
+	Candidates []discovery.Candidate `json:"candidates"`
 }
 
 type startPortalPayload struct {
@@ -86,11 +103,38 @@ func Serve(input io.Reader, output, diagnostics io.Writer) int {
 }
 
 func ServeWithRuntime(input io.Reader, output, diagnostics io.Writer, runtime PortalRuntime) int {
+	return ServeWithServices(input, output, diagnostics, Services{PortalRuntime: runtime})
+}
+
+func ServeWithServices(input io.Reader, output, diagnostics io.Writer, services Services) int {
+	runtime := services.PortalRuntime
 	if runtime != nil {
 		defer runtime.Close()
 	}
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	discoveryContext, cancelDiscovery := context.WithCancel(ctx)
+	var outputFailed atomic.Bool
+	failOutput := func() {
+		if outputFailed.CompareAndSwap(false, true) {
+			cancelDiscovery()
+			cancel()
+			if closer, ok := input.(io.Closer); ok {
+				_ = closer.Close()
+			}
+		}
+	}
+	var discoveryGroup sync.WaitGroup
+	discoveryGate := make(chan struct{}, 1)
+	cancelBeforeExit := true
+	defer func() {
+		if cancelBeforeExit {
+			cancelDiscovery()
+			cancel()
+		}
+		discoveryGroup.Wait()
+		cancelDiscovery()
+		cancel()
+	}()
 	writer := &messageWriter{encoder: json.NewEncoder(output)}
 	emit := func(event portal.Event) {
 		if event.Status != nil {
@@ -134,6 +178,8 @@ func ServeWithRuntime(input io.Reader, output, diagnostics io.Writer, runtime Po
 				_, _ = io.WriteString(diagnostics, invalidRequestDiagnostic)
 				return 1
 			}
+			cancelDiscovery()
+			discoveryGroup.Wait()
 			if runtime != nil {
 				if err := runtime.Close(); err != nil {
 					_ = writer.write(errorResponse(request.RequestID, "runtimeFailure", "portal runtime failed"))
@@ -144,6 +190,44 @@ func ServeWithRuntime(input io.Reader, output, diagnostics io.Writer, runtime Po
 				return 1
 			}
 			return 0
+		case "discoverLocalApps":
+			if !isEmptyPayload(request.Payload) {
+				_, _ = io.WriteString(diagnostics, invalidRequestDiagnostic)
+				return 1
+			}
+			if services.LocalAppDiscoverer == nil {
+				if writer.write(errorResponse(request.RequestID, "discoveryFailure", "local app discovery failed")) != nil {
+					return 1
+				}
+				continue
+			}
+			requestID := request.RequestID
+			discoveryGroup.Add(1)
+			go func() {
+				defer discoveryGroup.Done()
+				select {
+				case discoveryGate <- struct{}{}:
+					defer func() { <-discoveryGate }()
+				case <-discoveryContext.Done():
+					return
+				}
+				candidates, err := services.LocalAppDiscoverer.Discover(discoveryContext)
+				if discoveryContext.Err() != nil {
+					return
+				}
+				if err != nil {
+					if writer.write(errorResponse(requestID, "discoveryFailure", "local app discovery failed")) != nil {
+						failOutput()
+					}
+					return
+				}
+				if writer.write(response{
+					Version: Version, RequestID: requestID,
+					Result: discoverLocalAppsResult{Candidates: canonicalCandidates(candidates)},
+				}) != nil {
+					failOutput()
+				}
+			}()
 		case "startPortal":
 			var payload startPortalPayload
 			if runtime == nil || decodePayload(request.Payload, &payload) != nil {
@@ -198,11 +282,50 @@ func ServeWithRuntime(input io.Reader, output, diagnostics io.Writer, runtime Po
 			}
 		}
 	}
-	if scanner.Err() != nil {
-		_, _ = io.WriteString(diagnostics, invalidRequestDiagnostic)
+	if scannerError := scanner.Err(); scannerError != nil {
+		cancelDiscovery()
+		cancel()
+		discoveryGroup.Wait()
+		if !outputFailed.Load() {
+			_, _ = io.WriteString(diagnostics, invalidRequestDiagnostic)
+		}
 		return 1
 	}
+	discoveryGroup.Wait()
+	if outputFailed.Load() {
+		return 1
+	}
+	cancelBeforeExit = false
 	return 0
+}
+
+func canonicalCandidates(candidates []discovery.Candidate) []discovery.Candidate {
+	byPort := make(map[uint16]discovery.Candidate, len(candidates))
+	disagreed := make(map[uint16]bool)
+	for _, candidate := range candidates {
+		if candidate.LocalAppPort == 0 || candidate.ProcessLabel == "" {
+			continue
+		}
+		if previous, exists := byPort[candidate.LocalAppPort]; !exists {
+			byPort[candidate.LocalAppPort] = candidate
+		} else if previous != candidate {
+			disagreed[candidate.LocalAppPort] = true
+		}
+	}
+	ports := make([]uint16, 0, len(byPort))
+	for port := range byPort {
+		ports = append(ports, port)
+	}
+	sort.Slice(ports, func(i, j int) bool { return ports[i] < ports[j] })
+	result := make([]discovery.Candidate, 0, len(ports))
+	for _, port := range ports {
+		if disagreed[port] {
+			result = append(result, discovery.Candidate{LocalAppPort: port, ProcessLabel: fmt.Sprintf("Port %d", port)})
+		} else {
+			result = append(result, byPort[port])
+		}
+	}
+	return result
 }
 
 func (request request) isStructurallyValid() bool {

--- a/helper/internal/protocol/server_test.go
+++ b/helper/internal/protocol/server_test.go
@@ -4,12 +4,182 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/chrisbanes/portico/helper/internal/discovery"
 	"github.com/chrisbanes/portico/helper/internal/portal"
 )
+
+func TestDiscoverLocalAppsReturnsOnlyStableSanitizedCandidates(t *testing.T) {
+	discoverer := fakeDiscoverer{candidates: []discovery.Candidate{
+		{LocalAppPort: 9000, ProcessLabel: "hermes", SuggestedPortalName: "hermes"},
+		{LocalAppPort: 8000, ProcessLabel: "atlas", SuggestedPortalName: "atlas"},
+		{LocalAppPort: 9000, ProcessLabel: "hermes", SuggestedPortalName: "hermes"},
+		{LocalAppPort: 7000, ProcessLabel: "first", SuggestedPortalName: "first"},
+	}}
+	input := bytes.NewBufferString(`{"version":1,"requestId":"discover-1","command":"discoverLocalApps","payload":{}}` + "\n")
+	var output bytes.Buffer
+	var diagnostics bytes.Buffer
+
+	exitCode := ServeWithServices(input, &output, &diagnostics, Services{LocalAppDiscoverer: discoverer})
+
+	if exitCode != 0 || diagnostics.Len() != 0 {
+		t.Fatalf("ServeWithServices = (exit %d, diagnostics %q), want success", exitCode, diagnostics.String())
+	}
+	const want = `{"version":1,"requestId":"discover-1","result":{"candidates":[{"localAppPort":7000,"processLabel":"first","suggestedPortalName":"first"},{"localAppPort":8000,"processLabel":"atlas","suggestedPortalName":"atlas"},{"localAppPort":9000,"processLabel":"hermes","suggestedPortalName":"hermes"}]}}` + "\n"
+	if output.String() != want {
+		t.Fatalf("output = %q, want %q", output.String(), want)
+	}
+}
+
+func TestDiscoverLocalAppsCollapsesDisagreeingDuplicateOwners(t *testing.T) {
+	discoverer := fakeDiscoverer{candidates: []discovery.Candidate{
+		{LocalAppPort: 8787, ProcessLabel: "python3", SuggestedPortalName: "hermes"},
+		{LocalAppPort: 8787, ProcessLabel: "node", SuggestedPortalName: "atlas"},
+	}}
+	input := bytes.NewBufferString(`{"version":1,"requestId":"discover-1","command":"discoverLocalApps","payload":{}}` + "\n")
+	var output bytes.Buffer
+
+	if exitCode := ServeWithServices(input, &output, &bytes.Buffer{}, Services{LocalAppDiscoverer: discoverer}); exitCode != 0 {
+		t.Fatalf("ServeWithServices exit code = %d, want success", exitCode)
+	}
+	const want = `{"version":1,"requestId":"discover-1","result":{"candidates":[{"localAppPort":8787,"processLabel":"Port 8787"}]}}` + "\n"
+	if output.String() != want {
+		t.Fatalf("output = %q, want %q", output.String(), want)
+	}
+}
+
+func TestDiscoverLocalAppsRequiresEmptyPayload(t *testing.T) {
+	const secret = "do-not-copy"
+	input := bytes.NewBufferString(`{"version":1,"requestId":"discover-1","command":"discoverLocalApps","payload":{"unexpected":"` + secret + `"}}` + "\n")
+	var output bytes.Buffer
+	var diagnostics bytes.Buffer
+
+	exitCode := ServeWithServices(input, &output, &diagnostics, Services{LocalAppDiscoverer: fakeDiscoverer{}})
+
+	if exitCode == 0 || output.Len() != 0 || diagnostics.String() != invalidRequestDiagnostic {
+		t.Fatalf("ServeWithServices = (exit %d, output %q, diagnostics %q), want fixed invalid request", exitCode, output.String(), diagnostics.String())
+	}
+	if strings.Contains(output.String(), secret) || strings.Contains(diagnostics.String(), secret) {
+		t.Fatal("invalid discovery payload leaked")
+	}
+}
+
+func TestDiscoverLocalAppsReturnsFixedSecretFreeFailure(t *testing.T) {
+	const secret = "token=do-not-copy"
+	input := bytes.NewBufferString(`{"version":1,"requestId":"discover-1","command":"discoverLocalApps","payload":{}}` + "\n")
+	var output bytes.Buffer
+	var diagnostics bytes.Buffer
+
+	exitCode := ServeWithServices(input, &output, &diagnostics, Services{LocalAppDiscoverer: fakeDiscoverer{err: errors.New(secret)}})
+
+	if exitCode != 0 || diagnostics.Len() != 0 {
+		t.Fatalf("ServeWithServices = (exit %d, diagnostics %q), want correlated failure", exitCode, diagnostics.String())
+	}
+	const want = `{"version":1,"requestId":"discover-1","error":{"code":"discoveryFailure","message":"local app discovery failed"}}` + "\n"
+	if output.String() != want {
+		t.Fatalf("output = %q, want %q", output.String(), want)
+	}
+	if strings.Contains(output.String(), secret) || strings.Contains(diagnostics.String(), secret) {
+		t.Fatal("discovery failure leaked its underlying error")
+	}
+}
+
+func TestDiscoverLocalAppsCancelsBeforeRuntimeCloseAndShutdownAcknowledgement(t *testing.T) {
+	reader, input := io.Pipe()
+	discoverer := &blockingDiscoverer{started: make(chan struct{}), canceled: make(chan struct{})}
+	runtime := &shutdownOrderingRuntime{discoveryCanceled: discoverer.canceled}
+	var output bytes.Buffer
+	var diagnostics bytes.Buffer
+	done := make(chan int, 1)
+	go func() {
+		done <- ServeWithServices(reader, &output, &diagnostics, Services{
+			PortalRuntime: runtime, LocalAppDiscoverer: discoverer,
+		})
+	}()
+
+	_, _ = io.WriteString(input, `{"version":1,"requestId":"discover-1","command":"discoverLocalApps","payload":{}}`+"\n")
+	<-discoverer.started
+	go func() {
+		_, _ = io.WriteString(input, `{"version":1,"requestId":"shutdown-1","command":"shutdown","payload":{}}`+"\n")
+		_ = input.Close()
+	}()
+
+	if exitCode := <-done; exitCode != 0 {
+		t.Fatalf("ServeWithServices exit code = %d, want success", exitCode)
+	}
+	if !runtime.closedAfterDiscoveryCancellation {
+		t.Fatal("runtime closed before in-flight discovery observed cancellation")
+	}
+	const want = `{"version":1,"requestId":"shutdown-1","result":{"accepted":true}}` + "\n"
+	if output.String() != want || diagnostics.Len() != 0 {
+		t.Fatalf("ServeWithServices = (output %q, diagnostics %q), want only post-close shutdown acknowledgement", output.String(), diagnostics.String())
+	}
+}
+
+func TestDiscoverLocalAppsFailsServeWhenResponseCannotBeWritten(t *testing.T) {
+	input := bytes.NewBufferString(`{"version":1,"requestId":"discover-1","command":"discoverLocalApps","payload":{}}` + "\n")
+
+	exitCode := ServeWithServices(input, errorWriter{}, &bytes.Buffer{}, Services{LocalAppDiscoverer: fakeDiscoverer{}})
+
+	if exitCode == 0 {
+		t.Fatal("ServeWithServices exit code = 0, want response write failure")
+	}
+}
+
+type fakeDiscoverer struct {
+	candidates []discovery.Candidate
+	err        error
+}
+
+func (d fakeDiscoverer) Discover(context.Context) ([]discovery.Candidate, error) {
+	return d.candidates, d.err
+}
+
+type blockingDiscoverer struct {
+	started  chan struct{}
+	canceled chan struct{}
+}
+
+func (d *blockingDiscoverer) Discover(ctx context.Context) ([]discovery.Candidate, error) {
+	close(d.started)
+	select {
+	case <-ctx.Done():
+		close(d.canceled)
+		return nil, ctx.Err()
+	case <-time.After(250 * time.Millisecond):
+		return nil, errors.New("discovery did not observe cancellation")
+	}
+}
+
+type shutdownOrderingRuntime struct {
+	discoveryCanceled                <-chan struct{}
+	closedAfterDiscoveryCancellation bool
+}
+
+type errorWriter struct{}
+
+func (errorWriter) Write([]byte) (int, error) { return 0, errors.New("write failed") }
+
+func (*shutdownOrderingRuntime) Start(context.Context, portal.Config, func(portal.Event)) error {
+	return nil
+}
+
+func (*shutdownOrderingRuntime) Authenticate(context.Context, string) error { return nil }
+
+func (r *shutdownOrderingRuntime) Close() error {
+	select {
+	case <-r.discoveryCanceled:
+		r.closedAfterDiscoveryCancellation = true
+	default:
+	}
+	return nil
+}
 
 func TestServeCorrelatesHandshakeResponse(t *testing.T) {
 	input := bytes.NewBufferString(`{"version":1,"requestId":"request-1","command":"handshake","payload":{}}` + "\n")


### PR DESCRIPTION
## Summary
- discover current-user TCP listeners through a private Darwin adapter and short loopback probes
- send only sanitized port, basename label, and optional conservative DNS hint over JSONL
- add correlated refresh/selection UI while keeping manual port and name entry authoritative
- cancel and join discovery before helper runtime shutdown

## Validation
- `./Scripts/verify-xcode-project-generation.sh` (passed)
- `cd helper && go test -race ./...` (passed)
- `xcodebuild -project Portico.xcodeproj -scheme Portico -destination 'platform=macOS' -derivedDataPath .build/xcode test` (29 tests passed)
- `./Scripts/smoke-test-local-app.sh` (passed)

## Review
- Standards and spec review: no remaining findings
- privacy/lifecycle findings fixed: raw-data boundary, PID reuse, cancellable shutdown ordering, async writer errors
- review-and-simplify-changes: clean
- ponytail-review: Lean already. Ship.

Fixes #7