### PR TITLE
Document crash-safe Portal removal lifecycle

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -36,3 +36,8 @@ _Avoid_: Active Portal, automatic Portal
 **Stopped Portal**:
 A Portal that remains disconnected until the user explicitly starts it.
 _Avoid_: Disabled Portal, paused Portal
+
+**Removing Portal**:
+A Portal whose user-confirmed local removal has not yet finished. It cannot
+run and remains recorded only so Portico can complete crash-safe cleanup.
+_Avoid_: Deleted Portal, pending deletion

--- a/docs/adr/0005-persist-portal-removal-intent.md
+++ b/docs/adr/0005-persist-portal-removal-intent.md
@@ -1,0 +1,7 @@
+# Persist Portal removal intent before deleting identity state
+
+Before Portico permanently deletes local Portal identity state, it commits a
+durable removal lifecycle that prevents the Portal from running and lets
+cleanup resume safely after interruption. The Portal record is removed only
+after guarded deletion of its UUID-keyed state succeeds; remote tailnet-node
+cleanup remains the manual process established by ADR 0003.


### PR DESCRIPTION
## Summary

- define **Removing Portal** in the Portico domain glossary
- record the decision to persist removal intent before deleting UUID-keyed identity state

## Why

Triage for #9 established that local Portal removal must remain recoverable across interruption. Persisting the removal lifecycle first prevents the Portal from running again and lets guarded cleanup resume without weakening the manual remote-node boundary from ADR 0003.

Supports #9.

## Impact

This is documentation-only. It gives the implementation agent durable terminology and an architectural constraint; it does not change runtime behavior.

## Validation

- `git diff --check`
- reviewed the staged two-file diff