### PR TITLE
Run multiple independent Portals on one tailnet

### DIFF
--- a/Portico/HelperProtocol.swift
+++ b/Portico/HelperProtocol.swift
@@ -7,6 +7,7 @@ enum HelperCommand: String, Codable {
     case shutdown
     case startPortal
     case authenticatePortal
+    case cleanupRejectedPortal
     case discoverLocalApps
 }
 
@@ -52,6 +53,14 @@ struct AuthenticatePortalResult: Codable, Equatable {
     let accepted: Bool
 }
 
+struct CleanupRejectedPortalPayload: Codable, Equatable {
+    let portalId: UUID
+}
+
+struct CleanupRejectedPortalResult: Codable, Equatable {
+    let accepted: Bool
+}
+
 struct LocalAppCandidatePayload: Codable, Equatable {
     let localAppPort: UInt16
     let processLabel: String
@@ -89,6 +98,26 @@ struct PortalStatusPayload: Codable, Equatable {
     let assignedName: String?
     let portalURL: URL?
     let addresses: [String]
+    let tailnetName: String?
+    let magicDNSSuffix: String?
+
+    init(
+        state: PortalTailscaleState,
+        stableNodeId: String?,
+        assignedName: String?,
+        portalURL: URL?,
+        addresses: [String],
+        tailnetName: String? = nil,
+        magicDNSSuffix: String? = nil
+    ) {
+        self.state = state
+        self.stableNodeId = stableNodeId
+        self.assignedName = assignedName
+        self.portalURL = portalURL
+        self.addresses = addresses
+        self.tailnetName = tailnetName
+        self.magicDNSSuffix = magicDNSSuffix
+    }
 }
 
 struct AuthenticationURLPayload: Codable, Equatable {

--- a/Portico/HelperSupervisor.swift
+++ b/Portico/HelperSupervisor.swift
@@ -25,6 +25,7 @@ protocol PortalHelperClient: AnyObject {
 
     func startPortal(_ portal: PortalConfiguration, completion: @escaping (Result<Void, Error>) -> Void)
     func authenticatePortal(id: UUID, completion: @escaping (Result<Void, Error>) -> Void)
+    func cleanupRejectedPortal(id: UUID, completion: @escaping (Result<Void, Error>) -> Void)
     func discoverLocalApps(completion: @escaping (Result<[LocalAppCandidatePayload], Error>) -> Void)
 }
 
@@ -135,6 +136,20 @@ final class HelperSupervisor: ObservableObject, PortalHelperClient {
         }
         do {
             try sendRequest(command: .authenticatePortal, payload: AuthenticatePortalPayload(portalId: id)) { (result: Result<AuthenticatePortalResult, Error>) in
+                completion(result.map { _ in () })
+            }
+        } catch {
+            completion(.failure(error))
+        }
+    }
+
+    func cleanupRejectedPortal(id: UUID, completion: @escaping (Result<Void, Error>) -> Void) {
+        guard availability == .connected else {
+            completion(.failure(HelperClientError.unavailable))
+            return
+        }
+        do {
+            try sendRequest(command: .cleanupRejectedPortal, payload: CleanupRejectedPortalPayload(portalId: id)) { (result: Result<CleanupRejectedPortalResult, Error>) in
                 completion(result.map { _ in () })
             }
         } catch {

--- a/Portico/PortalConfiguration.swift
+++ b/Portico/PortalConfiguration.swift
@@ -5,19 +5,53 @@ struct PortalConfiguration: Codable, Equatable {
     let name: String
     let localAppPort: UInt16
     let createdAt: Date
+    var lifecycle: PortalLifecycle = .active
 }
 
-struct PortalConfigurationEnvelope: Codable, Equatable {
-    static let currentVersion = 1
+enum PortalLifecycle: String, Codable, Equatable {
+    case active
+    case pendingTailnetRejection
+}
+
+struct TailnetBinding: Codable, Equatable {
+    let name: String
+    var magicDNSSuffix: String
+}
+
+enum InstallationAlertKind: String, Codable, Equatable {
+    case crossTailnetRejection
+}
+
+struct InstallationAlert: Codable, Equatable, Identifiable {
+    let id: UUID
+    let kind: InstallationAlertKind
+    let portalName: String
+    let assignedName: String?
+    let expectedMagicDNSSuffix: String?
+    let rejectedMagicDNSSuffix: String?
+    let createdAt: Date
+}
+
+struct InstallationRecord: Codable, Equatable {
+    static let currentVersion = 2
 
     let version: Int
-    let portal: PortalConfiguration
+    var tailnetBinding: TailnetBinding?
+    var portals: [PortalConfiguration]
+    var alerts: [InstallationAlert]
 
-    init(portal: PortalConfiguration) {
+    init(
+        tailnetBinding: TailnetBinding? = nil,
+        portals: [PortalConfiguration] = [],
+        alerts: [InstallationAlert] = []
+    ) {
         version = Self.currentVersion
-        self.portal = portal
+        self.tailnetBinding = tailnetBinding
+        self.portals = portals
+        self.alerts = alerts
     }
 }
+
 
 enum PortalValidationError: Error, Equatable {
     case invalidName

--- a/Portico/PortalController.swift
+++ b/Portico/PortalController.swift
@@ -2,21 +2,36 @@ import Foundation
 
 @MainActor
 final class PortalController: ObservableObject {
+    static let manualRemovalURL = URL(
+        string: "https://tailscale.com/docs/features/access-control/device-management/how-to/remove"
+    )!
+
     @Published var portalName = ""
     @Published var localAppPort = ""
-    @Published private(set) var portal: PortalConfiguration?
-    @Published private(set) var status: PortalStatusPayload?
+    @Published private(set) var portals: [PortalConfiguration] = []
+    @Published private(set) var statuses: [UUID: PortalStatusPayload] = [:]
+    @Published private(set) var alerts: [InstallationAlert] = []
+    @Published private(set) var tailnetDisplaySuffix: String?
     @Published private(set) var message: String?
     @Published private(set) var localApps: [LocalAppCandidatePayload] = []
     @Published private(set) var isRefreshingLocalApps = false
     @Published private(set) var localAppsMessage: String?
+
+    var portal: PortalConfiguration? { portals.first }
+    var status: PortalStatusPayload? { portal.flatMap { statuses[$0.id] } }
+    var canResetTailnet: Bool { portals.isEmpty && installation.tailnetBinding != nil }
+    var pendingPortals: [PortalConfiguration] {
+        portals.filter { $0.lifecycle == .pendingTailnetRejection }
+    }
 
     private let store: PortalStore
     private let helper: PortalHelperClient
     private let uuidProvider: () -> UUID
     private let dateProvider: () -> Date
     private let openURL: (URL) -> Void
-    private var authenticationPending = false
+    private var installation = InstallationRecord()
+    private var authenticationPending: Set<UUID> = []
+    private var cleanupInFlight: Set<UUID> = []
     private var discoveryGeneration = 0
 
     init(
@@ -32,7 +47,8 @@ final class PortalController: ObservableObject {
         self.dateProvider = dateProvider
         self.openURL = openURL
         do {
-            portal = try store.load()
+            installation = try store.loadInstallation()
+            publishInstallation()
         } catch {
             message = "Saved Portal configuration could not be loaded."
         }
@@ -44,13 +60,12 @@ final class PortalController: ObservableObject {
     }
 
     func refreshLocalApps() {
-        guard portal == nil else { return }
         discoveryGeneration += 1
         let generation = discoveryGeneration
         isRefreshingLocalApps = true
         localAppsMessage = nil
         helper.discoverLocalApps { [weak self] result in
-            guard let self, self.portal == nil, self.discoveryGeneration == generation else { return }
+            guard let self, self.discoveryGeneration == generation else { return }
             self.isRefreshingLocalApps = false
             switch result {
             case let .success(candidates):
@@ -62,7 +77,7 @@ final class PortalController: ObservableObject {
     }
 
     func selectLocalApp(_ candidate: LocalAppCandidatePayload) {
-        guard portal == nil, localApps.contains(candidate) else { return }
+        guard localApps.contains(candidate) else { return }
         localAppPort = String(candidate.localAppPort)
         if portalName.isEmpty, let suggestion = candidate.suggestedPortalName {
             portalName = suggestion
@@ -70,7 +85,6 @@ final class PortalController: ObservableObject {
     }
 
     func addPortal() {
-        guard portal == nil else { return }
         let port: UInt16
         do {
             port = try PortalInputValidator.validate(name: portalName, port: localAppPort)
@@ -84,33 +98,99 @@ final class PortalController: ObservableObject {
             localAppPort: port,
             createdAt: dateProvider()
         )
+        var updated = installation
+        updated.portals.append(configuration)
         do {
-            try store.save(configuration)
-            portal = configuration
+            try store.save(updated)
+            installation = updated
+            publishInstallation()
             message = nil
+            portalName = ""
+            localAppPort = ""
             discoveryGeneration += 1
             localApps = []
             isRefreshingLocalApps = false
             localAppsMessage = nil
-            startSavedPortal()
+            start(configuration)
         } catch {
             message = "The Portal could not be saved."
         }
     }
 
     func authenticate() {
-        guard let portal, !authenticationPending else { return }
-        authenticationPending = true
-        helper.authenticatePortal(id: portal.id) { [weak self] result in
+        guard let portal else { return }
+        authenticate(id: portal.id)
+    }
+
+    func authenticate(id: UUID) {
+        guard portals.contains(where: { $0.id == id && $0.lifecycle == .active }),
+              authenticationPending.insert(id).inserted
+        else { return }
+        helper.authenticatePortal(id: id) { [weak self] result in
             if case .failure = result {
-                self?.authenticationPending = false
+                self?.authenticationPending.remove(id)
                 self?.message = "Authentication could not be started."
             }
         }
     }
 
-    private func startSavedPortal() {
-        guard let portal, helper.availability == .connected else { return }
+    func dismissAlert(id: UUID) {
+        guard installation.alerts.contains(where: { $0.id == id }) else { return }
+        var updated = installation
+        updated.alerts.removeAll { $0.id == id }
+        do {
+            try store.save(updated)
+            installation = updated
+            publishInstallation()
+        } catch {
+            message = "The warning could not be dismissed."
+        }
+    }
+
+    func resetTailnet(confirmed: Bool) {
+        guard confirmed else { return }
+        guard portals.isEmpty else {
+            message = "Reset Tailnet is available only when no Portals remain."
+            return
+        }
+        guard installation.tailnetBinding != nil else { return }
+        var updated = installation
+        updated.tailnetBinding = nil
+        do {
+            try store.save(updated)
+            installation = updated
+            publishInstallation()
+            message = nil
+        } catch {
+            message = "The tailnet binding could not be reset."
+        }
+    }
+
+    func pendingWarningText(for portal: PortalConfiguration) -> String {
+        "Removing \(portal.name) from a different tailnet. Local cleanup is in progress; its remote node may still require manual removal."
+    }
+
+    func completedWarningText(for alert: InstallationAlert) -> String {
+        let node = alert.assignedName.map { " \($0)" } ?? ""
+        let expected = alert.expectedMagicDNSSuffix.map { " Expected tailnet: \($0)." } ?? ""
+        let rejected = alert.rejectedMagicDNSSuffix.map { " Rejected tailnet: \($0)." } ?? ""
+        return "Portico removed \(alert.portalName)'s local configuration and identity state after it joined a different tailnet. The remote node\(node) may remain and may require manual removal.\(expected)\(rejected)"
+    }
+
+    private func helperConnected() {
+        refreshLocalApps()
+        for portal in installation.portals {
+            switch portal.lifecycle {
+            case .active:
+                start(portal)
+            case .pendingTailnetRejection:
+                cleanupRejectedPortal(portal, evidence: nil)
+            }
+        }
+    }
+
+    private func start(_ portal: PortalConfiguration) {
+        guard helper.availability == .connected, portal.lifecycle == .active else { return }
         helper.startPortal(portal) { [weak self] result in
             if case .failure = result {
                 self?.message = "The Portal could not be started."
@@ -118,24 +198,143 @@ final class PortalController: ObservableObject {
         }
     }
 
-    private func helperConnected() {
-        if portal == nil {
-            refreshLocalApps()
-        } else {
-            startSavedPortal()
+    private func receive(_ event: PortalHelperEvent) {
+        switch event {
+        case let .status(id, status):
+            guard let portal = installation.portals.first(where: { $0.id == id }) else { return }
+            statuses[id] = status.redactingTailnetName()
+            if portal.lifecycle == .active, status.state == .online,
+               let tailnetName = status.tailnetName, !tailnetName.isEmpty {
+                receiveOnlineStatus(for: portal, status: status, tailnetName: tailnetName)
+            }
+        case let .authenticationURL(id, url):
+            guard authenticationPending.remove(id) != nil,
+                  installation.portals.contains(where: { $0.id == id && $0.lifecycle == .active })
+            else { return }
+            openURL(url)
         }
     }
 
-    private func receive(_ event: PortalHelperEvent) {
-        guard let portal else { return }
-        switch event {
-        case let .status(id, status) where id == portal.id:
-            self.status = status
-        case let .authenticationURL(id, url) where id == portal.id && authenticationPending:
-            authenticationPending = false
-            openURL(url)
-        default:
-            break
+    private func receiveOnlineStatus(
+        for portal: PortalConfiguration,
+        status: PortalStatusPayload,
+        tailnetName: String
+    ) {
+        guard let binding = installation.tailnetBinding else {
+            var updated = installation
+            updated.tailnetBinding = TailnetBinding(
+                name: tailnetName,
+                magicDNSSuffix: status.magicDNSSuffix ?? ""
+            )
+            do {
+                try store.save(updated)
+                installation = updated
+                publishInstallation()
+                message = nil
+            } catch {
+                message = "The installation tailnet could not be saved."
+            }
+            return
         }
+        guard binding.name == tailnetName else {
+            reject(portal, status: status)
+            return
+        }
+        let suffix = status.magicDNSSuffix ?? ""
+        guard suffix != binding.magicDNSSuffix else { return }
+        var updated = installation
+        updated.tailnetBinding?.magicDNSSuffix = suffix
+        do {
+            try store.save(updated)
+            installation = updated
+            publishInstallation()
+        } catch {
+            message = "The tailnet display name could not be refreshed."
+        }
+    }
+
+    private func reject(_ portal: PortalConfiguration, status: PortalStatusPayload) {
+        guard let index = installation.portals.firstIndex(where: { $0.id == portal.id && $0.lifecycle == .active }) else {
+            return
+        }
+        var updated = installation
+        updated.portals[index].lifecycle = .pendingTailnetRejection
+        do {
+            try store.save(updated)
+            installation = updated
+            publishInstallation()
+            cleanupRejectedPortal(
+                updated.portals[index],
+                evidence: RejectionEvidence(
+                    assignedName: status.assignedName,
+                    rejectedMagicDNSSuffix: status.magicDNSSuffix
+                )
+            )
+        } catch {
+            message = "The rejected Portal could not be saved for cleanup."
+        }
+    }
+
+    private func cleanupRejectedPortal(_ portal: PortalConfiguration, evidence: RejectionEvidence?) {
+        guard helper.availability == .connected, cleanupInFlight.insert(portal.id).inserted else { return }
+        helper.cleanupRejectedPortal(id: portal.id) { [weak self] result in
+            guard let self else { return }
+            self.cleanupInFlight.remove(portal.id)
+            guard case .success = result else {
+                self.message = "Local cleanup will be retried the next time Portico starts."
+                return
+            }
+            guard self.installation.portals.contains(where: {
+                $0.id == portal.id && $0.lifecycle == .pendingTailnetRejection
+            }) else { return }
+            var updated = self.installation
+            updated.portals.removeAll { $0.id == portal.id }
+            updated.alerts.append(InstallationAlert(
+                id: self.uuidProvider(),
+                kind: .crossTailnetRejection,
+                portalName: portal.name,
+                assignedName: evidence?.assignedName,
+                expectedMagicDNSSuffix: self.installation.tailnetBinding?.magicDNSSuffix.nonEmpty,
+                rejectedMagicDNSSuffix: evidence?.rejectedMagicDNSSuffix?.nonEmpty,
+                createdAt: self.dateProvider()
+            ))
+            do {
+                try self.store.save(updated)
+                self.installation = updated
+                self.statuses.removeValue(forKey: portal.id)
+                self.publishInstallation()
+                self.message = nil
+            } catch {
+                self.message = "Local cleanup completed, but its warning could not be saved; Portico will retry."
+            }
+        }
+    }
+
+    private func publishInstallation() {
+        portals = installation.portals
+        alerts = installation.alerts
+        tailnetDisplaySuffix = installation.tailnetBinding?.magicDNSSuffix.nonEmpty
+    }
+}
+
+private struct RejectionEvidence {
+    let assignedName: String?
+    let rejectedMagicDNSSuffix: String?
+}
+
+private extension String {
+    var nonEmpty: String? { isEmpty ? nil : self }
+}
+
+private extension PortalStatusPayload {
+    func redactingTailnetName() -> PortalStatusPayload {
+        PortalStatusPayload(
+            state: state,
+            stableNodeId: stableNodeId,
+            assignedName: assignedName,
+            portalURL: portalURL,
+            addresses: addresses,
+            magicDNSSuffix: magicDNSSuffix
+        )
     }
 }

--- a/Portico/PortalStore.swift
+++ b/Portico/PortalStore.swift
@@ -7,35 +7,102 @@ enum PortalStoreError: Error {
 
 struct PortalStore {
     let rootURL: URL
+    private let writeData: (Data, URL) throws -> Void
+
+    init(
+        rootURL: URL,
+        writeData: @escaping (Data, URL) throws -> Void = { data, url in
+            try data.write(to: url, options: .atomic)
+        }
+    ) {
+        self.rootURL = rootURL
+        self.writeData = writeData
+    }
 
     var configurationURL: URL {
+        legacyConfigurationURL
+    }
+
+    var legacyConfigurationURL: URL {
         rootURL.appendingPathComponent("portal-v1.json", isDirectory: false)
     }
 
+    var installationURL: URL {
+        rootURL.appendingPathComponent("installation-v2.json", isDirectory: false)
+    }
+
     func load() throws -> PortalConfiguration? {
-        guard FileManager.default.fileExists(atPath: configurationURL.path) else {
-            return nil
-        }
-        let data = try Data(contentsOf: configurationURL)
-        let envelope = try JSONDecoder().decode(PortalConfigurationEnvelope.self, from: data)
-        guard envelope.version == PortalConfigurationEnvelope.currentVersion else {
-            throw PortalStoreError.unsupportedVersion(envelope.version)
-        }
-        return envelope.portal
+        try loadInstallation().portals.first
     }
 
     func save(_ portal: PortalConfiguration) throws {
-        guard !FileManager.default.fileExists(atPath: configurationURL.path) else {
+        var installation = try loadInstallation()
+        guard installation.portals.isEmpty else {
             throw PortalStoreError.alreadyExists
         }
+        installation.portals.append(portal)
+        try save(installation)
+    }
+
+    func loadInstallation() throws -> InstallationRecord {
+        if FileManager.default.fileExists(atPath: installationURL.path) {
+            let data = try Data(contentsOf: installationURL)
+            let installation = try JSONDecoder().decode(InstallationRecord.self, from: data)
+            guard installation.version == InstallationRecord.currentVersion else {
+                throw PortalStoreError.unsupportedVersion(installation.version)
+            }
+            if FileManager.default.fileExists(atPath: legacyConfigurationURL.path) {
+                try? FileManager.default.removeItem(at: legacyConfigurationURL)
+            }
+            return installation
+        }
+        guard FileManager.default.fileExists(atPath: legacyConfigurationURL.path) else {
+            return InstallationRecord()
+        }
+        let data = try Data(contentsOf: legacyConfigurationURL)
+        let envelope = try JSONDecoder().decode(LegacyPortalConfigurationEnvelope.self, from: data)
+        guard envelope.version == LegacyPortalConfigurationEnvelope.currentVersion else {
+            throw PortalStoreError.unsupportedVersion(envelope.version)
+        }
+        let installation = InstallationRecord(portals: [envelope.portal.migrated])
+        try save(installation)
+        try FileManager.default.removeItem(at: legacyConfigurationURL)
+        return installation
+    }
+
+    func save(_ installation: InstallationRecord) throws {
         try FileManager.default.createDirectory(
             at: rootURL,
             withIntermediateDirectories: true,
             attributes: [.posixPermissions: 0o700]
         )
         try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: rootURL.path)
-        let data = try JSONEncoder().encode(PortalConfigurationEnvelope(portal: portal))
-        try data.write(to: configurationURL, options: .atomic)
-        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: configurationURL.path)
+        let data = try JSONEncoder().encode(installation)
+        try writeData(data, installationURL)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: installationURL.path)
+    }
+}
+
+private struct LegacyPortalConfigurationEnvelope: Decodable {
+    static let currentVersion = 1
+
+    let version: Int
+    let portal: LegacyPortalConfiguration
+}
+
+private struct LegacyPortalConfiguration: Decodable {
+    let id: UUID
+    let name: String
+    let localAppPort: UInt16
+    let createdAt: Date
+
+    var migrated: PortalConfiguration {
+        PortalConfiguration(
+            id: id,
+            name: name,
+            localAppPort: localAppPort,
+            createdAt: createdAt,
+            lifecycle: .active
+        )
     }
 }

--- a/Portico/PorticoApp.swift
+++ b/Portico/PorticoApp.swift
@@ -16,15 +16,31 @@ struct PorticoApp: App {
 private struct PortalView: View {
     @ObservedObject var controller: PortalController
     @ObservedObject var supervisor: HelperSupervisor
+    @State private var showingResetConfirmation = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             Label(supervisor.availability.title, systemImage: supervisor.availability.symbolName)
+            if let suffix = controller.tailnetDisplaySuffix {
+                LabeledContent("Tailnet", value: suffix)
+            }
             Divider()
-            if let portal = controller.portal {
+            ForEach(controller.pendingPortals, id: \.id) { portal in
+                pendingWarning(portal)
+            }
+            ForEach(controller.alerts) { alert in
+                completedWarning(alert)
+            }
+            ForEach(controller.portals, id: \.id) { portal in
                 portalStatus(portal)
-            } else {
-                addPortalForm
+                Divider()
+            }
+            addPortalForm
+            if controller.canResetTailnet {
+                Divider()
+                Button("Reset Tailnet", role: .destructive) {
+                    showingResetConfirmation = true
+                }
             }
             if let message = controller.message {
                 Text(message)
@@ -33,7 +49,17 @@ private struct PortalView: View {
             }
         }
         .padding()
-        .frame(width: 320)
+        .frame(width: 380)
+        .confirmationDialog(
+            "Reset this installation's tailnet binding? This does not remove any remote Tailscale node.",
+            isPresented: $showingResetConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Reset Tailnet", role: .destructive) {
+                controller.resetTailnet(confirmed: true)
+            }
+            Button("Cancel", role: .cancel) {}
+        }
         Divider()
         Button("Quit Portico") {
             NSApp.terminate(nil)
@@ -83,7 +109,10 @@ private struct PortalView: View {
     private func portalStatus(_ portal: PortalConfiguration) -> some View {
         Text(portal.name).font(.headline)
         LabeledContent("Local App Port", value: String(portal.localAppPort))
-        if let status = controller.status {
+        if portal.lifecycle == .pendingTailnetRejection {
+            Text("Cleanup pending")
+                .foregroundStyle(.secondary)
+        } else if let status = controller.statuses[portal.id] {
             LabeledContent("Tailscale", value: status.state.title)
             if let assignedName = status.assignedName {
                 LabeledContent("Assigned Name", value: assignedName)
@@ -95,12 +124,36 @@ private struct PortalView: View {
                 LabeledContent("Addresses", value: status.addresses.joined(separator: ", "))
             }
             if status.state == .authenticating {
-                Button("Authenticate") { controller.authenticate() }
+                Button("Authenticate") { controller.authenticate(id: portal.id) }
                     .buttonStyle(.borderedProminent)
             }
         } else {
             Text("Waiting for Portal status…")
                 .foregroundStyle(.secondary)
+        }
+    }
+
+    private func pendingWarning(_ portal: PortalConfiguration) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Label("Cleanup in progress", systemImage: "exclamationmark.triangle.fill")
+                .font(.headline)
+            Text(controller.pendingWarningText(for: portal))
+                .font(.caption)
+            Link("How to remove a Tailscale device", destination: PortalController.manualRemovalURL)
+                .font(.caption)
+        }
+    }
+
+    private func completedWarning(_ alert: InstallationAlert) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Label("Portal removed from this Mac", systemImage: "exclamationmark.triangle.fill")
+                .font(.headline)
+            Text(controller.completedWarningText(for: alert))
+                .font(.caption)
+            Link("How to remove a Tailscale device", destination: PortalController.manualRemovalURL)
+                .font(.caption)
+            Button("Dismiss") { controller.dismissAlert(id: alert.id) }
+                .controlSize(.small)
         }
     }
 }

--- a/PorticoTests/HelperProtocolTests.swift
+++ b/PorticoTests/HelperProtocolTests.swift
@@ -34,11 +34,17 @@ final class HelperProtocolTests: XCTestCase {
             #"{"version":1,"requestId":"auth-1","command":"authenticatePortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A"}}"#,
             as: HelperRequest<AuthenticatePortalPayload>.self
         )
-        let statusFixture = #"{"version":1,"event":"portalStatus","portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","payload":{"state":"online","stableNodeId":"node-1","assignedName":"hermes-1","portalURL":"https:\/\/hermes-1.example.ts.net\/","addresses":["100.64.0.1","fd7a:115c:a1e0::1"]}}"#
+        try assertRoundTrip(
+            #"{"version":1,"requestId":"cleanup-1","command":"cleanupRejectedPortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A"}}"#,
+            as: HelperRequest<CleanupRejectedPortalPayload>.self
+        )
+        let statusFixture = #"{"version":1,"event":"portalStatus","portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","payload":{"state":"online","stableNodeId":"node-1","assignedName":"hermes-1","portalURL":"https:\/\/hermes-1.example.ts.net\/","addresses":["100.64.0.1","fd7a:115c:a1e0::1"],"tailnetName":"opaque-identity-do-not-display","magicDNSSuffix":"example.ts.net"}}"#
         let status = try JSONDecoder().decode(HelperEvent<PortalStatusPayload>.self, from: Data(statusFixture.utf8))
         XCTAssertEqual(status.portalId, portalID)
         XCTAssertEqual(status.payload.state, .online)
         XCTAssertEqual(status.payload.portalURL, URL(string: "https://hermes-1.example.ts.net/"))
+        XCTAssertEqual(status.payload.tailnetName, "opaque-identity-do-not-display")
+        XCTAssertEqual(status.payload.magicDNSSuffix, "example.ts.net")
         try assertRoundTrip(statusFixture, as: HelperEvent<PortalStatusPayload>.self)
 
         let authenticationFixture = #"{"version":1,"event":"authenticationURL","portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","payload":{"url":"https:\/\/login.tailscale.com\/a\/secret"}}"#

--- a/PorticoTests/HelperSupervisorTests.swift
+++ b/PorticoTests/HelperSupervisorTests.swift
@@ -129,6 +129,31 @@ final class HelperSupervisorTests: XCTestCase {
         )
     }
 
+    func testRequestsAndCorrelatesRejectedPortalCleanup() throws {
+        let launcher = FakeHelperLauncher()
+        var requestIDs = ["handshake-1", "cleanup-1"]
+        let supervisor = HelperSupervisor(
+            helperURL: URL(fileURLWithPath: "/unused/portico-helper"),
+            launcher: launcher,
+            requestIDProvider: { requestIDs.removeFirst() },
+            handshakeTimeout: 1
+        )
+        supervisor.start()
+        launcher.receive(line: #"{"version":1,"requestId":"handshake-1","result":{"protocolVersion":1}}"#)
+        let portalID = UUID(uuidString: "9f55ca93-d7b3-4eab-a871-310ea576005a")!
+        var result: Result<Void, Error>?
+
+        supervisor.cleanupRejectedPortal(id: portalID) { result = $0 }
+
+        let requestData = try XCTUnwrap(launcher.process.sent.last)
+        let request = try JSONDecoder().decode(HelperRequest<CleanupRejectedPortalPayload>.self, from: requestData)
+        XCTAssertEqual(request.command, .cleanupRejectedPortal)
+        XCTAssertEqual(request.payload.portalId, portalID)
+        XCTAssertNil(result)
+        launcher.receive(line: #"{"version":1,"requestId":"cleanup-1","result":{"accepted":true}}"#)
+        XCTAssertNoThrow(try result?.get())
+    }
+
     func testReturnsFixedHelperDiscoveryFailure() throws {
         let launcher = FakeHelperLauncher()
         var requestIDs = ["handshake-1", "discover-1"]

--- a/PorticoTests/PortalControllerTests.swift
+++ b/PorticoTests/PortalControllerTests.swift
@@ -151,7 +151,7 @@ final class PortalControllerTests: XCTestCase {
 
         client.connect()
         XCTAssertEqual(client.started, [saved])
-        XCTAssertTrue(client.discoveryCompletions.isEmpty)
+        XCTAssertEqual(client.discoveryCompletions.count, 1)
     }
 
     func testPresentsOnlyMatchingStructuredStatus() throws {
@@ -197,6 +197,252 @@ final class PortalControllerTests: XCTestCase {
         XCTAssertEqual(opened, [transient])
     }
 
+    func testAddsAndStartsSecondPortalWhileFirstRemainsEnabled() throws {
+        let firstID = portalID
+        let secondID = UUID(uuidString: "5ea74329-3144-4ba2-925f-138d14d61fcc")!
+        let first = PortalConfiguration(id: firstID, name: "hermes", localAppPort: 8787, createdAt: Date())
+        let store = PortalStore(rootURL: temporaryRoot())
+        try store.save(InstallationRecord(portals: [first]))
+        let client = FakePortalHelperClient()
+        let controller = PortalController(
+            store: store,
+            helper: client,
+            uuidProvider: { secondID },
+            dateProvider: { Date(timeIntervalSince1970: 1_786_000_100) },
+            openURL: { _ in }
+        )
+
+        controller.portalName = "atlas"
+        controller.localAppPort = "8788"
+        controller.addPortal()
+
+        XCTAssertEqual(controller.portals.map(\.id), [firstID, secondID])
+        XCTAssertEqual(client.started.map(\.id), [firstID, secondID])
+        XCTAssertEqual(try store.loadInstallation().portals.map(\.id), [firstID, secondID])
+    }
+
+    func testFirstSuccessfulOnlineSaveWinsAndExactMatchRefreshesSuffix() throws {
+        let secondID = UUID(uuidString: "5ea74329-3144-4ba2-925f-138d14d61fcc")!
+        let root = temporaryRoot()
+        let seed = PortalStore(rootURL: root)
+        try seed.save(InstallationRecord(portals: [
+            PortalConfiguration(id: portalID, name: "hermes", localAppPort: 8787, createdAt: Date()),
+            PortalConfiguration(id: secondID, name: "atlas", localAppPort: 8788, createdAt: Date()),
+        ]))
+        var failNextWrite = true
+        let store = PortalStore(rootURL: root, writeData: { data, url in
+            if failNextWrite {
+                failNextWrite = false
+                throw NSError(domain: "expected", code: 1)
+            }
+            try data.write(to: url, options: .atomic)
+        })
+        let client = FakePortalHelperClient()
+        let controller = PortalController(store: store, helper: client, openURL: { _ in })
+
+        client.send(.status(portalID, onlineStatus(tailnetName: "opaque-first", suffix: "first.ts.net")))
+        XCTAssertNil(try store.loadInstallation().tailnetBinding)
+        client.send(.status(secondID, onlineStatus(tailnetName: "opaque-winner", suffix: "winner.ts.net")))
+        XCTAssertEqual(
+            try store.loadInstallation().tailnetBinding,
+            TailnetBinding(name: "opaque-winner", magicDNSSuffix: "winner.ts.net")
+        )
+        XCTAssertNil(controller.statuses[secondID]?.tailnetName)
+        client.send(.status(portalID, onlineStatus(tailnetName: "opaque-winner", suffix: "refreshed.ts.net")))
+        XCTAssertEqual(controller.tailnetDisplaySuffix, "refreshed.ts.net")
+        XCTAssertEqual(try store.loadInstallation().tailnetBinding?.magicDNSSuffix, "refreshed.ts.net")
+        XCTAssertFalse(controller.message?.contains("opaque") ?? false)
+    }
+
+    func testEmptyTailnetNameDoesNotBindInstallation() throws {
+        let store = PortalStore(rootURL: temporaryRoot())
+        try store.save(InstallationRecord(portals: [
+            PortalConfiguration(id: portalID, name: "hermes", localAppPort: 8787, createdAt: Date())
+        ]))
+        let client = FakePortalHelperClient()
+        let controller = PortalController(store: store, helper: client, openURL: { _ in })
+
+        client.send(.status(portalID, onlineStatus(tailnetName: "", suffix: "example.ts.net")))
+
+        XCTAssertNil(try store.loadInstallation().tailnetBinding)
+        XCTAssertNil(controller.statuses[portalID]?.tailnetName)
+    }
+
+    func testDifferentTailnetNameWithSameSuffixRejectsOnlyAddressedPortal() throws {
+        let secondID = UUID(uuidString: "5ea74329-3144-4ba2-925f-138d14d61fcc")!
+        let first = PortalConfiguration(id: portalID, name: "hermes", localAppPort: 8787, createdAt: Date())
+        let second = PortalConfiguration(id: secondID, name: "atlas", localAppPort: 8788, createdAt: Date())
+        let store = PortalStore(rootURL: temporaryRoot())
+        try store.save(InstallationRecord(
+            tailnetBinding: TailnetBinding(name: "opaque-expected", magicDNSSuffix: "shared.ts.net"),
+            portals: [first, second]
+        ))
+        let client = FakePortalHelperClient()
+        client.completeCleanupImmediately = false
+        let controller = PortalController(store: store, helper: client, openURL: { _ in })
+
+        client.send(.status(portalID, onlineStatus(
+            tailnetName: "opaque-different",
+            suffix: "shared.ts.net"
+        )))
+        client.send(.status(secondID, onlineStatus(
+            tailnetName: "opaque-expected",
+            suffix: "shared.ts.net",
+            assignedName: "atlas-1"
+        )))
+        client.completeCleanup(.failure(NSError(domain: "expected", code: 1)))
+
+        XCTAssertEqual(client.cleaned, [portalID])
+        XCTAssertEqual(controller.pendingPortals.map(\.id), [portalID])
+        XCTAssertEqual(controller.portals.first(where: { $0.id == secondID })?.lifecycle, .active)
+        XCTAssertEqual(controller.statuses[secondID]?.state, .online)
+        XCTAssertEqual(client.started.map(\.id), [portalID, secondID])
+    }
+
+    func testCompletedCleanupPersistenceFailureKeepsPendingAndUnrelatedPortalEnabled() throws {
+        struct ExpectedFailure: Error {}
+        let secondID = UUID(uuidString: "5ea74329-3144-4ba2-925f-138d14d61fcc")!
+        let root = temporaryRoot()
+        let seed = PortalStore(rootURL: root)
+        try seed.save(InstallationRecord(
+            tailnetBinding: TailnetBinding(name: "opaque-expected", magicDNSSuffix: "expected.ts.net"),
+            portals: [
+                PortalConfiguration(id: portalID, name: "hermes", localAppPort: 8787, createdAt: Date()),
+                PortalConfiguration(id: secondID, name: "atlas", localAppPort: 8788, createdAt: Date()),
+            ]
+        ))
+        var writeCount = 0
+        let store = PortalStore(rootURL: root, writeData: { data, url in
+            writeCount += 1
+            if writeCount == 2 { throw ExpectedFailure() }
+            try data.write(to: url, options: .atomic)
+        })
+        let client = FakePortalHelperClient()
+        let controller = PortalController(store: store, helper: client, openURL: { _ in })
+
+        client.send(.status(portalID, onlineStatus(
+            tailnetName: "opaque-different",
+            suffix: "rejected.ts.net"
+        )))
+
+        let persisted = try store.loadInstallation()
+        XCTAssertEqual(persisted.portals.first(where: { $0.id == portalID })?.lifecycle, .pendingTailnetRejection)
+        XCTAssertEqual(persisted.portals.first(where: { $0.id == secondID })?.lifecycle, .active)
+        XCTAssertEqual(controller.pendingPortals.map(\.id), [portalID])
+        XCTAssertEqual(controller.portals.first(where: { $0.id == secondID })?.lifecycle, .active)
+        XCTAssertEqual(client.started.map(\.id), [portalID, secondID])
+    }
+
+    func testMismatchPersistsTombstoneBeforeCleanupAndRelaunchNeverRestartsIt() throws {
+        let store = PortalStore(rootURL: temporaryRoot())
+        let saved = PortalConfiguration(id: portalID, name: "hermes", localAppPort: 8787, createdAt: Date())
+        try store.save(InstallationRecord(
+            tailnetBinding: TailnetBinding(name: "opaque-expected", magicDNSSuffix: "expected.ts.net"),
+            portals: [saved]
+        ))
+        let client = FakePortalHelperClient()
+        client.completeCleanupImmediately = false
+        client.onCleanup = { id in
+            XCTAssertEqual(id, self.portalID)
+            XCTAssertEqual(try? store.loadInstallation().portals.first?.lifecycle, .pendingTailnetRejection)
+        }
+        let controller = PortalController(store: store, helper: client, openURL: { _ in })
+
+        client.send(.status(portalID, onlineStatus(
+            tailnetName: "opaque-rejected",
+            suffix: "rejected.ts.net",
+            assignedName: "hermes-rejected"
+        )))
+
+        XCTAssertEqual(controller.pendingPortals.map(\.id), [portalID])
+        XCTAssertEqual(client.cleaned, [portalID])
+        XCTAssertFalse(controller.pendingWarningText(for: controller.pendingPortals[0]).contains("opaque"))
+
+        let relaunchedClient = FakePortalHelperClient()
+        relaunchedClient.completeCleanupImmediately = false
+        _ = PortalController(store: store, helper: relaunchedClient, openURL: { _ in })
+        XCTAssertTrue(relaunchedClient.started.isEmpty)
+        XCTAssertEqual(relaunchedClient.cleaned, [portalID])
+    }
+
+    func testCompletedCleanupRemovesPortalPersistsSafeAlertAndCanBeDismissed() throws {
+        let store = PortalStore(rootURL: temporaryRoot())
+        let saved = PortalConfiguration(id: portalID, name: "hermes", localAppPort: 8787, createdAt: Date())
+        try store.save(InstallationRecord(
+            tailnetBinding: TailnetBinding(name: "opaque-expected", magicDNSSuffix: "expected.ts.net"),
+            portals: [saved]
+        ))
+        let alertID = UUID(uuidString: "1f93e456-69ec-445a-8374-d7fc5558d0c7")!
+        let client = FakePortalHelperClient()
+        client.completeCleanupImmediately = false
+        let controller = PortalController(
+            store: store,
+            helper: client,
+            uuidProvider: { alertID },
+            dateProvider: { Date(timeIntervalSince1970: 1_786_000_100) },
+            openURL: { _ in }
+        )
+        client.send(.status(portalID, onlineStatus(
+            tailnetName: "opaque-rejected",
+            suffix: "rejected.ts.net",
+            assignedName: "hermes-rejected"
+        )))
+
+        client.completeCleanup(.success(()))
+
+        XCTAssertTrue(controller.portals.isEmpty)
+        let alert = try XCTUnwrap(controller.alerts.first)
+        XCTAssertEqual(alert.id, alertID)
+        XCTAssertEqual(alert.assignedName, "hermes-rejected")
+        XCTAssertEqual(alert.expectedMagicDNSSuffix, "expected.ts.net")
+        XCTAssertEqual(alert.rejectedMagicDNSSuffix, "rejected.ts.net")
+        XCTAssertFalse(controller.completedWarningText(for: alert).contains("opaque"))
+        XCTAssertEqual(PortalController.manualRemovalURL.host, "tailscale.com")
+
+        controller.dismissAlert(id: alertID)
+        XCTAssertTrue(controller.alerts.isEmpty)
+        XCTAssertEqual(try store.loadInstallation().tailnetBinding?.name, "opaque-expected")
+    }
+
+    func testResetRequiresEmptyInstallationAndExplicitConfirmation() throws {
+        let root = temporaryRoot()
+        let store = PortalStore(rootURL: root)
+        let saved = PortalConfiguration(id: portalID, name: "hermes", localAppPort: 8787, createdAt: Date())
+        try store.save(InstallationRecord(
+            tailnetBinding: TailnetBinding(name: "opaque-expected", magicDNSSuffix: "expected.ts.net"),
+            portals: [saved]
+        ))
+        var controller = PortalController(store: store, helper: FakePortalHelperClient(), openURL: { _ in })
+        controller.resetTailnet(confirmed: true)
+        XCTAssertEqual(try store.loadInstallation().tailnetBinding?.name, "opaque-expected")
+
+        try store.save(InstallationRecord(
+            tailnetBinding: TailnetBinding(name: "opaque-expected", magicDNSSuffix: "expected.ts.net")
+        ))
+        controller = PortalController(store: store, helper: FakePortalHelperClient(), openURL: { _ in })
+        XCTAssertTrue(controller.canResetTailnet)
+        controller.resetTailnet(confirmed: false)
+        XCTAssertNotNil(try store.loadInstallation().tailnetBinding)
+        controller.resetTailnet(confirmed: true)
+        XCTAssertNil(try store.loadInstallation().tailnetBinding)
+    }
+
+    private func onlineStatus(
+        tailnetName: String,
+        suffix: String,
+        assignedName: String = "hermes-1"
+    ) -> PortalStatusPayload {
+        PortalStatusPayload(
+            state: .online,
+            stableNodeId: "node-1",
+            assignedName: assignedName,
+            portalURL: URL(string: "https://\(assignedName).\(suffix)/"),
+            addresses: ["100.64.0.1"],
+            tailnetName: tailnetName,
+            magicDNSSuffix: suffix
+        )
+    }
+
     private func temporaryRoot() -> URL {
         FileManager.default.temporaryDirectory.appendingPathComponent("PorticoControllerTests-\(UUID().uuidString)", isDirectory: true)
     }
@@ -209,7 +455,11 @@ final class FakePortalHelperClient: PortalHelperClient {
     var onEvent: ((PortalHelperEvent) -> Void)?
     private(set) var started: [PortalConfiguration] = []
     private(set) var authenticated: [UUID] = []
+    private(set) var cleaned: [UUID] = []
     private(set) var discoveryCompletions: [(Result<[LocalAppCandidatePayload], Error>) -> Void] = []
+    private(set) var cleanupCompletions: [(Result<Void, Error>) -> Void] = []
+    var completeCleanupImmediately = true
+    var onCleanup: ((UUID) -> Void)?
 
     init(availability: HelperAvailability = .connected) {
         self.availability = availability
@@ -225,6 +475,16 @@ final class FakePortalHelperClient: PortalHelperClient {
         completion(.success(()))
     }
 
+    func cleanupRejectedPortal(id: UUID, completion: @escaping (Result<Void, Error>) -> Void) {
+        cleaned.append(id)
+        onCleanup?(id)
+        if completeCleanupImmediately {
+            completion(.success(()))
+        } else {
+            cleanupCompletions.append(completion)
+        }
+    }
+
     func discoverLocalApps(completion: @escaping (Result<[LocalAppCandidatePayload], Error>) -> Void) {
         discoveryCompletions.append(completion)
     }
@@ -238,5 +498,9 @@ final class FakePortalHelperClient: PortalHelperClient {
 
     func completeDiscovery(_ result: Result<[LocalAppCandidatePayload], Error>, at index: Int = 0) {
         discoveryCompletions[index](result)
+    }
+
+    func completeCleanup(_ result: Result<Void, Error>, at index: Int = 0) {
+        cleanupCompletions[index](result)
     }
 }

--- a/PorticoTests/PortalStoreTests.swift
+++ b/PorticoTests/PortalStoreTests.swift
@@ -3,6 +3,83 @@ import XCTest
 @testable import Portico
 
 final class PortalStoreTests: XCTestCase {
+    func testMigratesValidVersionOnePortalIntoUnboundVersionTwoInstallation() throws {
+        let root = temporaryRoot()
+        let store = PortalStore(rootURL: root)
+        let legacyURL = root.appendingPathComponent("portal-v1.json", isDirectory: false)
+        let installationURL = root.appendingPathComponent("installation-v2.json", isDirectory: false)
+        let portal = PortalConfiguration(
+            id: UUID(uuidString: "9f55ca93-d7b3-4eab-a871-310ea576005a")!,
+            name: "hermes",
+            localAppPort: 8787,
+            createdAt: Date(timeIntervalSince1970: 1_786_000_000)
+        )
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try historicalVersionOneData().write(to: legacyURL)
+
+        _ = try store.load()
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: installationURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyURL.path))
+        XCTAssertEqual(try permissions(of: root), 0o700)
+        XCTAssertEqual(try permissions(of: installationURL), 0o600)
+        XCTAssertEqual(try store.loadInstallation(), InstallationRecord(portals: [portal]))
+    }
+
+    func testFailedVersionTwoWritePreservesVersionOneSource() throws {
+        struct ExpectedFailure: Error {}
+        let root = temporaryRoot()
+        let legacyURL = root.appendingPathComponent("portal-v1.json", isDirectory: false)
+        let store = PortalStore(rootURL: root, writeData: { _, _ in throw ExpectedFailure() })
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let source = historicalVersionOneData()
+        try source.write(to: legacyURL)
+
+        XCTAssertThrowsError(try store.loadInstallation())
+        XCTAssertEqual(try Data(contentsOf: legacyURL), source)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.installationURL.path))
+    }
+
+    func testValidVersionTwoIsAuthoritativeAndRemovesStaleVersionOne() throws {
+        let root = temporaryRoot()
+        let store = PortalStore(rootURL: root)
+        let authoritative = InstallationRecord(
+            tailnetBinding: TailnetBinding(name: "opaque-tailnet-id", magicDNSSuffix: "example.ts.net"),
+            portals: [makePortal(name: "authoritative")]
+        )
+        try store.save(authoritative)
+        try historicalVersionOneData(name: "stale").write(to: store.legacyConfigurationURL)
+
+        XCTAssertEqual(try store.loadInstallation(), authoritative)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.legacyConfigurationURL.path))
+    }
+
+    func testInstallationRoundTripsPortalLifecycleBindingAndAlert() throws {
+        let store = PortalStore(rootURL: temporaryRoot())
+        var pending = makePortal()
+        pending.lifecycle = .pendingTailnetRejection
+        let alert = InstallationAlert(
+            id: UUID(uuidString: "1f93e456-69ec-445a-8374-d7fc5558d0c7")!,
+            kind: .crossTailnetRejection,
+            portalName: "hermes",
+            assignedName: "hermes-1",
+            expectedMagicDNSSuffix: "one.ts.net",
+            rejectedMagicDNSSuffix: "two.ts.net",
+            createdAt: Date(timeIntervalSince1970: 1_786_000_100)
+        )
+        let installation = InstallationRecord(
+            tailnetBinding: TailnetBinding(name: "opaque-tailnet-id", magicDNSSuffix: "one.ts.net"),
+            portals: [pending],
+            alerts: [alert]
+        )
+
+        try store.save(installation)
+
+        XCTAssertEqual(try store.loadInstallation(), installation)
+        XCTAssertEqual(try permissions(of: store.rootURL), 0o700)
+        XCTAssertEqual(try permissions(of: store.installationURL), 0o600)
+    }
+
     func testSavedPortalReloadsWithSameImmutableDefinition() throws {
         let root = temporaryRoot()
         let store = PortalStore(rootURL: root)
@@ -17,8 +94,31 @@ final class PortalStoreTests: XCTestCase {
 
         XCTAssertEqual(try store.load(), portal)
         XCTAssertEqual(try permissions(of: root), 0o700)
-        XCTAssertEqual(try permissions(of: store.configurationURL), 0o600)
+        XCTAssertEqual(try permissions(of: store.installationURL), 0o600)
         XCTAssertThrowsError(try store.save(portal))
+    }
+
+    func testSavingFirstPortalPreservesInstallationBindingAndAlerts() throws {
+        let store = PortalStore(rootURL: temporaryRoot())
+        let alert = InstallationAlert(
+            id: UUID(uuidString: "1f93e456-69ec-445a-8374-d7fc5558d0c7")!,
+            kind: .crossTailnetRejection,
+            portalName: "atlas",
+            assignedName: nil,
+            expectedMagicDNSSuffix: "one.ts.net",
+            rejectedMagicDNSSuffix: nil,
+            createdAt: Date(timeIntervalSince1970: 1_786_000_100)
+        )
+        let binding = TailnetBinding(name: "opaque-tailnet-id", magicDNSSuffix: "one.ts.net")
+        try store.save(InstallationRecord(tailnetBinding: binding, alerts: [alert]))
+
+        let portal = makePortal()
+        try store.save(portal)
+
+        XCTAssertEqual(
+            try store.loadInstallation(),
+            InstallationRecord(tailnetBinding: binding, portals: [portal], alerts: [alert])
+        )
     }
 
     func testMissingConfigurationLoadsAsNil() throws {
@@ -48,6 +148,21 @@ final class PortalStoreTests: XCTestCase {
     private func temporaryRoot() -> URL {
         FileManager.default.temporaryDirectory
             .appendingPathComponent("PorticoTests-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    private func makePortal(name: String = "hermes") -> PortalConfiguration {
+        PortalConfiguration(
+            id: UUID(uuidString: "9f55ca93-d7b3-4eab-a871-310ea576005a")!,
+            name: name,
+            localAppPort: 8787,
+            createdAt: Date(timeIntervalSince1970: 1_786_000_000)
+        )
+    }
+
+    private func historicalVersionOneData(name: String = "hermes") -> Data {
+        Data(
+            #"{"version":1,"portal":{"id":"9F55CA93-D7B3-4EAB-A871-310EA576005A","name":"\#(name)","localAppPort":8787,"createdAt":807692800}}"#.utf8
+        )
     }
 
     private func permissions(of url: URL) throws -> Int {

--- a/helper/internal/portal/runtime.go
+++ b/helper/internal/portal/runtime.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -45,11 +46,13 @@ func (c Config) normalized() Config {
 }
 
 type Status struct {
-	BackendState string
-	StableNodeID string
-	DNSName      string
-	CertDomains  []string
-	Addresses    []string
+	BackendState   string
+	StableNodeID   string
+	DNSName        string
+	CertDomains    []string
+	Addresses      []string
+	TailnetName    string
+	MagicDNSSuffix string
 }
 
 type Notification struct {
@@ -73,11 +76,13 @@ type Node interface {
 type NodeFactory func(dir, hostname string) Node
 
 type StatusEvent struct {
-	State        State    `json:"state"`
-	StableNodeID string   `json:"stableNodeId,omitempty"`
-	AssignedName string   `json:"assignedName,omitempty"`
-	PortalURL    string   `json:"portalURL,omitempty"`
-	Addresses    []string `json:"addresses"`
+	State          State    `json:"state"`
+	StableNodeID   string   `json:"stableNodeId,omitempty"`
+	AssignedName   string   `json:"assignedName,omitempty"`
+	PortalURL      string   `json:"portalURL,omitempty"`
+	Addresses      []string `json:"addresses"`
+	TailnetName    string   `json:"tailnetName,omitempty"`
+	MagicDNSSuffix string   `json:"magicDNSSuffix,omitempty"`
 }
 
 type Event struct {
@@ -87,9 +92,14 @@ type Event struct {
 }
 
 type Runtime struct {
+	mu        sync.Mutex
+	stateRoot string
+	factory   NodeFactory
+	portals   map[string]*portalRuntime
+}
+
+type portalRuntime struct {
 	mu                    sync.Mutex
-	stateRoot             string
-	factory               NodeFactory
 	config                *Config
 	node                  Node
 	watcher               Watcher
@@ -102,7 +112,7 @@ type Runtime struct {
 }
 
 func NewRuntime(stateRoot string, factory NodeFactory) *Runtime {
-	return &Runtime{stateRoot: stateRoot, factory: factory}
+	return &Runtime{stateRoot: stateRoot, factory: factory, portals: make(map[string]*portalRuntime)}
 }
 
 func (r *Runtime) Start(ctx context.Context, config Config, emit func(Event)) error {
@@ -112,10 +122,93 @@ func (r *Runtime) Start(ctx context.Context, config Config, emit func(Event)) er
 		return err
 	}
 	config = config.normalized()
-	if r.node != nil {
-		return errors.New("a portal is already running")
+	if _, exists := r.portals[config.ID]; exists {
+		return errors.New("portal is already running")
 	}
 	node := r.factory(filepath.Join(r.stateRoot, config.ID), config.Name)
+	portal := &portalRuntime{}
+	if err := portal.start(ctx, config, node, emit); err != nil {
+		return err
+	}
+	r.portals[config.ID] = portal
+	return nil
+}
+
+func (r *Runtime) Authenticate(ctx context.Context, portalID string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	portalID, err := normalizePortalID(portalID)
+	if err != nil {
+		return errors.New("portal is not running")
+	}
+	portal := r.portals[portalID]
+	if portal == nil {
+		return errors.New("portal is not running")
+	}
+	return portal.authenticate(ctx)
+}
+
+func (r *Runtime) CleanupRejectedPortal(portalID string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	portalID, err := normalizePortalID(portalID)
+	if err != nil {
+		return errors.New("invalid portal ID")
+	}
+	stateDirectory, err := validatedStateDirectory(r.stateRoot, portalID)
+	if err != nil {
+		return err
+	}
+	if portal := r.portals[portalID]; portal != nil {
+		if err := portal.close(); err != nil {
+			return err
+		}
+	}
+	if err := os.RemoveAll(stateDirectory); err != nil {
+		return errors.New("remove portal state")
+	}
+	delete(r.portals, portalID)
+	return nil
+}
+
+func (r *Runtime) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var errs []error
+	for portalID, portal := range r.portals {
+		errs = append(errs, portal.close())
+		delete(r.portals, portalID)
+	}
+	return errors.Join(errs...)
+}
+
+func normalizePortalID(portalID string) (string, error) {
+	portalID = strings.ToLower(portalID)
+	if !uuidPattern.MatchString(portalID) {
+		return "", errors.New("invalid portal ID")
+	}
+	return portalID, nil
+}
+
+func validatedStateDirectory(stateRoot, portalID string) (string, error) {
+	portalID, err := normalizePortalID(portalID)
+	if err != nil {
+		return "", err
+	}
+	root, err := filepath.Abs(filepath.Clean(stateRoot))
+	if err != nil {
+		return "", errors.New("resolve state root")
+	}
+	target := filepath.Join(root, portalID)
+	if filepath.Dir(target) != root || filepath.Base(target) != portalID {
+		return "", errors.New("invalid portal state directory")
+	}
+	return target, nil
+}
+
+func (r *portalRuntime) start(ctx context.Context, config Config, node Node, emit func(Event)) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	if err := node.Start(); err != nil {
 		_ = node.Close()
 		return errors.New("start portal")
@@ -142,10 +235,10 @@ func (r *Runtime) Start(ctx context.Context, config Config, emit func(Event)) er
 	return nil
 }
 
-func (r *Runtime) Authenticate(ctx context.Context, portalID string) error {
+func (r *portalRuntime) authenticate(ctx context.Context) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if r.node == nil || r.config == nil || !strings.EqualFold(r.config.ID, portalID) {
+	if r.node == nil || r.config == nil {
 		return errors.New("portal is not running")
 	}
 	if err := r.node.StartLoginInteractive(ctx); err != nil {
@@ -155,7 +248,7 @@ func (r *Runtime) Authenticate(ctx context.Context, portalID string) error {
 	return nil
 }
 
-func (r *Runtime) Close() error {
+func (r *portalRuntime) close() error {
 	r.mu.Lock()
 	err := r.closeLocked()
 	r.mu.Unlock()
@@ -163,7 +256,7 @@ func (r *Runtime) Close() error {
 	return err
 }
 
-func (r *Runtime) closeLocked() error {
+func (r *portalRuntime) closeLocked() error {
 	var proxyErr error
 	if r.cancel != nil {
 		r.cancel()
@@ -189,7 +282,7 @@ func (r *Runtime) closeLocked() error {
 	return errors.Join(proxyErr, nodeErr)
 }
 
-func (r *Runtime) watch(ctx context.Context, watcher Watcher) {
+func (r *portalRuntime) watch(ctx context.Context, watcher Watcher) {
 	defer r.watchDone.Done()
 	for {
 		notification, err := watcher.Next()
@@ -206,7 +299,7 @@ func (r *Runtime) watch(ctx context.Context, watcher Watcher) {
 	}
 }
 
-func (r *Runtime) emitStatusLocked(ctx context.Context) error {
+func (r *portalRuntime) emitStatusLocked(ctx context.Context) error {
 	if r.node == nil || r.config == nil || r.emit == nil {
 		return nil
 	}
@@ -226,7 +319,7 @@ func (r *Runtime) emitStatusLocked(ctx context.Context) error {
 	return nil
 }
 
-func (r *Runtime) ensureProxyLocked() error {
+func (r *portalRuntime) ensureProxyLocked() error {
 	if r.proxy != nil {
 		return nil
 	}
@@ -244,9 +337,11 @@ func (r *Runtime) ensureProxyLocked() error {
 
 func mapStatus(status Status) StatusEvent {
 	mapped := StatusEvent{
-		State:        mapBackendState(status.BackendState),
-		StableNodeID: status.StableNodeID,
-		Addresses:    append([]string{}, status.Addresses...),
+		State:          mapBackendState(status.BackendState),
+		StableNodeID:   status.StableNodeID,
+		Addresses:      append([]string{}, status.Addresses...),
+		TailnetName:    status.TailnetName,
+		MagicDNSSuffix: status.MagicDNSSuffix,
 	}
 	dnsName := strings.TrimSuffix(status.DNSName, ".")
 	if dnsName != "" {

--- a/helper/internal/portal/runtime_test.go
+++ b/helper/internal/portal/runtime_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -17,6 +18,155 @@ import (
 )
 
 const testPortalID = "9f55ca93-d7b3-4eab-a871-310ea576005a"
+const secondPortalID = "5ea74329-3144-4ba2-925f-138d14d61fcc"
+
+func TestRuntimeKeepsTwoIndependentPortalsOnline(t *testing.T) {
+	root := t.TempDir()
+	events := make(map[string]StatusEvent)
+	factory := func(dir, hostname string) Node {
+		id := filepath.Base(dir)
+		suffix := "1"
+		address := "100.64.0.1"
+		if id == secondPortalID {
+			suffix = "2"
+			address = "100.64.0.2"
+		}
+		dnsName := hostname + "-" + suffix + ".example.ts.net."
+		return &fakeNode{
+			watcher: newFakeWatcher(),
+			status: Status{
+				BackendState: "Running",
+				StableNodeID: "node-" + suffix,
+				DNSName:      dnsName,
+				CertDomains:  []string{strings.TrimSuffix(dnsName, ".")},
+				Addresses:    []string{address},
+			},
+		}
+	}
+	runtime := NewRuntime(root, factory)
+	emit := func(event Event) {
+		if event.Status != nil {
+			events[event.PortalID] = *event.Status
+		}
+	}
+
+	if err := runtime.Start(context.Background(), Config{ID: testPortalID, Name: "hermes", Port: 8787}, emit); err != nil {
+		t.Fatalf("Start first Portal: %v", err)
+	}
+	if err := runtime.Start(context.Background(), Config{ID: secondPortalID, Name: "atlas", Port: 8788}, emit); err != nil {
+		t.Fatalf("Start second Portal: %v", err)
+	}
+	t.Cleanup(func() { _ = runtime.Close() })
+
+	first, firstOK := events[testPortalID]
+	second, secondOK := events[secondPortalID]
+	if !firstOK || !secondOK || first.State != StateOnline || second.State != StateOnline {
+		t.Fatalf("events = %+v, want both Portals online", events)
+	}
+	if first.StableNodeID == second.StableNodeID || first.AssignedName == second.AssignedName || first.PortalURL == second.PortalURL || first.Addresses[0] == second.Addresses[0] {
+		t.Fatalf("statuses = (%+v, %+v), want independent identities and addresses", first, second)
+	}
+}
+
+func TestCleanupRejectedPortalClosesAndDeletesOnlyAddressedPortal(t *testing.T) {
+	root := t.TempDir()
+	nodes := make(map[string]*fakeNode)
+	runtime := NewRuntime(root, func(dir, _ string) Node {
+		node := &fakeNode{watcher: newFakeWatcher(), status: Status{BackendState: "Starting"}}
+		nodes[filepath.Base(dir)] = node
+		return node
+	})
+	for _, config := range []Config{
+		{ID: testPortalID, Name: "hermes", Port: 8787},
+		{ID: secondPortalID, Name: "atlas", Port: 8788},
+	} {
+		if err := runtime.Start(context.Background(), config, func(Event) {}); err != nil {
+			t.Fatalf("Start(%s): %v", config.ID, err)
+		}
+		if err := os.MkdirAll(filepath.Join(root, config.ID), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Cleanup(func() { _ = runtime.Close() })
+
+	if err := runtime.CleanupRejectedPortal(testPortalID); err != nil {
+		t.Fatalf("CleanupRejectedPortal: %v", err)
+	}
+	if !nodes[testPortalID].closed {
+		t.Fatal("rejected Portal node was not closed")
+	}
+	if _, err := os.Stat(filepath.Join(root, testPortalID)); !os.IsNotExist(err) {
+		t.Fatalf("rejected Portal state still exists: %v", err)
+	}
+	if nodes[secondPortalID].closed {
+		t.Fatal("unrelated Portal node was closed")
+	}
+	if _, err := os.Stat(filepath.Join(root, secondPortalID)); err != nil {
+		t.Fatalf("unrelated Portal state was affected: %v", err)
+	}
+	if err := runtime.Authenticate(context.Background(), secondPortalID); err != nil {
+		t.Fatalf("unrelated Portal is no longer online: %v", err)
+	}
+	if err := runtime.CleanupRejectedPortal(testPortalID); err != nil {
+		t.Fatalf("repeated cleanup should be idempotent: %v", err)
+	}
+}
+
+func TestCleanupRejectedPortalRejectsUntrustedDeletionTargets(t *testing.T) {
+	root := t.TempDir()
+	protected := filepath.Join(root, secondPortalID)
+	if err := os.MkdirAll(protected, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	runtime := NewRuntime(root, func(_, _ string) Node { return &fakeNode{watcher: newFakeWatcher()} })
+
+	for _, portalID := range []string{"../" + secondPortalID, "not-a-uuid", testPortalID + "/child"} {
+		if err := runtime.CleanupRejectedPortal(portalID); err == nil {
+			t.Fatalf("CleanupRejectedPortal(%q) = nil, want error", portalID)
+		}
+	}
+	if _, err := os.Stat(protected); err != nil {
+		t.Fatalf("protected state directory was affected: %v", err)
+	}
+}
+
+func TestCleanupWaitsForStartBeforeDeletingAnyPortalState(t *testing.T) {
+	root := t.TempDir()
+	blocked := &fakeNode{
+		watcher:      newFakeWatcher(),
+		startEntered: make(chan struct{}),
+		releaseStart: make(chan struct{}),
+	}
+	runtime := NewRuntime(root, func(_, _ string) Node { return blocked })
+	protected := filepath.Join(root, secondPortalID)
+	if err := os.MkdirAll(protected, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- runtime.Start(context.Background(), Config{ID: testPortalID, Name: "hermes", Port: 8787}, func(Event) {})
+	}()
+	<-blocked.startEntered
+	cleanupDone := make(chan error, 1)
+	go func() { cleanupDone <- runtime.CleanupRejectedPortal(secondPortalID) }()
+
+	select {
+	case <-cleanupDone:
+		t.Fatal("cleanup completed while another Portal start was in progress")
+	default:
+	}
+	if _, err := os.Stat(protected); err != nil {
+		t.Fatalf("state was deleted during another Portal start: %v", err)
+	}
+	close(blocked.releaseStart)
+	if err := <-startDone; err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := <-cleanupDone; err != nil {
+		t.Fatalf("CleanupRejectedPortal: %v", err)
+	}
+	_ = runtime.Close()
+}
 
 func TestRuntimeUsesUUIDStateDirectoryAndStableIdentity(t *testing.T) {
 	factory := newFakeFactory()
@@ -101,6 +251,18 @@ func TestMapStatusUsesAnEmptyAddressArray(t *testing.T) {
 	mapped := mapStatus(Status{BackendState: "NeedsLogin"})
 	if mapped.Addresses == nil {
 		t.Fatal("Addresses = nil, want an empty JSON array")
+	}
+}
+
+func TestMapStatusKeepsOpaqueTailnetNameSeparateFromDisplaySuffix(t *testing.T) {
+	mapped := mapStatus(Status{
+		BackendState:   "Running",
+		TailnetName:    "opaque-identity-do-not-display",
+		MagicDNSSuffix: "safe.example.ts.net",
+	})
+
+	if mapped.TailnetName != "opaque-identity-do-not-display" || mapped.MagicDNSSuffix != "safe.example.ts.net" {
+		t.Fatalf("mapped status = %+v, want exact identity and separate suffix", mapped)
 	}
 }
 
@@ -404,6 +566,7 @@ type fakeNode struct {
 	releaseStart              chan struct{}
 	startReturned             bool
 	closedBeforeStartReturned bool
+	closed                    bool
 	listenNetwork             string
 	listenAddress             string
 	listener                  *fakeListener
@@ -453,6 +616,7 @@ func (n *fakeNode) Close() error {
 		n.observeClose()
 	}
 	n.closedBeforeStartReturned = !n.startReturned
+	n.closed = true
 	if n.listener != nil {
 		n.listenerClosedBeforeNode = n.listener.closed
 	} else if n.realListener != nil {

--- a/helper/internal/portal/tsnet_node.go
+++ b/helper/internal/portal/tsnet_node.go
@@ -58,6 +58,10 @@ func (n *tsnetNode) Status(ctx context.Context) (Status, error) {
 		CertDomains:  append([]string(nil), status.CertDomains...),
 		Addresses:    make([]string, 0, len(status.TailscaleIPs)),
 	}
+	if status.CurrentTailnet != nil {
+		mapped.TailnetName = status.CurrentTailnet.Name
+		mapped.MagicDNSSuffix = status.CurrentTailnet.MagicDNSSuffix
+	}
 	for _, address := range status.TailscaleIPs {
 		mapped.Addresses = append(mapped.Addresses, address.String())
 	}

--- a/helper/internal/protocol/server.go
+++ b/helper/internal/protocol/server.go
@@ -23,6 +23,7 @@ const invalidRequestDiagnostic = "portico-helper: invalid request\n"
 type PortalRuntime interface {
 	Start(context.Context, portal.Config, func(portal.Event)) error
 	Authenticate(context.Context, string) error
+	CleanupRejectedPortal(string) error
 	Close() error
 }
 
@@ -73,6 +74,10 @@ type startPortalPayload struct {
 }
 
 type authenticatePortalPayload struct {
+	PortalID string `json:"portalId"`
+}
+
+type cleanupRejectedPortalPayload struct {
 	PortalID string `json:"portalId"`
 }
 
@@ -260,14 +265,38 @@ func ServeWithServices(input io.Reader, output, diagnostics io.Writer, services 
 				}
 				continue
 			}
-			portalID := strings.ToLower(payload.PortalID)
-			if err := (portal.Config{ID: portalID, Name: "a", Port: 1}).Validate(); err != nil {
+			portalID, valid := validatedPortalID(payload.PortalID)
+			if !valid {
 				if writer.write(errorResponse(request.RequestID, "invalidPayload", "invalid portal request")) != nil {
 					return 1
 				}
 				continue
 			}
 			if err := runtime.Authenticate(ctx, portalID); err != nil {
+				if writer.write(errorResponse(request.RequestID, "runtimeFailure", "portal runtime failed")) != nil {
+					return 1
+				}
+				continue
+			}
+			if writer.write(response{Version: Version, RequestID: request.RequestID, Result: acceptedResult{Accepted: true}}) != nil {
+				return 1
+			}
+		case "cleanupRejectedPortal":
+			var payload cleanupRejectedPortalPayload
+			if runtime == nil || decodePayload(request.Payload, &payload) != nil {
+				if writer.write(errorResponse(request.RequestID, "invalidPayload", "invalid portal request")) != nil {
+					return 1
+				}
+				continue
+			}
+			portalID, valid := validatedPortalID(payload.PortalID)
+			if !valid {
+				if writer.write(errorResponse(request.RequestID, "invalidPayload", "invalid portal request")) != nil {
+					return 1
+				}
+				continue
+			}
+			if err := runtime.CleanupRejectedPortal(portalID); err != nil {
 				if writer.write(errorResponse(request.RequestID, "runtimeFailure", "portal runtime failed")) != nil {
 					return 1
 				}
@@ -297,6 +326,12 @@ func ServeWithServices(input io.Reader, output, diagnostics io.Writer, services 
 	}
 	cancelBeforeExit = false
 	return 0
+}
+
+func validatedPortalID(raw string) (string, bool) {
+	portalID := strings.ToLower(raw)
+	err := (portal.Config{ID: portalID, Name: "a", Port: 1}).Validate()
+	return portalID, err == nil
 }
 
 func canonicalCandidates(candidates []discovery.Candidate) []discovery.Candidate {

--- a/helper/internal/protocol/server_test.go
+++ b/helper/internal/protocol/server_test.go
@@ -172,6 +172,8 @@ func (*shutdownOrderingRuntime) Start(context.Context, portal.Config, func(porta
 
 func (*shutdownOrderingRuntime) Authenticate(context.Context, string) error { return nil }
 
+func (*shutdownOrderingRuntime) CleanupRejectedPortal(string) error { return nil }
+
 func (r *shutdownOrderingRuntime) Close() error {
 	select {
 	case <-r.discoveryCanceled:
@@ -234,6 +236,10 @@ func TestServeStartsPortalAndSerializesStructuredStatusEvent(t *testing.T) {
 	if event["event"] != "portalStatus" || event["portalId"] != "9f55ca93-d7b3-4eab-a871-310ea576005a" {
 		t.Fatalf("event = %+v, want structured portal status", event)
 	}
+	payload := event["payload"].(map[string]any)
+	if payload["tailnetName"] != "opaque-identity-do-not-display" || payload["magicDNSSuffix"] != "example.ts.net" {
+		t.Fatalf("payload = %+v, want exact identity and separate display suffix", payload)
+	}
 	const wantResponse = `{"version":1,"requestId":"start-1","result":{"accepted":true}}`
 	if lines[1] != wantResponse {
 		t.Fatalf("response = %q, want %q", lines[1], wantResponse)
@@ -259,6 +265,25 @@ func TestServeAuthenticatesCorrelatedPortalAndEmitsTransientURL(t *testing.T) {
 	}
 	if !strings.Contains(output.String(), `"requestId":"auth-1","result":{"accepted":true}`) {
 		t.Fatalf("output = %q, want correlated accepted response", output.String())
+	}
+}
+
+func TestServeCleansUpOnlyCorrelatedRejectedPortal(t *testing.T) {
+	runtime := &fakeRuntime{}
+	input := bytes.NewBufferString(
+		`{"version":1,"requestId":"cleanup-1","command":"cleanupRejectedPortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A"}}` + "\n",
+	)
+	var output bytes.Buffer
+	var diagnostics bytes.Buffer
+
+	exitCode := ServeWithRuntime(input, &output, &diagnostics, runtime)
+
+	if exitCode != 0 || diagnostics.Len() != 0 || runtime.cleaned != "9f55ca93-d7b3-4eab-a871-310ea576005a" {
+		t.Fatalf("ServeWithRuntime = (exit %d, cleaned %q, diagnostics %q), want correlated cleanup", exitCode, runtime.cleaned, diagnostics.String())
+	}
+	const want = `{"version":1,"requestId":"cleanup-1","result":{"accepted":true}}` + "\n"
+	if output.String() != want {
+		t.Fatalf("output = %q, want %q", output.String(), want)
 	}
 }
 
@@ -335,6 +360,7 @@ func TestServeAcknowledgesShutdownAfterRuntimeCloseCompletes(t *testing.T) {
 type fakeRuntime struct {
 	started       portal.Config
 	authenticated string
+	cleaned       string
 	closed        bool
 	emit          func(portal.Event)
 	closeEntered  chan struct{}
@@ -345,7 +371,10 @@ type fakeRuntime struct {
 func (r *fakeRuntime) Start(_ context.Context, config portal.Config, emit func(portal.Event)) error {
 	r.started = config
 	r.emit = emit
-	emit(portal.Event{PortalID: config.ID, Status: &portal.StatusEvent{State: portal.StateConnecting, Addresses: []string{}}})
+	emit(portal.Event{PortalID: config.ID, Status: &portal.StatusEvent{
+		State: portal.StateConnecting, Addresses: []string{},
+		TailnetName: "opaque-identity-do-not-display", MagicDNSSuffix: "example.ts.net",
+	}})
 	return nil
 }
 
@@ -354,6 +383,11 @@ func (r *fakeRuntime) Authenticate(_ context.Context, portalID string) error {
 	if r.emit != nil {
 		r.emit(portal.Event{PortalID: r.authenticated, AuthenticationURL: "https://login.tailscale.com/a/transient"})
 	}
+	return nil
+}
+
+func (r *fakeRuntime) CleanupRejectedPortal(portalID string) error {
+	r.cleaned = strings.ToLower(portalID)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- migrate the singleton Portal file into an atomic version-two installation record with collection, tailnet binding, lifecycle, and durable warning state
- run one isolated tsnet runtime per Portal behind a globally serialized helper owner, including UUID-guarded rejection cleanup
- bind the installation to the first exact online tailnet identity, reject mismatches safely, and present multiple Portals with durable cleanup warnings and explicit reset

## Why

Portico previously enforced one running Portal in both the app and helper. This change keeps Portal identity and runtime state independent while preventing one installation from silently spanning multiple tailnets.

## Validation

- `./Scripts/generate-xcode-project.sh`
- `xcodebuild -project Portico.xcodeproj -scheme Portico -destination platform=macOS -derivedDataPath .build/xcode-fresh test` — 43 tests, 0 failures
- `go build -o .build/portico-helper ./cmd/portico-helper`
- `go test ./...` — all helper packages passed
- correctness/spec review, review-and-simplify, and ponytail-review completed on final HEAD

## Residual risk

No live tailnet mutation was run, as allowed by the approved plan. Multi-runtime concurrency, binding, rejection, migration, and recovery are covered with fake nodes and filesystem-backed tests.

Fixes #5