### PR TITLE
Operate and reconcile persistent Portals

### DIFF
--- a/Portico/HelperProtocol.swift
+++ b/Portico/HelperProtocol.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-let helperProtocolVersion = 1
+let helperProtocolVersion = 2
 
 enum HelperCommand: String, Codable {
     case handshake
     case shutdown
-    case startPortal
+    case reconcilePortals
     case authenticatePortal
     case cleanupRejectedPortal
     case discoverLocalApps
@@ -35,14 +35,30 @@ struct ShutdownResult: Codable, Equatable {
     let accepted: Bool
 }
 
-struct StartPortalPayload: Codable, Equatable {
+struct ReconcilePortalPayload: Codable, Equatable {
     let portalId: UUID
     let portalName: String
     let localAppPort: UInt16
+    let desiredState: PortalDesiredState
 }
 
-struct StartPortalResult: Codable, Equatable {
-    let accepted: Bool
+struct ReconcilePortalsPayload: Codable, Equatable {
+    let portals: [ReconcilePortalPayload]
+}
+
+enum ReconcilePortalOutcome: String, Codable, Equatable {
+    case converged
+    case startFailed
+    case closeFailed
+}
+
+struct ReconcilePortalEntry: Codable, Equatable {
+    let portalId: UUID
+    let outcome: ReconcilePortalOutcome
+}
+
+struct ReconcilePortalsResult: Codable, Equatable {
+    let entries: [ReconcilePortalEntry]
 }
 
 struct AuthenticatePortalPayload: Codable, Equatable {

--- a/Portico/HelperSupervisor.swift
+++ b/Portico/HelperSupervisor.swift
@@ -23,7 +23,10 @@ protocol PortalHelperClient: AnyObject {
     var onConnected: (() -> Void)? { get set }
     var onEvent: ((PortalHelperEvent) -> Void)? { get set }
 
-    func startPortal(_ portal: PortalConfiguration, completion: @escaping (Result<Void, Error>) -> Void)
+    func reconcilePortals(
+        _ portals: [PortalConfiguration],
+        completion: @escaping (Result<ReconcilePortalsResult, Error>) -> Void
+    )
     func authenticatePortal(id: UUID, completion: @escaping (Result<Void, Error>) -> Void)
     func cleanupRejectedPortal(id: UUID, completion: @escaping (Result<Void, Error>) -> Void)
     func discoverLocalApps(completion: @escaping (Result<[LocalAppCandidatePayload], Error>) -> Void)
@@ -114,16 +117,28 @@ final class HelperSupervisor: ObservableObject, PortalHelperClient {
         }
     }
 
-    func startPortal(_ portal: PortalConfiguration, completion: @escaping (Result<Void, Error>) -> Void) {
+    func reconcilePortals(
+        _ portals: [PortalConfiguration],
+        completion: @escaping (Result<ReconcilePortalsResult, Error>) -> Void
+    ) {
         guard availability == .connected else {
             completion(.failure(HelperClientError.unavailable))
             return
         }
-        let payload = StartPortalPayload(portalId: portal.id, portalName: portal.name, localAppPort: portal.localAppPort)
+        let payload = ReconcilePortalsPayload(
+            portals: portals
+                .sorted { $0.id.uuidString.lowercased() < $1.id.uuidString.lowercased() }
+                .map {
+                    ReconcilePortalPayload(
+                        portalId: $0.id,
+                        portalName: $0.name,
+                        localAppPort: $0.localAppPort,
+                        desiredState: $0.desiredState
+                    )
+                }
+        )
         do {
-            try sendRequest(command: .startPortal, payload: payload) { (result: Result<StartPortalResult, Error>) in
-                completion(result.map { _ in () })
-            }
+            try sendRequest(command: .reconcilePortals, payload: payload, completion: completion)
         } catch {
             completion(.failure(error))
         }

--- a/Portico/PortalConfiguration.swift
+++ b/Portico/PortalConfiguration.swift
@@ -3,9 +3,48 @@ import Foundation
 struct PortalConfiguration: Codable, Equatable {
     let id: UUID
     let name: String
-    let localAppPort: UInt16
+    var localAppPort: UInt16
     let createdAt: Date
+    var desiredState: PortalDesiredState = .enabled
     var lifecycle: PortalLifecycle = .active
+}
+
+enum PortalDesiredState: String, Codable, Equatable {
+    case enabled
+    case stopped
+}
+
+extension PortalConfiguration {
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case localAppPort
+        case createdAt
+        case desiredState
+        case lifecycle
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        localAppPort = try container.decode(UInt16.self, forKey: .localAppPort)
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        desiredState = try container.contains(.desiredState)
+            ? container.decode(PortalDesiredState.self, forKey: .desiredState)
+            : .enabled
+        lifecycle = try container.decode(PortalLifecycle.self, forKey: .lifecycle)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(name, forKey: .name)
+        try container.encode(localAppPort, forKey: .localAppPort)
+        try container.encode(createdAt, forKey: .createdAt)
+        try container.encode(desiredState, forKey: .desiredState)
+        try container.encode(lifecycle, forKey: .lifecycle)
+    }
 }
 
 enum PortalLifecycle: String, Codable, Equatable {

--- a/Portico/PortalController.swift
+++ b/Portico/PortalController.swift
@@ -33,6 +33,9 @@ final class PortalController: ObservableObject {
     private var authenticationPending: Set<UUID> = []
     private var cleanupInFlight: Set<UUID> = []
     private var discoveryGeneration = 0
+    private var reconciliationGeneration = 0
+    private var reconciliationInFlight = false
+    private var pendingReconciliation: PortalReconciliation?
 
     init(
         store: PortalStore,
@@ -111,10 +114,38 @@ final class PortalController: ObservableObject {
             localApps = []
             isRefreshingLocalApps = false
             localAppsMessage = nil
-            start(configuration)
+            scheduleReconciliation()
         } catch {
             message = "The Portal could not be saved."
         }
+    }
+
+    func startPortal(id: UUID) {
+        updateDesiredState(id: id, desiredState: .enabled)
+    }
+
+    func stopPortal(id: UUID) {
+        updateDesiredState(id: id, desiredState: .stopped)
+    }
+
+    func updateLocalAppPort(id: UUID, port: String) {
+        guard let index = installation.portals.firstIndex(where: {
+            $0.id == id && $0.lifecycle == .active
+        }) else { return }
+        let localAppPort: UInt16
+        do {
+            localAppPort = try PortalInputValidator.validate(
+                name: installation.portals[index].name,
+                port: port
+            )
+        } catch {
+            message = "Enter a port from 1 through 65535."
+            return
+        }
+        guard installation.portals[index].localAppPort != localAppPort else { return }
+        var updated = installation
+        updated.portals[index].localAppPort = localAppPort
+        savePortalOperation(updated)
     }
 
     func authenticate() {
@@ -179,21 +210,68 @@ final class PortalController: ObservableObject {
 
     private func helperConnected() {
         refreshLocalApps()
+        scheduleReconciliation()
         for portal in installation.portals {
-            switch portal.lifecycle {
-            case .active:
-                start(portal)
-            case .pendingTailnetRejection:
+            if portal.lifecycle == .pendingTailnetRejection {
                 cleanupRejectedPortal(portal, evidence: nil)
             }
         }
     }
 
-    private func start(_ portal: PortalConfiguration) {
-        guard helper.availability == .connected, portal.lifecycle == .active else { return }
-        helper.startPortal(portal) { [weak self] result in
-            if case .failure = result {
-                self?.message = "The Portal could not be started."
+    private func updateDesiredState(id: UUID, desiredState: PortalDesiredState) {
+        guard let index = installation.portals.firstIndex(where: {
+            $0.id == id && $0.lifecycle == .active
+        }), installation.portals[index].desiredState != desiredState else { return }
+        var updated = installation
+        updated.portals[index].desiredState = desiredState
+        savePortalOperation(updated)
+    }
+
+    private func savePortalOperation(_ updated: InstallationRecord) {
+        do {
+            try store.save(updated)
+            installation = updated
+            publishInstallation()
+            message = nil
+            scheduleReconciliation()
+        } catch {
+            message = "The Portal could not be saved."
+        }
+    }
+
+    private func scheduleReconciliation() {
+        reconciliationGeneration += 1
+        let reconciliation = PortalReconciliation(
+            generation: reconciliationGeneration,
+            portals: installation.portals.filter { $0.lifecycle == .active }
+        )
+        guard helper.availability == .connected else { return }
+        guard !reconciliationInFlight else {
+            pendingReconciliation = reconciliation
+            return
+        }
+        send(reconciliation)
+    }
+
+    private func send(_ reconciliation: PortalReconciliation) {
+        reconciliationInFlight = true
+        helper.reconcilePortals(reconciliation.portals) { [weak self] result in
+            guard let self else { return }
+            self.reconciliationInFlight = false
+            if reconciliation.generation == self.reconciliationGeneration {
+                switch result {
+                case let .success(response):
+                    self.message = response.entries.contains { $0.outcome != .converged }
+                        ? "Some Portals could not be reconciled."
+                        : nil
+                case .failure:
+                    self.message = "Portals could not be reconciled."
+                }
+            }
+            if let pending = self.pendingReconciliation {
+                self.pendingReconciliation = nil
+                guard self.helper.availability == .connected else { return }
+                self.send(pending)
             }
         }
     }
@@ -263,6 +341,7 @@ final class PortalController: ObservableObject {
             try store.save(updated)
             installation = updated
             publishInstallation()
+            scheduleReconciliation()
             cleanupRejectedPortal(
                 updated.portals[index],
                 evidence: RejectionEvidence(
@@ -320,6 +399,11 @@ final class PortalController: ObservableObject {
 private struct RejectionEvidence {
     let assignedName: String?
     let rejectedMagicDNSSuffix: String?
+}
+
+private struct PortalReconciliation {
+    let generation: Int
+    let portals: [PortalConfiguration]
 }
 
 private extension String {

--- a/Portico/PorticoApp.swift
+++ b/Portico/PorticoApp.swift
@@ -31,8 +31,8 @@ private struct PortalView: View {
             ForEach(controller.alerts) { alert in
                 completedWarning(alert)
             }
-            ForEach(controller.portals, id: \.id) { portal in
-                portalStatus(portal)
+            ForEach(controller.portals.filter { $0.lifecycle == .active }, id: \.id) { portal in
+                PortalStatusView(controller: controller, portal: portal)
                 Divider()
             }
             addPortalForm
@@ -105,34 +105,6 @@ private struct PortalView: View {
         }
     }
 
-    @ViewBuilder
-    private func portalStatus(_ portal: PortalConfiguration) -> some View {
-        Text(portal.name).font(.headline)
-        LabeledContent("Local App Port", value: String(portal.localAppPort))
-        if portal.lifecycle == .pendingTailnetRejection {
-            Text("Cleanup pending")
-                .foregroundStyle(.secondary)
-        } else if let status = controller.statuses[portal.id] {
-            LabeledContent("Tailscale", value: status.state.title)
-            if let assignedName = status.assignedName {
-                LabeledContent("Assigned Name", value: assignedName)
-            }
-            if let portalURL = status.portalURL {
-                LabeledContent("Portal URL", value: portalURL.absoluteString)
-            }
-            if !status.addresses.isEmpty {
-                LabeledContent("Addresses", value: status.addresses.joined(separator: ", "))
-            }
-            if status.state == .authenticating {
-                Button("Authenticate") { controller.authenticate(id: portal.id) }
-                    .buttonStyle(.borderedProminent)
-            }
-        } else {
-            Text("Waiting for Portal status…")
-                .foregroundStyle(.secondary)
-        }
-    }
-
     private func pendingWarning(_ portal: PortalConfiguration) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             Label("Cleanup in progress", systemImage: "exclamationmark.triangle.fill")
@@ -155,6 +127,63 @@ private struct PortalView: View {
             Button("Dismiss") { controller.dismissAlert(id: alert.id) }
                 .controlSize(.small)
         }
+    }
+}
+
+private struct PortalStatusView: View {
+    @ObservedObject var controller: PortalController
+    let portal: PortalConfiguration
+    @State private var localAppPort: String
+
+    init(controller: PortalController, portal: PortalConfiguration) {
+        self.controller = controller
+        self.portal = portal
+        _localAppPort = State(initialValue: String(portal.localAppPort))
+    }
+
+    var body: some View {
+        Text(portal.name).font(.headline)
+        LabeledContent("Desired State", value: portal.desiredState.title)
+        HStack {
+            Text("Local App Port")
+            Spacer()
+            TextField("Local App Port", text: $localAppPort)
+                .frame(width: 80)
+                .onSubmit(updatePort)
+            Button("Update") { updatePort() }
+                .controlSize(.small)
+            Button(portal.desiredState == .enabled ? "Stop" : "Start") {
+                if portal.desiredState == .enabled {
+                    controller.stopPortal(id: portal.id)
+                } else {
+                    controller.startPortal(id: portal.id)
+                }
+            }
+            .controlSize(.small)
+        }
+        if let status = controller.statuses[portal.id] {
+            LabeledContent("Tailscale", value: status.state.title)
+            if let assignedName = status.assignedName {
+                LabeledContent("Assigned Name", value: assignedName)
+            }
+            if let portalURL = status.portalURL {
+                LabeledContent("Portal URL", value: portalURL.absoluteString)
+            }
+            if !status.addresses.isEmpty {
+                LabeledContent("Addresses", value: status.addresses.joined(separator: ", "))
+            }
+            if status.state == .authenticating {
+                Button("Authenticate") { controller.authenticate(id: portal.id) }
+                    .buttonStyle(.borderedProminent)
+            }
+        } else {
+            Text("Waiting for Portal status…")
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func updatePort() {
+        controller.updateLocalAppPort(id: portal.id, port: localAppPort)
     }
 }
 
@@ -185,6 +214,15 @@ private extension PortalTailscaleState {
         case .online: "Online"
         case .stopped: "Stopped"
         case .error: "Error"
+        }
+    }
+}
+
+private extension PortalDesiredState {
+    var title: String {
+        switch self {
+        case .enabled: "Enabled"
+        case .stopped: "Stopped"
         }
     }
 }

--- a/PorticoTests/HelperProtocolTests.swift
+++ b/PorticoTests/HelperProtocolTests.swift
@@ -2,43 +2,65 @@ import XCTest
 @testable import Portico
 
 final class HelperProtocolTests: XCTestCase {
-    func testDecodesVersionOneHandshakeResponse() throws {
-        let fixture = Data(#"{"version":1,"requestId":"request-1","result":{"protocolVersion":1}}"#.utf8)
+    func testVersionTwoReconciliationFixturesRoundTrip() throws {
+        let requestFixture = #"{"version":2,"requestId":"reconcile-1","command":"reconcilePortals","payload":{"portals":[{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","portalName":"hermes","localAppPort":8787,"desiredState":"enabled"},{"portalId":"5EA74329-3144-4BA2-925F-138D14D61FCC","portalName":"atlas","localAppPort":8788,"desiredState":"stopped"}]}}"#
+        let responseFixture = #"{"version":2,"requestId":"reconcile-1","result":{"entries":[{"portalId":"5EA74329-3144-4BA2-925F-138D14D61FCC","outcome":"converged"},{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","outcome":"startFailed"}]}}"#
+
+        try assertRoundTrip(requestFixture, as: HelperRequest<ReconcilePortalsPayload>.self)
+        let response = try JSONDecoder().decode(
+            HelperResponse<ReconcilePortalsResult>.self,
+            from: Data(responseFixture.utf8)
+        )
+
+        XCTAssertEqual(
+            response.result?.entries,
+            [
+                ReconcilePortalEntry(
+                    portalId: UUID(uuidString: "5ea74329-3144-4ba2-925f-138d14d61fcc")!,
+                    outcome: .converged
+                ),
+                ReconcilePortalEntry(
+                    portalId: UUID(uuidString: "9f55ca93-d7b3-4eab-a871-310ea576005a")!,
+                    outcome: .startFailed
+                ),
+            ]
+        )
+        try assertRoundTrip(responseFixture, as: HelperResponse<ReconcilePortalsResult>.self)
+    }
+
+    func testDecodesVersionTwoHandshakeResponse() throws {
+        let fixture = Data(#"{"version":2,"requestId":"request-1","result":{"protocolVersion":2}}"#.utf8)
 
         let response = try JSONDecoder().decode(HelperResponse<HandshakeResult>.self, from: fixture)
 
-        XCTAssertEqual(response.version, 1)
+        XCTAssertEqual(response.version, 2)
         XCTAssertEqual(response.requestId, "request-1")
-        XCTAssertEqual(response.result?.protocolVersion, 1)
+        XCTAssertEqual(response.result?.protocolVersion, 2)
         XCTAssertNil(response.error)
     }
 
     func testDecodesStructuredProtocolError() throws {
-        let fixture = Data(#"{"version":1,"requestId":"request-2","error":{"code":"unknownCommand","message":"unsupported command"}}"#.utf8)
+        let fixture = Data(#"{"version":2,"requestId":"request-2","error":{"code":"unknownCommand","message":"unsupported command"}}"#.utf8)
 
         let response = try JSONDecoder().decode(HelperResponse<HandshakeResult>.self, from: fixture)
 
-        XCTAssertEqual(response.version, 1)
+        XCTAssertEqual(response.version, 2)
         XCTAssertEqual(response.requestId, "request-2")
         XCTAssertNil(response.result)
         XCTAssertEqual(response.error, HelperProtocolError(code: "unknownCommand", message: "unsupported command"))
     }
 
-    func testVersionOnePortalFixturesRoundTrip() throws {
+    func testVersionTwoPortalFixturesRoundTrip() throws {
         let portalID = UUID(uuidString: "9f55ca93-d7b3-4eab-a871-310ea576005a")!
         try assertRoundTrip(
-            #"{"version":1,"requestId":"start-1","command":"startPortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","portalName":"hermes","localAppPort":8787}}"#,
-            as: HelperRequest<StartPortalPayload>.self
-        )
-        try assertRoundTrip(
-            #"{"version":1,"requestId":"auth-1","command":"authenticatePortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A"}}"#,
+            #"{"version":2,"requestId":"auth-1","command":"authenticatePortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A"}}"#,
             as: HelperRequest<AuthenticatePortalPayload>.self
         )
         try assertRoundTrip(
-            #"{"version":1,"requestId":"cleanup-1","command":"cleanupRejectedPortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A"}}"#,
+            #"{"version":2,"requestId":"cleanup-1","command":"cleanupRejectedPortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A"}}"#,
             as: HelperRequest<CleanupRejectedPortalPayload>.self
         )
-        let statusFixture = #"{"version":1,"event":"portalStatus","portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","payload":{"state":"online","stableNodeId":"node-1","assignedName":"hermes-1","portalURL":"https:\/\/hermes-1.example.ts.net\/","addresses":["100.64.0.1","fd7a:115c:a1e0::1"],"tailnetName":"opaque-identity-do-not-display","magicDNSSuffix":"example.ts.net"}}"#
+        let statusFixture = #"{"version":2,"event":"portalStatus","portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","payload":{"state":"online","stableNodeId":"node-1","assignedName":"hermes-1","portalURL":"https:\/\/hermes-1.example.ts.net\/","addresses":["100.64.0.1","fd7a:115c:a1e0::1"],"tailnetName":"opaque-identity-do-not-display","magicDNSSuffix":"example.ts.net"}}"#
         let status = try JSONDecoder().decode(HelperEvent<PortalStatusPayload>.self, from: Data(statusFixture.utf8))
         XCTAssertEqual(status.portalId, portalID)
         XCTAssertEqual(status.payload.state, .online)
@@ -47,12 +69,12 @@ final class HelperProtocolTests: XCTestCase {
         XCTAssertEqual(status.payload.magicDNSSuffix, "example.ts.net")
         try assertRoundTrip(statusFixture, as: HelperEvent<PortalStatusPayload>.self)
 
-        let authenticationFixture = #"{"version":1,"event":"authenticationURL","portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","payload":{"url":"https:\/\/login.tailscale.com\/a\/secret"}}"#
+        let authenticationFixture = #"{"version":2,"event":"authenticationURL","portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","payload":{"url":"https:\/\/login.tailscale.com\/a\/secret"}}"#
         try assertRoundTrip(authenticationFixture, as: HelperEvent<AuthenticationURLPayload>.self)
     }
 
-    func testDecodesVersionOneDiscoverLocalAppsResult() throws {
-        let fixture = Data(#"{"version":1,"requestId":"discover-1","result":{"candidates":[{"localAppPort":3000,"processLabel":"node","suggestedPortalName":"hermes"},{"localAppPort":8787,"processLabel":"python3"}]}}"#.utf8)
+    func testDecodesVersionTwoDiscoverLocalAppsResult() throws {
+        let fixture = Data(#"{"version":2,"requestId":"discover-1","result":{"candidates":[{"localAppPort":3000,"processLabel":"node","suggestedPortalName":"hermes"},{"localAppPort":8787,"processLabel":"python3"}]}}"#.utf8)
 
         let response = try JSONDecoder().decode(HelperResponse<DiscoverLocalAppsResult>.self, from: fixture)
 

--- a/PorticoTests/HelperShutdownTests.swift
+++ b/PorticoTests/HelperShutdownTests.swift
@@ -15,7 +15,7 @@ final class HelperShutdownTests: XCTestCase {
             shutdownGraceInterval: 1
         )
         supervisor.start()
-        launcher.receive(line: #"{"version":1,"requestId":"handshake-1","result":{"protocolVersion":1}}"#)
+        launcher.receive(line: #"{"version":2,"requestId":"handshake-1","result":{"protocolVersion":2}}"#)
         var completionCount = 0
 
         supervisor.shutdown { completionCount += 1 }
@@ -28,7 +28,7 @@ final class HelperShutdownTests: XCTestCase {
         XCTAssertEqual(request.requestId, "shutdown-1")
         XCTAssertEqual(request.command, .shutdown)
 
-        launcher.receive(line: #"{"version":1,"requestId":"shutdown-1","result":{"accepted":true}}"#)
+        launcher.receive(line: #"{"version":2,"requestId":"shutdown-1","result":{"accepted":true}}"#)
         XCTAssertEqual(completionCount, 0)
         launcher.exit(status: 0)
 
@@ -47,7 +47,7 @@ final class HelperShutdownTests: XCTestCase {
             shutdownGraceInterval: 0.01
         )
         supervisor.start()
-        launcher.receive(line: #"{"version":1,"requestId":"handshake-1","result":{"protocolVersion":1}}"#)
+        launcher.receive(line: #"{"version":2,"requestId":"handshake-1","result":{"protocolVersion":2}}"#)
         var completionCount = 0
 
         supervisor.shutdown { completionCount += 1 }
@@ -84,7 +84,7 @@ final class HelperShutdownTests: XCTestCase {
             shutdownGraceInterval: 1
         )
         supervisor.start()
-        launcher.receive(line: #"{"version":1,"requestId":"handshake-1","result":{"protocolVersion":1}}"#)
+        launcher.receive(line: #"{"version":2,"requestId":"handshake-1","result":{"protocolVersion":2}}"#)
         var completionCount = 0
 
         supervisor.shutdown { completionCount += 1 }

--- a/PorticoTests/HelperSupervisorTests.swift
+++ b/PorticoTests/HelperSupervisorTests.swift
@@ -18,14 +18,14 @@ final class HelperSupervisorTests: XCTestCase {
         XCTAssertEqual(supervisor.availability, .connecting)
         let requestData = try XCTUnwrap(launcher.process.sent.first)
         let request = try JSONDecoder().decode(HelperRequest<EmptyPayload>.self, from: requestData)
-        XCTAssertEqual(request.version, 1)
+        XCTAssertEqual(request.version, 2)
         XCTAssertEqual(request.requestId, "request-1")
         XCTAssertEqual(request.command, .handshake)
 
-        launcher.receive(line: #"{"version":1,"requestId":"other","result":{"protocolVersion":1}}"#)
+        launcher.receive(line: #"{"version":2,"requestId":"other","result":{"protocolVersion":2}}"#)
         XCTAssertEqual(supervisor.availability, .connecting)
 
-        launcher.receive(line: #"{"version":1,"requestId":"request-1","result":{"protocolVersion":1}}"#)
+        launcher.receive(line: #"{"version":2,"requestId":"request-1","result":{"protocolVersion":2}}"#)
         XCTAssertEqual(supervisor.availability, .connected)
     }
 
@@ -49,8 +49,8 @@ final class HelperSupervisorTests: XCTestCase {
     func testHandshakeFailuresBecomeUnavailable() {
         let failures: [(String, (FakeHelperLauncher) -> Void)] = [
             ("malformed line", { $0.receive(line: "{") }),
-            ("correlated error", { $0.receive(line: #"{"version":1,"requestId":"request-1","error":{"code":"unsupportedVersion","message":"unsupported protocol version"}}"#) }),
-            ("unsupported response version", { $0.receive(line: #"{"version":2,"requestId":"request-1","result":{"protocolVersion":1}}"#) }),
+            ("correlated error", { $0.receive(line: #"{"version":2,"requestId":"request-1","error":{"code":"unsupportedVersion","message":"unsupported protocol version"}}"#) }),
+            ("unsupported response version", { $0.receive(line: #"{"version":1,"requestId":"request-1","result":{"protocolVersion":1}}"#) }),
             ("EOF", { $0.receiveEOF() }),
             ("nonzero exit", { $0.exit(status: 1) }),
         ]
@@ -72,9 +72,9 @@ final class HelperSupervisorTests: XCTestCase {
         }
     }
 
-    func testRoutesCorrelatedPortalResponseAndAsynchronousEvent() throws {
+    func testRoutesCorrelatedReconciliationResponseAndAsynchronousEvent() throws {
         let launcher = FakeHelperLauncher()
-        var requestIDs = ["handshake-1", "start-1"]
+        var requestIDs = ["handshake-1", "reconcile-1"]
         let supervisor = HelperSupervisor(
             helperURL: URL(fileURLWithPath: "/unused/portico-helper"),
             stateRootURL: URL(fileURLWithPath: "/trusted/tsnet"),
@@ -86,21 +86,77 @@ final class HelperSupervisorTests: XCTestCase {
         supervisor.onEvent = { events.append($0) }
         supervisor.start()
         XCTAssertEqual(launcher.arguments, ["--state-root", "/trusted/tsnet"])
-        launcher.receive(line: #"{"version":1,"requestId":"handshake-1","result":{"protocolVersion":1}}"#)
-        let portal = PortalConfiguration(
+        launcher.receive(line: #"{"version":2,"requestId":"handshake-1","result":{"protocolVersion":2}}"#)
+        let laterPortal = PortalConfiguration(
             id: UUID(uuidString: "9f55ca93-d7b3-4eab-a871-310ea576005a")!,
             name: "hermes",
             localAppPort: 8787,
             createdAt: Date()
         )
-        var result: Result<Void, Error>?
+        let earlierPortal = PortalConfiguration(
+            id: UUID(uuidString: "5ea74329-3144-4ba2-925f-138d14d61fcc")!,
+            name: "atlas",
+            localAppPort: 8788,
+            createdAt: Date(),
+            desiredState: .stopped
+        )
+        var result: Result<ReconcilePortalsResult, Error>?
 
-        supervisor.startPortal(portal) { result = $0 }
-        launcher.receive(line: #"{"version":1,"event":"portalStatus","portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","payload":{"state":"connecting","addresses":[]}}"#)
-        XCTAssertEqual(events, [.status(portal.id, PortalStatusPayload(state: .connecting, stableNodeId: nil, assignedName: nil, portalURL: nil, addresses: []))])
+        supervisor.reconcilePortals([laterPortal, earlierPortal]) { result = $0 }
+
+        let requestData = try XCTUnwrap(launcher.process.sent.last)
+        let request = try JSONDecoder().decode(HelperRequest<ReconcilePortalsPayload>.self, from: requestData)
+        XCTAssertEqual(request.command, .reconcilePortals)
+        XCTAssertEqual(request.requestId, "reconcile-1")
+        XCTAssertEqual(
+            request.payload.portals,
+            [
+                ReconcilePortalPayload(
+                    portalId: earlierPortal.id,
+                    portalName: "atlas",
+                    localAppPort: 8788,
+                    desiredState: .stopped
+                ),
+                ReconcilePortalPayload(
+                    portalId: laterPortal.id,
+                    portalName: "hermes",
+                    localAppPort: 8787,
+                    desiredState: .enabled
+                ),
+            ]
+        )
+        launcher.receive(line: #"{"version":2,"event":"portalStatus","portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","payload":{"state":"connecting","addresses":[]}}"#)
+        XCTAssertEqual(events, [.status(laterPortal.id, PortalStatusPayload(state: .connecting, stableNodeId: nil, assignedName: nil, portalURL: nil, addresses: []))])
         XCTAssertNil(result)
-        launcher.receive(line: #"{"version":1,"requestId":"start-1","result":{"accepted":true}}"#)
-        XCTAssertNoThrow(try result?.get())
+        launcher.receive(line: #"{"version":2,"requestId":"reconcile-1","result":{"entries":[{"portalId":"5EA74329-3144-4BA2-925F-138D14D61FCC","outcome":"converged"},{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","outcome":"startFailed"}]}}"#)
+        XCTAssertEqual(
+            try result?.get().entries,
+            [
+                ReconcilePortalEntry(portalId: earlierPortal.id, outcome: .converged),
+                ReconcilePortalEntry(portalId: laterPortal.id, outcome: .startFailed),
+            ]
+        )
+    }
+
+    func testConnectionLossFailsUnresolvedReconciliation() {
+        let launcher = FakeHelperLauncher()
+        var requestIDs = ["handshake-1", "reconcile-1"]
+        let supervisor = HelperSupervisor(
+            helperURL: URL(fileURLWithPath: "/unused/portico-helper"),
+            launcher: launcher,
+            requestIDProvider: { requestIDs.removeFirst() },
+            handshakeTimeout: 1
+        )
+        supervisor.start()
+        launcher.receive(line: #"{"version":2,"requestId":"handshake-1","result":{"protocolVersion":2}}"#)
+        var result: Result<ReconcilePortalsResult, Error>?
+
+        supervisor.reconcilePortals([]) { result = $0 }
+        launcher.receiveEOF()
+
+        guard case .failure(HelperClientError.protocolFailure) = result else {
+            return XCTFail("expected unresolved reconciliation to fail")
+        }
     }
 
     func testRequestsAndCorrelatesLocalAppDiscovery() throws {
@@ -113,7 +169,7 @@ final class HelperSupervisorTests: XCTestCase {
             handshakeTimeout: 1
         )
         supervisor.start()
-        launcher.receive(line: #"{"version":1,"requestId":"handshake-1","result":{"protocolVersion":1}}"#)
+        launcher.receive(line: #"{"version":2,"requestId":"handshake-1","result":{"protocolVersion":2}}"#)
         var result: Result<[LocalAppCandidatePayload], Error>?
 
         supervisor.discoverLocalApps { result = $0 }
@@ -122,7 +178,7 @@ final class HelperSupervisorTests: XCTestCase {
         let request = try JSONDecoder().decode(HelperRequest<EmptyPayload>.self, from: requestData)
         XCTAssertEqual(request.command, .discoverLocalApps)
         XCTAssertEqual(request.requestId, "discover-1")
-        launcher.receive(line: #"{"version":1,"requestId":"discover-1","result":{"candidates":[{"localAppPort":3000,"processLabel":"node","suggestedPortalName":"hermes"}]}}"#)
+        launcher.receive(line: #"{"version":2,"requestId":"discover-1","result":{"candidates":[{"localAppPort":3000,"processLabel":"node","suggestedPortalName":"hermes"}]}}"#)
         XCTAssertEqual(
             try result?.get(),
             [LocalAppCandidatePayload(localAppPort: 3000, processLabel: "node", suggestedPortalName: "hermes")]
@@ -139,7 +195,7 @@ final class HelperSupervisorTests: XCTestCase {
             handshakeTimeout: 1
         )
         supervisor.start()
-        launcher.receive(line: #"{"version":1,"requestId":"handshake-1","result":{"protocolVersion":1}}"#)
+        launcher.receive(line: #"{"version":2,"requestId":"handshake-1","result":{"protocolVersion":2}}"#)
         let portalID = UUID(uuidString: "9f55ca93-d7b3-4eab-a871-310ea576005a")!
         var result: Result<Void, Error>?
 
@@ -150,7 +206,7 @@ final class HelperSupervisorTests: XCTestCase {
         XCTAssertEqual(request.command, .cleanupRejectedPortal)
         XCTAssertEqual(request.payload.portalId, portalID)
         XCTAssertNil(result)
-        launcher.receive(line: #"{"version":1,"requestId":"cleanup-1","result":{"accepted":true}}"#)
+        launcher.receive(line: #"{"version":2,"requestId":"cleanup-1","result":{"accepted":true}}"#)
         XCTAssertNoThrow(try result?.get())
     }
 
@@ -164,11 +220,11 @@ final class HelperSupervisorTests: XCTestCase {
             handshakeTimeout: 1
         )
         supervisor.start()
-        launcher.receive(line: #"{"version":1,"requestId":"handshake-1","result":{"protocolVersion":1}}"#)
+        launcher.receive(line: #"{"version":2,"requestId":"handshake-1","result":{"protocolVersion":2}}"#)
         var result: Result<[LocalAppCandidatePayload], Error>?
 
         supervisor.discoverLocalApps { result = $0 }
-        launcher.receive(line: #"{"version":1,"requestId":"discover-1","error":{"code":"discoveryFailure","message":"local app discovery failed"}}"#)
+        launcher.receive(line: #"{"version":2,"requestId":"discover-1","error":{"code":"discoveryFailure","message":"local app discovery failed"}}"#)
 
         guard case let .failure(HelperClientError.helper(error)) = result else {
             return XCTFail("expected fixed helper discovery failure")

--- a/PorticoTests/PortalControllerTests.swift
+++ b/PorticoTests/PortalControllerTests.swift
@@ -154,6 +154,163 @@ final class PortalControllerTests: XCTestCase {
         XCTAssertEqual(client.discoveryCompletions.count, 1)
     }
 
+    func testConnectionReconcilesOneFullActiveSnapshotAndOmitsPendingCleanup() throws {
+        let stoppedID = UUID(uuidString: "5ea74329-3144-4ba2-925f-138d14d61fcc")!
+        let pendingID = UUID(uuidString: "1f93e456-69ec-445a-8374-d7fc5558d0c7")!
+        let enabled = PortalConfiguration(
+            id: portalID,
+            name: "hermes",
+            localAppPort: 8787,
+            createdAt: Date(),
+            desiredState: .enabled
+        )
+        let stopped = PortalConfiguration(
+            id: stoppedID,
+            name: "atlas",
+            localAppPort: 8788,
+            createdAt: Date(),
+            desiredState: .stopped
+        )
+        let pending = PortalConfiguration(
+            id: pendingID,
+            name: "rejected",
+            localAppPort: 8789,
+            createdAt: Date(),
+            lifecycle: .pendingTailnetRejection
+        )
+        let store = PortalStore(rootURL: temporaryRoot())
+        try store.save(InstallationRecord(portals: [enabled, pending, stopped]))
+        let client = FakePortalHelperClient(availability: .connecting)
+        let controller = PortalController(store: store, helper: client, openURL: { _ in })
+
+        client.connect()
+
+        _ = controller
+        XCTAssertEqual(client.reconciliations, [[enabled, stopped]])
+        XCTAssertEqual(client.cleaned, [pendingID])
+    }
+
+    func testDesiredStateAndPortPersistBeforeReconciliation() throws {
+        let saved = PortalConfiguration(
+            id: portalID,
+            name: "hermes",
+            localAppPort: 8787,
+            createdAt: Date()
+        )
+        let store = PortalStore(rootURL: temporaryRoot())
+        try store.save(saved)
+        let client = FakePortalHelperClient()
+        let controller = PortalController(store: store, helper: client, openURL: { _ in })
+        client.onReconcile = { snapshot in
+            XCTAssertEqual(try? store.loadInstallation().portals, snapshot)
+        }
+
+        controller.stopPortal(id: portalID)
+        controller.updateLocalAppPort(id: portalID, port: "4321")
+
+        XCTAssertEqual(client.reconciliations.last?.first?.desiredState, .stopped)
+        XCTAssertEqual(client.reconciliations.last?.first?.localAppPort, 4321)
+        XCTAssertEqual(try store.loadInstallation().portals.first?.desiredState, .stopped)
+        XCTAssertEqual(try store.loadInstallation().portals.first?.localAppPort, 4321)
+    }
+
+    func testSingleFlightCoalescesLatestSnapshotAndIgnoresStaleFailure() throws {
+        let saved = PortalConfiguration(
+            id: portalID,
+            name: "hermes",
+            localAppPort: 8787,
+            createdAt: Date()
+        )
+        let store = PortalStore(rootURL: temporaryRoot())
+        try store.save(saved)
+        let client = FakePortalHelperClient()
+        client.completeReconciliationImmediately = false
+        let controller = PortalController(store: store, helper: client, openURL: { _ in })
+
+        controller.stopPortal(id: portalID)
+        controller.startPortal(id: portalID)
+        XCTAssertEqual(client.reconciliations.count, 1)
+
+        client.completeReconciliation(.success(ReconcilePortalsResult(entries: [
+            ReconcilePortalEntry(portalId: portalID, outcome: .startFailed)
+        ])))
+
+        XCTAssertNil(controller.message)
+        XCTAssertEqual(client.reconciliations.count, 2)
+        XCTAssertEqual(client.reconciliations.last?.first?.desiredState, .enabled)
+        client.completeReconciliation(.success(ReconcilePortalsResult(entries: [
+            ReconcilePortalEntry(portalId: portalID, outcome: .converged)
+        ])), at: 1)
+        XCTAssertNil(controller.message)
+    }
+
+    func testInvalidPortEditDoesNotPersistOrReconcile() throws {
+        let saved = PortalConfiguration(
+            id: portalID,
+            name: "hermes",
+            localAppPort: 8787,
+            createdAt: Date(),
+            desiredState: .stopped
+        )
+        let store = PortalStore(rootURL: temporaryRoot())
+        try store.save(saved)
+        let client = FakePortalHelperClient()
+        let controller = PortalController(store: store, helper: client, openURL: { _ in })
+        let originalReconciliationCount = client.reconciliations.count
+
+        controller.updateLocalAppPort(id: portalID, port: "0")
+
+        XCTAssertEqual(try store.loadInstallation().portals, [saved])
+        XCTAssertEqual(client.reconciliations.count, originalReconciliationCount)
+        XCTAssertEqual(controller.message, "Enter a port from 1 through 65535.")
+    }
+
+    func testAlreadySatisfiedStartAndStopAreHarmless() throws {
+        let saved = PortalConfiguration(
+            id: portalID,
+            name: "hermes",
+            localAppPort: 8787,
+            createdAt: Date()
+        )
+        let store = PortalStore(rootURL: temporaryRoot())
+        try store.save(saved)
+        let client = FakePortalHelperClient()
+        let controller = PortalController(store: store, helper: client, openURL: { _ in })
+
+        controller.startPortal(id: portalID)
+        XCTAssertEqual(client.reconciliations.count, 1)
+        controller.stopPortal(id: portalID)
+        XCTAssertEqual(client.reconciliations.count, 2)
+        controller.stopPortal(id: portalID)
+
+        XCTAssertEqual(client.reconciliations.count, 2)
+        XCTAssertEqual(try store.loadInstallation().portals.first?.desiredState, .stopped)
+    }
+
+    func testCurrentPartialFailureKeepsCommittedDesiredState() throws {
+        let saved = PortalConfiguration(
+            id: portalID,
+            name: "hermes",
+            localAppPort: 8787,
+            createdAt: Date()
+        )
+        let store = PortalStore(rootURL: temporaryRoot())
+        try store.save(saved)
+        let client = FakePortalHelperClient(availability: .connecting)
+        client.completeReconciliationImmediately = false
+        let controller = PortalController(store: store, helper: client, openURL: { _ in })
+
+        controller.stopPortal(id: portalID)
+        client.connect()
+        client.completeReconciliation(.success(ReconcilePortalsResult(entries: [
+            ReconcilePortalEntry(portalId: portalID, outcome: .closeFailed)
+        ])))
+
+        XCTAssertEqual(controller.portals.first?.desiredState, .stopped)
+        XCTAssertEqual(try store.loadInstallation().portals.first?.desiredState, .stopped)
+        XCTAssertEqual(controller.message, "Some Portals could not be reconciled.")
+    }
+
     func testPresentsOnlyMatchingStructuredStatus() throws {
         let store = PortalStore(rootURL: temporaryRoot())
         let saved = PortalConfiguration(id: portalID, name: "hermes", localAppPort: 8787, createdAt: Date())
@@ -217,7 +374,7 @@ final class PortalControllerTests: XCTestCase {
         controller.addPortal()
 
         XCTAssertEqual(controller.portals.map(\.id), [firstID, secondID])
-        XCTAssertEqual(client.started.map(\.id), [firstID, secondID])
+        XCTAssertEqual(client.reconciliations, [[first], try store.loadInstallation().portals])
         XCTAssertEqual(try store.loadInstallation().portals.map(\.id), [firstID, secondID])
     }
 
@@ -296,7 +453,8 @@ final class PortalControllerTests: XCTestCase {
         XCTAssertEqual(controller.pendingPortals.map(\.id), [portalID])
         XCTAssertEqual(controller.portals.first(where: { $0.id == secondID })?.lifecycle, .active)
         XCTAssertEqual(controller.statuses[secondID]?.state, .online)
-        XCTAssertEqual(client.started.map(\.id), [portalID, secondID])
+        XCTAssertEqual(client.reconciliations.first?.map(\.id), [portalID, secondID])
+        XCTAssertEqual(client.reconciliations.last?.map(\.id), [secondID])
     }
 
     func testCompletedCleanupPersistenceFailureKeepsPendingAndUnrelatedPortalEnabled() throws {
@@ -330,7 +488,8 @@ final class PortalControllerTests: XCTestCase {
         XCTAssertEqual(persisted.portals.first(where: { $0.id == secondID })?.lifecycle, .active)
         XCTAssertEqual(controller.pendingPortals.map(\.id), [portalID])
         XCTAssertEqual(controller.portals.first(where: { $0.id == secondID })?.lifecycle, .active)
-        XCTAssertEqual(client.started.map(\.id), [portalID, secondID])
+        XCTAssertEqual(client.reconciliations.first?.map(\.id), [portalID, secondID])
+        XCTAssertEqual(client.reconciliations.last?.map(\.id), [secondID])
     }
 
     func testMismatchPersistsTombstoneBeforeCleanupAndRelaunchNeverRestartsIt() throws {
@@ -453,21 +612,35 @@ final class FakePortalHelperClient: PortalHelperClient {
     var availability: HelperAvailability
     var onConnected: (() -> Void)?
     var onEvent: ((PortalHelperEvent) -> Void)?
-    private(set) var started: [PortalConfiguration] = []
+    private(set) var reconciliations: [[PortalConfiguration]] = []
+    var started: [PortalConfiguration] { reconciliations.flatMap { $0 } }
     private(set) var authenticated: [UUID] = []
     private(set) var cleaned: [UUID] = []
     private(set) var discoveryCompletions: [(Result<[LocalAppCandidatePayload], Error>) -> Void] = []
     private(set) var cleanupCompletions: [(Result<Void, Error>) -> Void] = []
+    private(set) var reconciliationCompletions: [(Result<ReconcilePortalsResult, Error>) -> Void] = []
     var completeCleanupImmediately = true
+    var completeReconciliationImmediately = true
     var onCleanup: ((UUID) -> Void)?
+    var onReconcile: (([PortalConfiguration]) -> Void)?
 
     init(availability: HelperAvailability = .connected) {
         self.availability = availability
     }
 
-    func startPortal(_ portal: PortalConfiguration, completion: @escaping (Result<Void, Error>) -> Void) {
-        started.append(portal)
-        completion(.success(()))
+    func reconcilePortals(
+        _ portals: [PortalConfiguration],
+        completion: @escaping (Result<ReconcilePortalsResult, Error>) -> Void
+    ) {
+        reconciliations.append(portals)
+        onReconcile?(portals)
+        if completeReconciliationImmediately {
+            completion(.success(ReconcilePortalsResult(entries: portals.map {
+                ReconcilePortalEntry(portalId: $0.id, outcome: .converged)
+            })))
+        } else {
+            reconciliationCompletions.append(completion)
+        }
     }
 
     func authenticatePortal(id: UUID, completion: @escaping (Result<Void, Error>) -> Void) {
@@ -502,5 +675,12 @@ final class FakePortalHelperClient: PortalHelperClient {
 
     func completeCleanup(_ result: Result<Void, Error>, at index: Int = 0) {
         cleanupCompletions[index](result)
+    }
+
+    func completeReconciliation(
+        _ result: Result<ReconcilePortalsResult, Error>,
+        at index: Int = 0
+    ) {
+        reconciliationCompletions[index](result)
     }
 }

--- a/PorticoTests/PortalStoreTests.swift
+++ b/PorticoTests/PortalStoreTests.swift
@@ -80,6 +80,51 @@ final class PortalStoreTests: XCTestCase {
         XCTAssertEqual(try permissions(of: store.installationURL), 0o600)
     }
 
+    func testHistoricalVersionTwoDefaultsToEnabledAndNextSavePersistsDesiredState() throws {
+        struct ExpectedFailure: Error {}
+
+        let root = temporaryRoot()
+        let installationURL = root.appendingPathComponent("installation-v2.json", isDirectory: false)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let historical = Data(
+            #"{"version":2,"portals":[{"id":"9F55CA93-D7B3-4EAB-A871-310EA576005A","name":"hermes","localAppPort":8787,"createdAt":807692800,"lifecycle":"active"},{"id":"5EA74329-3144-4BA2-925F-138D14D61FCC","name":"atlas","localAppPort":8788,"createdAt":807692801,"lifecycle":"active"}],"alerts":[]}"#.utf8
+        )
+        try historical.write(to: installationURL)
+        var shouldFail = true
+        let store = PortalStore(rootURL: root, writeData: { data, url in
+            guard !shouldFail else { throw ExpectedFailure() }
+            try data.write(to: url, options: .atomic)
+        })
+
+        var installation = try store.loadInstallation()
+
+        XCTAssertEqual(installation.portals.map(\.desiredState), [.enabled, .enabled])
+        installation.portals[1].desiredState = .stopped
+        XCTAssertThrowsError(try store.save(installation))
+        XCTAssertEqual(try Data(contentsOf: installationURL), historical)
+
+        shouldFail = false
+        try store.save(installation)
+
+        let saved = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(contentsOf: installationURL)) as? [String: Any])
+        XCTAssertEqual(saved["version"] as? Int, 2)
+        let portals = try XCTUnwrap(saved["portals"] as? [[String: Any]])
+        XCTAssertEqual(portals.map { $0["desiredState"] as? String }, ["enabled", "stopped"])
+        XCTAssertEqual(try store.loadInstallation(), installation)
+    }
+
+    func testExplicitNullDesiredStateIsCorruptRatherThanDefaulting() throws {
+        let store = PortalStore(rootURL: temporaryRoot())
+        try FileManager.default.createDirectory(at: store.rootURL, withIntermediateDirectories: true)
+        let corrupt = Data(
+            #"{"version":2,"portals":[{"id":"9F55CA93-D7B3-4EAB-A871-310EA576005A","name":"hermes","localAppPort":8787,"createdAt":807692800,"desiredState":null,"lifecycle":"active"}],"alerts":[]}"#.utf8
+        )
+        try corrupt.write(to: store.installationURL)
+
+        XCTAssertThrowsError(try store.loadInstallation())
+        XCTAssertEqual(try Data(contentsOf: store.installationURL), corrupt)
+    }
+
     func testSavedPortalReloadsWithSameImmutableDefinition() throws {
         let root = temporaryRoot()
         let store = PortalStore(rootURL: root)

--- a/helper/internal/portal/proxy.go
+++ b/helper/internal/portal/proxy.go
@@ -46,6 +46,10 @@ type proxyServer struct {
 	listener net.Listener
 	handler  *trackedHandler
 	done     chan error
+	closeMu  sync.Mutex
+	stopOnce sync.Once
+	doneOnce sync.Once
+	serveErr error
 }
 
 func startProxyServer(ctx context.Context, listener net.Listener, handler http.Handler) *proxyServer {
@@ -72,15 +76,21 @@ func startProxyServer(ctx context.Context, listener net.Listener, handler http.H
 }
 
 func (p *proxyServer) close() error {
-	p.cancel()
-	p.handler.stopAccepting()
+	p.closeMu.Lock()
+	defer p.closeMu.Unlock()
+	p.stopOnce.Do(func() {
+		p.cancel()
+		p.handler.stopAccepting()
+	})
 	shutdownContext, cancel := context.WithTimeout(context.Background(), proxyShutdownTimeout)
-	shutdownErr := p.server.Shutdown(shutdownContext)
+	_ = p.server.Shutdown(shutdownContext)
 	cancel()
 	closeErr := p.server.Close()
 	listenerErr := p.listener.Close()
 	p.handler.wait()
-	serveErr := <-p.done
+	p.doneOnce.Do(func() { p.serveErr = <-p.done })
+	serveErr := p.serveErr
+	p.serveErr = nil
 	if errors.Is(closeErr, http.ErrServerClosed) || errors.Is(closeErr, net.ErrClosed) {
 		closeErr = nil
 	}
@@ -90,7 +100,11 @@ func (p *proxyServer) close() error {
 	if errors.Is(serveErr, http.ErrServerClosed) || errors.Is(serveErr, net.ErrClosed) {
 		serveErr = nil
 	}
-	return errors.Join(shutdownErr, closeErr, listenerErr, serveErr)
+	return errors.Join(closeErr, listenerErr, serveErr)
+}
+
+func (p *proxyServer) replaceHandler(handler http.Handler) {
+	p.handler.replace(handler)
 }
 
 type trackedHandler struct {
@@ -107,10 +121,17 @@ func (h *trackedHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 		http.Error(writer, http.StatusText(http.StatusServiceUnavailable), http.StatusServiceUnavailable)
 		return
 	}
+	handler := h.handler
 	h.active.Add(1)
 	h.mu.Unlock()
 	defer h.active.Done()
-	h.handler.ServeHTTP(writer, request)
+	handler.ServeHTTP(writer, request)
+}
+
+func (h *trackedHandler) replace(handler http.Handler) {
+	h.mu.Lock()
+	h.handler = handler
+	h.mu.Unlock()
 }
 
 func (h *trackedHandler) stopAccepting() {

--- a/helper/internal/portal/proxy_test.go
+++ b/helper/internal/portal/proxy_test.go
@@ -3,6 +3,7 @@ package portal
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"log"
 	"net"
@@ -10,6 +11,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -316,4 +318,40 @@ func TestLoopbackDestinationCannotContainHostSchemePathOrURL(t *testing.T) {
 			t.Fatalf("destination = %q, want internally constructed loopback URL", got)
 		}
 	}
+}
+
+func TestProxyCloseCanRetryAfterUnconfirmedListenerClose(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	flaky := &flakyCloseListener{Listener: listener}
+	flaky.failuresRemaining.Store(2)
+	proxy := startProxyServer(context.Background(), flaky, http.NotFoundHandler())
+
+	if err := proxy.close(); err == nil {
+		t.Fatal("first close succeeded, want unconfirmed close failure")
+	}
+	done := make(chan error, 1)
+	go func() { done <- proxy.close() }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("retry close: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("retry close blocked after Serve result was already collected")
+	}
+}
+
+type flakyCloseListener struct {
+	net.Listener
+	failuresRemaining atomic.Int32
+}
+
+func (l *flakyCloseListener) Close() error {
+	if l.failuresRemaining.Add(-1) >= 0 {
+		return errors.New("injected listener close failure")
+	}
+	return l.Listener.Close()
 }

--- a/helper/internal/portal/runtime.go
+++ b/helper/internal/portal/runtime.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 )
@@ -23,9 +24,30 @@ const (
 )
 
 type Config struct {
-	ID   string
-	Name string
-	Port uint16
+	ID           string
+	Name         string
+	Port         uint16
+	DesiredState DesiredState
+}
+
+type DesiredState string
+
+const (
+	DesiredStateEnabled DesiredState = "enabled"
+	DesiredStateStopped DesiredState = "stopped"
+)
+
+type ReconcileOutcome string
+
+const (
+	OutcomeConverged   ReconcileOutcome = "converged"
+	OutcomeStartFailed ReconcileOutcome = "startFailed"
+	OutcomeCloseFailed ReconcileOutcome = "closeFailed"
+)
+
+type ReconcileEntry struct {
+	PortalID string           `json:"portalId"`
+	Outcome  ReconcileOutcome `json:"outcome"`
 }
 
 var (
@@ -43,6 +65,16 @@ func (c Config) Validate() error {
 func (c Config) normalized() Config {
 	c.ID = strings.ToLower(c.ID)
 	return c
+}
+
+func (c Config) validateDesired() error {
+	if err := c.Validate(); err != nil {
+		return err
+	}
+	if c.DesiredState != DesiredStateEnabled && c.DesiredState != DesiredStateStopped {
+		return errors.New("invalid portal desired state")
+	}
+	return nil
 }
 
 type Status struct {
@@ -109,29 +141,102 @@ type portalRuntime struct {
 	emit                  func(Event)
 	authenticationPending bool
 	proxy                 *proxyServer
+	isRunning             bool
 }
 
 func NewRuntime(stateRoot string, factory NodeFactory) *Runtime {
 	return &Runtime{stateRoot: stateRoot, factory: factory, portals: make(map[string]*portalRuntime)}
 }
 
-func (r *Runtime) Start(ctx context.Context, config Config, emit func(Event)) error {
+func (r *Runtime) Reconcile(ctx context.Context, configs []Config, emit func(Event)) ([]ReconcileEntry, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if err := config.Validate(); err != nil {
-		return err
+
+	desired := make(map[string]Config, len(configs))
+	for _, config := range configs {
+		if err := config.validateDesired(); err != nil {
+			return nil, err
+		}
+		config = config.normalized()
+		if _, exists := desired[config.ID]; exists {
+			return nil, errors.New("duplicate portal configuration")
+		}
+		desired[config.ID] = config
 	}
-	config = config.normalized()
-	if _, exists := r.portals[config.ID]; exists {
-		return errors.New("portal is already running")
+
+	portalIDs := make([]string, 0, len(desired)+len(r.portals))
+	seen := make(map[string]struct{}, len(desired)+len(r.portals))
+	for portalID := range desired {
+		portalIDs = append(portalIDs, portalID)
+		seen[portalID] = struct{}{}
 	}
+	for portalID := range r.portals {
+		if _, exists := seen[portalID]; !exists {
+			portalIDs = append(portalIDs, portalID)
+		}
+	}
+	sort.Strings(portalIDs)
+
+	entries := make([]ReconcileEntry, 0, len(portalIDs))
+	for _, portalID := range portalIDs {
+		config, included := desired[portalID]
+		outcome := r.reconcilePortalLocked(ctx, portalID, config, included, emit)
+		entries = append(entries, ReconcileEntry{PortalID: portalID, Outcome: outcome})
+	}
+	return entries, nil
+}
+
+func (r *Runtime) reconcilePortalLocked(
+	ctx context.Context,
+	portalID string,
+	config Config,
+	included bool,
+	emit func(Event),
+) ReconcileOutcome {
+	portal := r.portals[portalID]
+	if !included || config.DesiredState == DesiredStateStopped {
+		if portal == nil {
+			return OutcomeConverged
+		}
+		if err := portal.close(); err != nil {
+			return OutcomeCloseFailed
+		}
+		delete(r.portals, portalID)
+		return OutcomeConverged
+	}
+
+	if portal == nil {
+		return r.startPortalLocked(ctx, config, emit)
+	}
+	if portal.config == nil || !portal.isRunning {
+		if err := portal.close(); err != nil {
+			return OutcomeStartFailed
+		}
+		delete(r.portals, portalID)
+		return r.startPortalLocked(ctx, config, emit)
+	}
+	if portal.config.Name != config.Name {
+		return OutcomeStartFailed
+	}
+	if portal.config.Port != config.Port {
+		if err := portal.updatePort(config.Port); err != nil {
+			return OutcomeStartFailed
+		}
+	}
+	return OutcomeConverged
+}
+
+func (r *Runtime) startPortalLocked(ctx context.Context, config Config, emit func(Event)) ReconcileOutcome {
 	node := r.factory(filepath.Join(r.stateRoot, config.ID), config.Name)
 	portal := &portalRuntime{}
-	if err := portal.start(ctx, config, node, emit); err != nil {
-		return err
-	}
 	r.portals[config.ID] = portal
-	return nil
+	if err := portal.start(ctx, config, node, emit); err != nil {
+		if closeErr := portal.close(); closeErr == nil {
+			delete(r.portals, config.ID)
+		}
+		return OutcomeStartFailed
+	}
+	return OutcomeConverged
 }
 
 func (r *Runtime) Authenticate(ctx context.Context, portalID string) error {
@@ -176,8 +281,11 @@ func (r *Runtime) Close() error {
 	defer r.mu.Unlock()
 	var errs []error
 	for portalID, portal := range r.portals {
-		errs = append(errs, portal.close())
-		delete(r.portals, portalID)
+		if err := portal.close(); err != nil {
+			errs = append(errs, err)
+		} else {
+			delete(r.portals, portalID)
+		}
 	}
 	return errors.Join(errs...)
 }
@@ -209,29 +317,44 @@ func validatedStateDirectory(stateRoot, portalID string) (string, error) {
 func (r *portalRuntime) start(ctx context.Context, config Config, node Node, emit func(Event)) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	r.config = &config
+	r.node = node
+	r.emit = emit
 	if err := node.Start(); err != nil {
-		_ = node.Close()
 		return errors.New("start portal")
 	}
 	watchContext, cancel := context.WithCancel(ctx)
 	watcher, err := node.Watch(watchContext)
 	if err != nil {
 		cancel()
-		_ = node.Close()
 		return errors.New("watch portal status")
 	}
-	r.config = &config
-	r.node = node
 	r.watcher = watcher
 	r.cancel = cancel
 	r.runContext = watchContext
-	r.emit = emit
 	if err := r.emitStatusLocked(ctx); err != nil {
-		r.closeLocked()
 		return err
 	}
 	r.watchDone.Add(1)
 	go r.watch(watchContext, watcher)
+	r.isRunning = true
+	return nil
+}
+
+func (r *portalRuntime) updatePort(port uint16) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.config == nil {
+		return errors.New("portal is not running")
+	}
+	handler, err := newLoopbackProxy(int(port))
+	if err != nil {
+		return err
+	}
+	if r.proxy != nil {
+		r.proxy.replaceHandler(handler)
+	}
+	r.config.Port = port
 	return nil
 }
 
@@ -260,26 +383,35 @@ func (r *portalRuntime) closeLocked() error {
 	var proxyErr error
 	if r.cancel != nil {
 		r.cancel()
+		r.cancel = nil
 	}
 	if r.watcher != nil {
 		_ = r.watcher.Close()
+		r.watcher = nil
 	}
 	if r.proxy != nil {
 		proxyErr = r.proxy.close()
+		if proxyErr == nil {
+			r.proxy = nil
+		}
 	}
 	var nodeErr error
 	if r.node != nil {
 		nodeErr = r.node.Close()
+		if nodeErr == nil {
+			r.node = nil
+		}
 	}
-	r.config = nil
-	r.node = nil
-	r.watcher = nil
-	r.cancel = nil
-	r.runContext = nil
-	r.emit = nil
+	err := errors.Join(proxyErr, nodeErr)
+	r.isRunning = false
+	if err == nil {
+		r.config = nil
+		r.runContext = nil
+		r.emit = nil
+		r.proxy = nil
+	}
 	r.authenticationPending = false
-	r.proxy = nil
-	return errors.Join(proxyErr, nodeErr)
+	return err
 }
 
 func (r *portalRuntime) watch(ctx context.Context, watcher Watcher) {

--- a/helper/internal/portal/runtime_test.go
+++ b/helper/internal/portal/runtime_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -19,6 +20,299 @@ import (
 
 const testPortalID = "9f55ca93-d7b3-4eab-a871-310ea576005a"
 const secondPortalID = "5ea74329-3144-4ba2-925f-138d14d61fcc"
+
+func TestRuntimeReconcileContinuesAfterStartFailureAndRetainsOwnershipUntilCleanup(t *testing.T) {
+	root := t.TempDir()
+	created := make(map[string][]*fakeNode)
+	runtime := NewRuntime(root, func(dir, _ string) Node {
+		portalID := filepath.Base(dir)
+		node := &fakeNode{watcher: newFakeWatcher(), status: Status{BackendState: "Starting"}}
+		if portalID == testPortalID && len(created[portalID]) == 0 {
+			node.startErr = errors.New("start failed")
+			node.closeResults = []error{errors.New("cleanup unconfirmed"), nil}
+		}
+		created[portalID] = append(created[portalID], node)
+		return node
+	})
+	desired := []Config{
+		{ID: testPortalID, Name: "hermes", Port: 8787, DesiredState: DesiredStateEnabled},
+		{ID: secondPortalID, Name: "atlas", Port: 8788, DesiredState: DesiredStateEnabled},
+	}
+
+	entries, err := runtime.Reconcile(context.Background(), desired, func(Event) {})
+
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	want := []ReconcileEntry{
+		{PortalID: secondPortalID, Outcome: OutcomeConverged},
+		{PortalID: testPortalID, Outcome: OutcomeStartFailed},
+	}
+	if !reflect.DeepEqual(entries, want) {
+		t.Fatalf("entries = %+v, want %+v", entries, want)
+	}
+	if len(created[testPortalID]) != 1 || len(created[secondPortalID]) != 1 {
+		t.Fatalf("created = %+v, want one owned node per Portal", created)
+	}
+
+	entries, err = runtime.Reconcile(context.Background(), desired, func(Event) {})
+	if err != nil {
+		t.Fatalf("retry Reconcile: %v", err)
+	}
+	if entries[1].Outcome != OutcomeConverged || len(created[testPortalID]) != 2 {
+		t.Fatalf("retry = (%+v, %d nodes), want cleanup then one replacement", entries, len(created[testPortalID]))
+	}
+
+	conflicting := append([]Config(nil), desired...)
+	conflicting[1].Name = "renamed"
+	entries, err = runtime.Reconcile(context.Background(), conflicting, func(Event) {})
+	if err != nil {
+		t.Fatalf("conflicting Reconcile: %v", err)
+	}
+	if entries[0].Outcome != OutcomeStartFailed || len(created[secondPortalID]) != 1 {
+		t.Fatalf("conflicting immutable name = (%+v, %d nodes), want retained identity", entries, len(created[secondPortalID]))
+	}
+	_ = runtime.Close()
+}
+
+func TestRuntimePortEditPreservesIdentityAndDrainsAcceptedHTTPAndWebSocketTraffic(t *testing.T) {
+	oldHTTPEntered := make(chan struct{})
+	releaseOldHTTP := make(chan struct{})
+	var releaseOldHTTPOnce sync.Once
+	releaseOld := func() { releaseOldHTTPOnce.Do(func() { close(releaseOldHTTP) }) }
+	defer releaseOld()
+	t.Cleanup(releaseOld)
+	oldLocalApp := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if strings.EqualFold(request.Header.Get("Upgrade"), "websocket") {
+			echoWebSocket(t, writer, request, "old:")
+			return
+		}
+		_, _ = io.WriteString(writer, "old-start\n")
+		writer.(http.Flusher).Flush()
+		close(oldHTTPEntered)
+		<-releaseOldHTTP
+		_, _ = io.WriteString(writer, "old-end\n")
+	}))
+	t.Cleanup(oldLocalApp.Close)
+	newLocalApp := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if strings.EqualFold(request.Header.Get("Upgrade"), "websocket") {
+			echoWebSocket(t, writer, request, "new:")
+			return
+		}
+		_, _ = io.WriteString(writer, "new-http\n")
+	}))
+	t.Cleanup(newLocalApp.Close)
+	oldPort, _ := localAppPort(t, oldLocalApp.URL)
+	newPort, _ := localAppPort(t, newLocalApp.URL)
+
+	tailnetListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	factory := newFakeFactory()
+	factory.status = Status{
+		BackendState: "Running",
+		DNSName:      "hermes.example.ts.net.",
+		CertDomains:  []string{"hermes.example.ts.net"},
+	}
+	factory.node.realListener = tailnetListener
+	runtime := NewRuntime(t.TempDir(), factory.New)
+	desired := []Config{{
+		ID: testPortalID, Name: "hermes", Port: uint16(oldPort), DesiredState: DesiredStateEnabled,
+	}}
+	if entries, reconcileErr := runtime.Reconcile(context.Background(), desired, func(Event) {}); reconcileErr != nil || entries[0].Outcome != OutcomeConverged {
+		t.Fatalf("initial Reconcile = (%+v, %v), want converged", entries, reconcileErr)
+	}
+	t.Cleanup(func() { _ = runtime.Close() })
+	proxyURL := "http://" + tailnetListener.Addr().String()
+
+	oldHTTPResponse := make(chan *http.Response, 1)
+	go func() {
+		response, requestErr := http.Get(proxyURL)
+		if requestErr != nil {
+			oldHTTPResponse <- nil
+			return
+		}
+		oldHTTPResponse <- response
+	}()
+	waitForSignal(t, oldHTTPEntered, "old Local App HTTP request")
+	response := <-oldHTTPResponse
+	if response == nil {
+		t.Fatal("old HTTP request failed")
+	}
+	defer response.Body.Close()
+	first := make([]byte, len("old-start\n"))
+	if _, err := io.ReadFull(response.Body, first); err != nil || string(first) != "old-start\n" {
+		t.Fatalf("old HTTP prefix = (%q, %v)", first, err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	oldWebSocket, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(proxyURL, "http"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer oldWebSocket.CloseNow()
+
+	desired[0].Port = uint16(newPort)
+	entries, err := runtime.Reconcile(context.Background(), desired, func(Event) {})
+	if err != nil || entries[0].Outcome != OutcomeConverged {
+		t.Fatalf("port-edit Reconcile = (%+v, %v), want converged", entries, err)
+	}
+	if len(factory.created) != 1 || factory.node.realListener != tailnetListener {
+		t.Fatalf("factory created %d nodes, want unchanged node and listener", len(factory.created))
+	}
+
+	newHTTPResponse, err := http.Get(proxyURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newHTTPBody, _ := io.ReadAll(newHTTPResponse.Body)
+	_ = newHTTPResponse.Body.Close()
+	if string(newHTTPBody) != "new-http\n" {
+		t.Fatalf("new HTTP response = %q, want new Local App", newHTTPBody)
+	}
+	assertWebSocketEcho(t, ctx, oldWebSocket, "old:existing")
+	newWebSocket, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(proxyURL, "http"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer newWebSocket.CloseNow()
+	assertWebSocketEcho(t, ctx, newWebSocket, "new:fresh")
+
+	releaseOld()
+	remainder, err := io.ReadAll(response.Body)
+	if err != nil || string(remainder) != "old-end\n" {
+		t.Fatalf("old HTTP remainder = (%q, %v), want drained old Local App", remainder, err)
+	}
+}
+
+func TestRuntimeReconcileStopsAndOmitsPortalsWithoutDeletingIdentity(t *testing.T) {
+	root := t.TempDir()
+	nodes := make(map[string]*fakeNode)
+	runtime := NewRuntime(root, func(dir, _ string) Node {
+		portalID := filepath.Base(dir)
+		node := &fakeNode{watcher: newFakeWatcher(), status: Status{BackendState: "Starting"}}
+		nodes[portalID] = node
+		return node
+	})
+	desired := []Config{
+		{ID: testPortalID, Name: "hermes", Port: 8787, DesiredState: DesiredStateEnabled},
+		{ID: secondPortalID, Name: "atlas", Port: 8788, DesiredState: DesiredStateEnabled},
+	}
+	if _, err := runtime.Reconcile(context.Background(), desired, func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+	for _, portalID := range []string{testPortalID, secondPortalID} {
+		if err := os.MkdirAll(filepath.Join(root, portalID), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	entries, err := runtime.Reconcile(context.Background(), []Config{{
+		ID: testPortalID, Name: "hermes", Port: 8787, DesiredState: DesiredStateStopped,
+	}}, func(Event) {})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []ReconcileEntry{
+		{PortalID: secondPortalID, Outcome: OutcomeConverged},
+		{PortalID: testPortalID, Outcome: OutcomeConverged},
+	}
+	if !reflect.DeepEqual(entries, want) {
+		t.Fatalf("entries = %+v, want stopped and omitted convergence", entries)
+	}
+	for portalID, node := range nodes {
+		if !node.closed {
+			t.Fatalf("Portal %s was not closed", portalID)
+		}
+		if _, err := os.Stat(filepath.Join(root, portalID)); err != nil {
+			t.Fatalf("Portal %s identity was deleted: %v", portalID, err)
+		}
+	}
+
+	entries, err = runtime.Reconcile(context.Background(), []Config{{
+		ID: testPortalID, Name: "hermes", Port: 8787, DesiredState: DesiredStateStopped,
+	}}, func(Event) {})
+	if err != nil || len(entries) != 1 || entries[0].PortalID != testPortalID || entries[0].Outcome != OutcomeConverged {
+		t.Fatalf("already-converged retry = (%+v, %v)", entries, err)
+	}
+}
+
+func TestRuntimeReconcileRetainsOwnershipAfterCloseFailure(t *testing.T) {
+	var created []*fakeNode
+	runtime := NewRuntime(t.TempDir(), func(_, _ string) Node {
+		node := &fakeNode{
+			watcher:      newFakeWatcher(),
+			status:       Status{BackendState: "Starting"},
+			closeResults: []error{errors.New("close unconfirmed"), nil},
+		}
+		created = append(created, node)
+		return node
+	})
+	enabled := Config{ID: testPortalID, Name: "hermes", Port: 8787, DesiredState: DesiredStateEnabled}
+	if _, err := runtime.Reconcile(context.Background(), []Config{enabled}, func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+	stopped := enabled
+	stopped.DesiredState = DesiredStateStopped
+
+	entries, err := runtime.Reconcile(context.Background(), []Config{stopped}, func(Event) {})
+	if err != nil || entries[0].Outcome != OutcomeCloseFailed || len(created) != 1 {
+		t.Fatalf("failed close = (%+v, %v, %d nodes), want retained ownership", entries, err, len(created))
+	}
+	entries, err = runtime.Reconcile(context.Background(), []Config{stopped}, func(Event) {})
+	if err != nil || entries[0].Outcome != OutcomeConverged || len(created) != 1 || created[0].closeCalls != 2 {
+		t.Fatalf("close retry = (%+v, %v, %d nodes, %d closes)", entries, err, len(created), created[0].closeCalls)
+	}
+}
+
+func TestRuntimeReconcileRejectsWholeInvalidSnapshotBeforeMutation(t *testing.T) {
+	created := 0
+	runtime := NewRuntime(t.TempDir(), func(_, _ string) Node {
+		created++
+		return &fakeNode{watcher: newFakeWatcher()}
+	})
+	configs := []Config{
+		{ID: testPortalID, Name: "hermes", Port: 8787, DesiredState: DesiredStateEnabled},
+		{ID: secondPortalID, Name: "Atlas", Port: 8788, DesiredState: DesiredStateEnabled},
+	}
+
+	if entries, err := runtime.Reconcile(context.Background(), configs, func(Event) {}); err == nil || entries != nil {
+		t.Fatalf("Reconcile = (%+v, %v), want full rejection", entries, err)
+	}
+	if created != 0 {
+		t.Fatalf("created %d nodes before validating the full snapshot", created)
+	}
+}
+
+func echoWebSocket(t *testing.T, writer http.ResponseWriter, request *http.Request, prefix string) {
+	t.Helper()
+	connection, err := websocket.Accept(writer, request, nil)
+	if err != nil {
+		return
+	}
+	defer connection.CloseNow()
+	messageType, message, err := connection.Read(request.Context())
+	if err != nil {
+		return
+	}
+	_ = connection.Write(request.Context(), messageType, append([]byte(prefix), message...))
+}
+
+func assertWebSocketEcho(t *testing.T, ctx context.Context, connection *websocket.Conn, expected string) {
+	t.Helper()
+	message := strings.TrimPrefix(expected, "old:")
+	message = strings.TrimPrefix(message, "new:")
+	if err := connection.Write(ctx, websocket.MessageText, []byte(message)); err != nil {
+		t.Fatal(err)
+	}
+	_, response, err := connection.Read(ctx)
+	if err != nil || string(response) != expected {
+		t.Fatalf("WebSocket response = (%q, %v), want %q", response, err, expected)
+	}
+}
 
 func TestRuntimeKeepsTwoIndependentPortalsOnline(t *testing.T) {
 	root := t.TempDir()
@@ -50,11 +344,12 @@ func TestRuntimeKeepsTwoIndependentPortalsOnline(t *testing.T) {
 		}
 	}
 
-	if err := runtime.Start(context.Background(), Config{ID: testPortalID, Name: "hermes", Port: 8787}, emit); err != nil {
-		t.Fatalf("Start first Portal: %v", err)
+	configs := []Config{
+		{ID: testPortalID, Name: "hermes", Port: 8787, DesiredState: DesiredStateEnabled},
+		{ID: secondPortalID, Name: "atlas", Port: 8788, DesiredState: DesiredStateEnabled},
 	}
-	if err := runtime.Start(context.Background(), Config{ID: secondPortalID, Name: "atlas", Port: 8788}, emit); err != nil {
-		t.Fatalf("Start second Portal: %v", err)
+	if _, err := runtime.Reconcile(context.Background(), configs, emit); err != nil {
+		t.Fatalf("Reconcile Portals: %v", err)
 	}
 	t.Cleanup(func() { _ = runtime.Close() })
 
@@ -76,13 +371,14 @@ func TestCleanupRejectedPortalClosesAndDeletesOnlyAddressedPortal(t *testing.T) 
 		nodes[filepath.Base(dir)] = node
 		return node
 	})
-	for _, config := range []Config{
-		{ID: testPortalID, Name: "hermes", Port: 8787},
-		{ID: secondPortalID, Name: "atlas", Port: 8788},
-	} {
-		if err := runtime.Start(context.Background(), config, func(Event) {}); err != nil {
-			t.Fatalf("Start(%s): %v", config.ID, err)
-		}
+	configs := []Config{
+		{ID: testPortalID, Name: "hermes", Port: 8787, DesiredState: DesiredStateEnabled},
+		{ID: secondPortalID, Name: "atlas", Port: 8788, DesiredState: DesiredStateEnabled},
+	}
+	if _, err := runtime.Reconcile(context.Background(), configs, func(Event) {}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	for _, config := range configs {
 		if err := os.MkdirAll(filepath.Join(root, config.ID), 0o700); err != nil {
 			t.Fatal(err)
 		}
@@ -144,7 +440,7 @@ func TestCleanupWaitsForStartBeforeDeletingAnyPortalState(t *testing.T) {
 	}
 	startDone := make(chan error, 1)
 	go func() {
-		startDone <- runtime.Start(context.Background(), Config{ID: testPortalID, Name: "hermes", Port: 8787}, func(Event) {})
+		startDone <- reconcileOne(runtime, Config{ID: testPortalID, Name: "hermes", Port: 8787}, func(Event) {})
 	}()
 	<-blocked.startEntered
 	cleanupDone := make(chan error, 1)
@@ -175,7 +471,7 @@ func TestRuntimeUsesUUIDStateDirectoryAndStableIdentity(t *testing.T) {
 
 	for range 2 {
 		runtime := NewRuntime(root, factory.New)
-		if err := runtime.Start(context.Background(), config, func(Event) {}); err != nil {
+		if err := reconcileOne(runtime, config, func(Event) {}); err != nil {
 			t.Fatalf("Start: %v", err)
 		}
 		if err := runtime.Close(); err != nil {
@@ -229,7 +525,7 @@ func TestRuntimeMapsStructuredStatus(t *testing.T) {
 			}
 			var events []Event
 			runtime := NewRuntime(t.TempDir(), factory.New)
-			if err := runtime.Start(context.Background(), Config{ID: testPortalID, Name: "hermes", Port: 8787}, func(event Event) {
+			if err := reconcileOne(runtime, Config{ID: testPortalID, Name: "hermes", Port: 8787}, func(event Event) {
 				events = append(events, event)
 			}); err != nil {
 				t.Fatalf("Start: %v", err)
@@ -270,7 +566,7 @@ func TestAuthenticateEmitsTransientURLFromFreshNotification(t *testing.T) {
 	factory := newFakeFactory()
 	events := make(chan Event, 8)
 	runtime := NewRuntime(t.TempDir(), factory.New)
-	if err := runtime.Start(context.Background(), Config{ID: testPortalID, Name: "hermes", Port: 8787}, func(event Event) {
+	if err := reconcileOne(runtime, Config{ID: testPortalID, Name: "hermes", Port: 8787}, func(event Event) {
 		events <- event
 	}); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -300,7 +596,7 @@ func TestStartAndCloseAreSerialized(t *testing.T) {
 	runtime := NewRuntime(t.TempDir(), factory.New)
 	startDone := make(chan error, 1)
 	go func() {
-		startDone <- runtime.Start(context.Background(), Config{ID: testPortalID, Name: "hermes", Port: 8787}, func(Event) {})
+		startDone <- reconcileOne(runtime, Config{ID: testPortalID, Name: "hermes", Port: 8787}, func(Event) {})
 	}()
 	<-factory.node.startEntered
 	closeDone := make(chan error, 1)
@@ -331,7 +627,7 @@ func TestOnlineRuntimeListensTLSAndClosesListenerBeforeNode(t *testing.T) {
 		CertDomains:  []string{"hermes.example.ts.net"},
 	}
 	runtime := NewRuntime(t.TempDir(), factory.New)
-	if err := runtime.Start(context.Background(), Config{ID: testPortalID, Name: "hermes", Port: 8787}, func(Event) {}); err != nil {
+	if err := reconcileOne(runtime, Config{ID: testPortalID, Name: "hermes", Port: 8787}, func(Event) {}); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
 	if factory.node.listenNetwork != "tcp" || factory.node.listenAddress != ":443" {
@@ -353,7 +649,7 @@ func TestRuntimeCloseReturnsListenerFailure(t *testing.T) {
 		CertDomains:  []string{"hermes.example.ts.net"},
 	}
 	runtime := NewRuntime(t.TempDir(), factory.New)
-	if err := runtime.Start(context.Background(), Config{ID: testPortalID, Name: "hermes", Port: 8787}, func(Event) {}); err != nil {
+	if err := reconcileOne(runtime, Config{ID: testPortalID, Name: "hermes", Port: 8787}, func(Event) {}); err != nil {
 		t.Fatal(err)
 	}
 	factory.node.listener.closeErr = errors.New("close failed")
@@ -481,12 +777,24 @@ func newOnlineRuntimeWithLocalApp(t *testing.T, handler http.Handler) (*Runtime,
 	}
 	factory.node.realListener = listener
 	runtime := NewRuntime(t.TempDir(), factory.New)
-	if err := runtime.Start(context.Background(), Config{ID: testPortalID, Name: "hermes", Port: uint16(port)}, func(Event) {}); err != nil {
+	if err := reconcileOne(runtime, Config{ID: testPortalID, Name: "hermes", Port: uint16(port)}, func(Event) {}); err != nil {
 		_ = listener.Close()
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = runtime.Close() })
 	return runtime, "http://" + listener.Addr().String(), factory
+}
+
+func reconcileOne(runtime *Runtime, config Config, emit func(Event)) error {
+	config.DesiredState = DesiredStateEnabled
+	entries, err := runtime.Reconcile(context.Background(), []Config{config}, emit)
+	if err != nil {
+		return err
+	}
+	if len(entries) != 1 || entries[0].Outcome != OutcomeConverged {
+		return errors.New("portal did not converge")
+	}
+	return nil
 }
 
 func waitForSignal(t *testing.T, signal <-chan struct{}, description string) {
@@ -561,6 +869,9 @@ type fakeNode struct {
 	status                    Status
 	nodeID                    string
 	watcher                   *fakeWatcher
+	startErr                  error
+	closeResults              []error
+	closeCalls                int
 	loginRequested            bool
 	startEntered              chan struct{}
 	releaseStart              chan struct{}
@@ -591,7 +902,7 @@ func (n *fakeNode) Start() error {
 	n.mu.Lock()
 	n.startReturned = true
 	n.mu.Unlock()
-	return nil
+	return n.startErr
 }
 
 func (n *fakeNode) Status(context.Context) (Status, error) { return n.status, nil }
@@ -612,6 +923,7 @@ func (n *fakeNode) ListenTLS(network, address string) (net.Listener, error) {
 func (n *fakeNode) Close() error {
 	n.mu.Lock()
 	defer n.mu.Unlock()
+	n.closeCalls++
 	if n.observeClose != nil {
 		n.observeClose()
 	}
@@ -625,6 +937,9 @@ func (n *fakeNode) Close() error {
 			_ = connection.Close()
 		}
 		n.listenerClosedBeforeNode = err != nil
+	}
+	if n.closeCalls <= len(n.closeResults) {
+		return n.closeResults[n.closeCalls-1]
 	}
 	return nil
 }

--- a/helper/internal/protocol/server.go
+++ b/helper/internal/protocol/server.go
@@ -16,12 +16,12 @@ import (
 	"github.com/chrisbanes/portico/helper/internal/portal"
 )
 
-const Version = 1
+const Version = 2
 
 const invalidRequestDiagnostic = "portico-helper: invalid request\n"
 
 type PortalRuntime interface {
-	Start(context.Context, portal.Config, func(portal.Event)) error
+	Reconcile(context.Context, []portal.Config, func(portal.Event)) ([]portal.ReconcileEntry, error)
 	Authenticate(context.Context, string) error
 	CleanupRejectedPortal(string) error
 	Close() error
@@ -67,10 +67,19 @@ type discoverLocalAppsResult struct {
 	Candidates []discovery.Candidate `json:"candidates"`
 }
 
-type startPortalPayload struct {
-	PortalID     string `json:"portalId"`
-	PortalName   string `json:"portalName"`
-	LocalAppPort uint16 `json:"localAppPort"`
+type reconcilePortalPayload struct {
+	PortalID     string              `json:"portalId"`
+	PortalName   string              `json:"portalName"`
+	LocalAppPort uint16              `json:"localAppPort"`
+	DesiredState portal.DesiredState `json:"desiredState"`
+}
+
+type reconcilePortalsPayload struct {
+	Portals *[]reconcilePortalPayload `json:"portals"`
+}
+
+type reconcilePortalsResult struct {
+	Entries []portal.ReconcileEntry `json:"entries"`
 }
 
 type authenticatePortalPayload struct {
@@ -233,28 +242,25 @@ func ServeWithServices(input io.Reader, output, diagnostics io.Writer, services 
 					failOutput()
 				}
 			}()
-		case "startPortal":
-			var payload startPortalPayload
-			if runtime == nil || decodePayload(request.Payload, &payload) != nil {
+		case "reconcilePortals":
+			configs, err := decodeReconcilePortalsPayload(request.Payload)
+			if runtime == nil || err != nil {
 				if writer.write(errorResponse(request.RequestID, "invalidPayload", "invalid portal request")) != nil {
 					return 1
 				}
 				continue
 			}
-			config := portal.Config{ID: strings.ToLower(payload.PortalID), Name: payload.PortalName, Port: payload.LocalAppPort}
-			if err := config.Validate(); err != nil {
+			entries, err := runtime.Reconcile(ctx, configs, emit)
+			if err != nil {
 				if writer.write(errorResponse(request.RequestID, "invalidPayload", "invalid portal request")) != nil {
 					return 1
 				}
 				continue
 			}
-			if err := runtime.Start(ctx, config, emit); err != nil {
-				if writer.write(errorResponse(request.RequestID, "runtimeFailure", "portal runtime failed")) != nil {
-					return 1
-				}
-				continue
-			}
-			if writer.write(response{Version: Version, RequestID: request.RequestID, Result: acceptedResult{Accepted: true}}) != nil {
+			if writer.write(response{
+				Version: Version, RequestID: request.RequestID,
+				Result: reconcilePortalsResult{Entries: entries},
+			}) != nil {
 				return 1
 			}
 		case "authenticatePortal":
@@ -332,6 +338,35 @@ func validatedPortalID(raw string) (string, bool) {
 	portalID := strings.ToLower(raw)
 	err := (portal.Config{ID: portalID, Name: "a", Port: 1}).Validate()
 	return portalID, err == nil
+}
+
+func decodeReconcilePortalsPayload(raw json.RawMessage) ([]portal.Config, error) {
+	var payload reconcilePortalsPayload
+	if err := decodePayload(raw, &payload); err != nil || payload.Portals == nil {
+		return nil, fmt.Errorf("invalid reconcile payload")
+	}
+	configs := make([]portal.Config, 0, len(*payload.Portals))
+	seen := make(map[string]struct{}, len(*payload.Portals))
+	for _, requested := range *payload.Portals {
+		config := portal.Config{
+			ID:           strings.ToLower(requested.PortalID),
+			Name:         requested.PortalName,
+			Port:         requested.LocalAppPort,
+			DesiredState: requested.DesiredState,
+		}
+		if err := config.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid reconcile payload")
+		}
+		if config.DesiredState != portal.DesiredStateEnabled && config.DesiredState != portal.DesiredStateStopped {
+			return nil, fmt.Errorf("invalid reconcile payload")
+		}
+		if _, exists := seen[config.ID]; exists {
+			return nil, fmt.Errorf("invalid reconcile payload")
+		}
+		seen[config.ID] = struct{}{}
+		configs = append(configs, config)
+	}
+	return configs, nil
 }
 
 func canonicalCandidates(candidates []discovery.Candidate) []discovery.Candidate {

--- a/helper/internal/protocol/server_test.go
+++ b/helper/internal/protocol/server_test.go
@@ -15,6 +15,34 @@ import (
 	"github.com/chrisbanes/portico/helper/internal/portal"
 )
 
+func TestServeReconcilesLiteralProtocolVersionTwoSnapshot(t *testing.T) {
+	runtime := &fakeRuntime{reconcileEntries: []portal.ReconcileEntry{
+		{PortalID: "5ea74329-3144-4ba2-925f-138d14d61fcc", Outcome: portal.OutcomeConverged},
+		{PortalID: "9f55ca93-d7b3-4eab-a871-310ea576005a", Outcome: portal.OutcomeStartFailed},
+	}}
+	input := bytes.NewBufferString(
+		`{"version":2,"requestId":"reconcile-1","command":"reconcilePortals","payload":{"portals":[` +
+			`{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","portalName":"hermes","localAppPort":8787,"desiredState":"enabled"},` +
+			`{"portalId":"5EA74329-3144-4BA2-925F-138D14D61FCC","portalName":"atlas","localAppPort":8788,"desiredState":"stopped"}` +
+			`]}}` + "\n",
+	)
+	var output bytes.Buffer
+	var diagnostics bytes.Buffer
+
+	exitCode := ServeWithRuntime(input, &output, &diagnostics, runtime)
+
+	if exitCode != 0 || diagnostics.Len() != 0 {
+		t.Fatalf("ServeWithRuntime = (exit %d, diagnostics %q), want success", exitCode, diagnostics.String())
+	}
+	if len(runtime.reconciled) != 2 || runtime.reconciled[0].ID != "9f55ca93-d7b3-4eab-a871-310ea576005a" || runtime.reconciled[1].DesiredState != portal.DesiredStateStopped {
+		t.Fatalf("reconciled = %+v, want normalized complete snapshot", runtime.reconciled)
+	}
+	const want = `{"version":2,"requestId":"reconcile-1","result":{"entries":[{"portalId":"5ea74329-3144-4ba2-925f-138d14d61fcc","outcome":"converged"},{"portalId":"9f55ca93-d7b3-4eab-a871-310ea576005a","outcome":"startFailed"}]}}` + "\n"
+	if output.String() != want {
+		t.Fatalf("output = %q, want exact protocol-v2 result %q", output.String(), want)
+	}
+}
+
 func TestDiscoverLocalAppsReturnsOnlyStableSanitizedCandidates(t *testing.T) {
 	discoverer := fakeDiscoverer{candidates: []discovery.Candidate{
 		{LocalAppPort: 9000, ProcessLabel: "hermes", SuggestedPortalName: "hermes"},
@@ -22,7 +50,7 @@ func TestDiscoverLocalAppsReturnsOnlyStableSanitizedCandidates(t *testing.T) {
 		{LocalAppPort: 9000, ProcessLabel: "hermes", SuggestedPortalName: "hermes"},
 		{LocalAppPort: 7000, ProcessLabel: "first", SuggestedPortalName: "first"},
 	}}
-	input := bytes.NewBufferString(`{"version":1,"requestId":"discover-1","command":"discoverLocalApps","payload":{}}` + "\n")
+	input := bytes.NewBufferString(`{"version":2,"requestId":"discover-1","command":"discoverLocalApps","payload":{}}` + "\n")
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
 
@@ -31,7 +59,7 @@ func TestDiscoverLocalAppsReturnsOnlyStableSanitizedCandidates(t *testing.T) {
 	if exitCode != 0 || diagnostics.Len() != 0 {
 		t.Fatalf("ServeWithServices = (exit %d, diagnostics %q), want success", exitCode, diagnostics.String())
 	}
-	const want = `{"version":1,"requestId":"discover-1","result":{"candidates":[{"localAppPort":7000,"processLabel":"first","suggestedPortalName":"first"},{"localAppPort":8000,"processLabel":"atlas","suggestedPortalName":"atlas"},{"localAppPort":9000,"processLabel":"hermes","suggestedPortalName":"hermes"}]}}` + "\n"
+	const want = `{"version":2,"requestId":"discover-1","result":{"candidates":[{"localAppPort":7000,"processLabel":"first","suggestedPortalName":"first"},{"localAppPort":8000,"processLabel":"atlas","suggestedPortalName":"atlas"},{"localAppPort":9000,"processLabel":"hermes","suggestedPortalName":"hermes"}]}}` + "\n"
 	if output.String() != want {
 		t.Fatalf("output = %q, want %q", output.String(), want)
 	}
@@ -42,13 +70,13 @@ func TestDiscoverLocalAppsCollapsesDisagreeingDuplicateOwners(t *testing.T) {
 		{LocalAppPort: 8787, ProcessLabel: "python3", SuggestedPortalName: "hermes"},
 		{LocalAppPort: 8787, ProcessLabel: "node", SuggestedPortalName: "atlas"},
 	}}
-	input := bytes.NewBufferString(`{"version":1,"requestId":"discover-1","command":"discoverLocalApps","payload":{}}` + "\n")
+	input := bytes.NewBufferString(`{"version":2,"requestId":"discover-1","command":"discoverLocalApps","payload":{}}` + "\n")
 	var output bytes.Buffer
 
 	if exitCode := ServeWithServices(input, &output, &bytes.Buffer{}, Services{LocalAppDiscoverer: discoverer}); exitCode != 0 {
 		t.Fatalf("ServeWithServices exit code = %d, want success", exitCode)
 	}
-	const want = `{"version":1,"requestId":"discover-1","result":{"candidates":[{"localAppPort":8787,"processLabel":"Port 8787"}]}}` + "\n"
+	const want = `{"version":2,"requestId":"discover-1","result":{"candidates":[{"localAppPort":8787,"processLabel":"Port 8787"}]}}` + "\n"
 	if output.String() != want {
 		t.Fatalf("output = %q, want %q", output.String(), want)
 	}
@@ -56,7 +84,7 @@ func TestDiscoverLocalAppsCollapsesDisagreeingDuplicateOwners(t *testing.T) {
 
 func TestDiscoverLocalAppsRequiresEmptyPayload(t *testing.T) {
 	const secret = "do-not-copy"
-	input := bytes.NewBufferString(`{"version":1,"requestId":"discover-1","command":"discoverLocalApps","payload":{"unexpected":"` + secret + `"}}` + "\n")
+	input := bytes.NewBufferString(`{"version":2,"requestId":"discover-1","command":"discoverLocalApps","payload":{"unexpected":"` + secret + `"}}` + "\n")
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
 
@@ -72,7 +100,7 @@ func TestDiscoverLocalAppsRequiresEmptyPayload(t *testing.T) {
 
 func TestDiscoverLocalAppsReturnsFixedSecretFreeFailure(t *testing.T) {
 	const secret = "token=do-not-copy"
-	input := bytes.NewBufferString(`{"version":1,"requestId":"discover-1","command":"discoverLocalApps","payload":{}}` + "\n")
+	input := bytes.NewBufferString(`{"version":2,"requestId":"discover-1","command":"discoverLocalApps","payload":{}}` + "\n")
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
 
@@ -81,7 +109,7 @@ func TestDiscoverLocalAppsReturnsFixedSecretFreeFailure(t *testing.T) {
 	if exitCode != 0 || diagnostics.Len() != 0 {
 		t.Fatalf("ServeWithServices = (exit %d, diagnostics %q), want correlated failure", exitCode, diagnostics.String())
 	}
-	const want = `{"version":1,"requestId":"discover-1","error":{"code":"discoveryFailure","message":"local app discovery failed"}}` + "\n"
+	const want = `{"version":2,"requestId":"discover-1","error":{"code":"discoveryFailure","message":"local app discovery failed"}}` + "\n"
 	if output.String() != want {
 		t.Fatalf("output = %q, want %q", output.String(), want)
 	}
@@ -103,10 +131,10 @@ func TestDiscoverLocalAppsCancelsBeforeRuntimeCloseAndShutdownAcknowledgement(t 
 		})
 	}()
 
-	_, _ = io.WriteString(input, `{"version":1,"requestId":"discover-1","command":"discoverLocalApps","payload":{}}`+"\n")
+	_, _ = io.WriteString(input, `{"version":2,"requestId":"discover-1","command":"discoverLocalApps","payload":{}}`+"\n")
 	<-discoverer.started
 	go func() {
-		_, _ = io.WriteString(input, `{"version":1,"requestId":"shutdown-1","command":"shutdown","payload":{}}`+"\n")
+		_, _ = io.WriteString(input, `{"version":2,"requestId":"shutdown-1","command":"shutdown","payload":{}}`+"\n")
 		_ = input.Close()
 	}()
 
@@ -116,14 +144,14 @@ func TestDiscoverLocalAppsCancelsBeforeRuntimeCloseAndShutdownAcknowledgement(t 
 	if !runtime.closedAfterDiscoveryCancellation {
 		t.Fatal("runtime closed before in-flight discovery observed cancellation")
 	}
-	const want = `{"version":1,"requestId":"shutdown-1","result":{"accepted":true}}` + "\n"
+	const want = `{"version":2,"requestId":"shutdown-1","result":{"accepted":true}}` + "\n"
 	if output.String() != want || diagnostics.Len() != 0 {
 		t.Fatalf("ServeWithServices = (output %q, diagnostics %q), want only post-close shutdown acknowledgement", output.String(), diagnostics.String())
 	}
 }
 
 func TestDiscoverLocalAppsFailsServeWhenResponseCannotBeWritten(t *testing.T) {
-	input := bytes.NewBufferString(`{"version":1,"requestId":"discover-1","command":"discoverLocalApps","payload":{}}` + "\n")
+	input := bytes.NewBufferString(`{"version":2,"requestId":"discover-1","command":"discoverLocalApps","payload":{}}` + "\n")
 
 	exitCode := ServeWithServices(input, errorWriter{}, &bytes.Buffer{}, Services{LocalAppDiscoverer: fakeDiscoverer{}})
 
@@ -166,8 +194,8 @@ type errorWriter struct{}
 
 func (errorWriter) Write([]byte) (int, error) { return 0, errors.New("write failed") }
 
-func (*shutdownOrderingRuntime) Start(context.Context, portal.Config, func(portal.Event)) error {
-	return nil
+func (*shutdownOrderingRuntime) Reconcile(context.Context, []portal.Config, func(portal.Event)) ([]portal.ReconcileEntry, error) {
+	return []portal.ReconcileEntry{}, nil
 }
 
 func (*shutdownOrderingRuntime) Authenticate(context.Context, string) error { return nil }
@@ -184,7 +212,7 @@ func (r *shutdownOrderingRuntime) Close() error {
 }
 
 func TestServeCorrelatesHandshakeResponse(t *testing.T) {
-	input := bytes.NewBufferString(`{"version":1,"requestId":"request-1","command":"handshake","payload":{}}` + "\n")
+	input := bytes.NewBufferString(`{"version":2,"requestId":"request-1","command":"handshake","payload":{}}` + "\n")
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
 
@@ -201,18 +229,20 @@ func TestServeCorrelatesHandshakeResponse(t *testing.T) {
 	if err := json.NewDecoder(&output).Decode(&response); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if response.Version != 1 || response.RequestID != "request-1" || string(response.Result) != `{"protocolVersion":1}` {
-		t.Fatalf("response = %+v, want correlated version-one handshake", response)
+	if response.Version != 2 || response.RequestID != "request-1" || string(response.Result) != `{"protocolVersion":2}` {
+		t.Fatalf("response = %+v, want correlated version-two handshake", response)
 	}
 	if diagnostics.Len() != 0 {
 		t.Fatalf("diagnostics = %q, want empty", diagnostics.String())
 	}
 }
 
-func TestServeStartsPortalAndSerializesStructuredStatusEvent(t *testing.T) {
-	runtime := &fakeRuntime{}
+func TestServeReconciliationSerializesStructuredStatusEvent(t *testing.T) {
+	runtime := &fakeRuntime{emitStatus: true, reconcileEntries: []portal.ReconcileEntry{{
+		PortalID: "9f55ca93-d7b3-4eab-a871-310ea576005a", Outcome: portal.OutcomeConverged,
+	}}}
 	input := bytes.NewBufferString(
-		`{"version":1,"requestId":"start-1","command":"startPortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","portalName":"hermes","localAppPort":8787}}` + "\n",
+		`{"version":2,"requestId":"reconcile-1","command":"reconcilePortals","payload":{"portals":[{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","portalName":"hermes","localAppPort":8787,"desiredState":"enabled"}]}}` + "\n",
 	)
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
@@ -221,9 +251,6 @@ func TestServeStartsPortalAndSerializesStructuredStatusEvent(t *testing.T) {
 
 	if exitCode != 0 || diagnostics.Len() != 0 {
 		t.Fatalf("ServeWithRuntime = (exit %d, diagnostics %q), want success", exitCode, diagnostics.String())
-	}
-	if runtime.started.ID != "9f55ca93-d7b3-4eab-a871-310ea576005a" || runtime.started.Name != "hermes" || runtime.started.Port != 8787 {
-		t.Fatalf("started = %+v, want normalized typed configuration", runtime.started)
 	}
 	lines := strings.Split(strings.TrimSpace(output.String()), "\n")
 	if len(lines) != 2 {
@@ -240,17 +267,19 @@ func TestServeStartsPortalAndSerializesStructuredStatusEvent(t *testing.T) {
 	if payload["tailnetName"] != "opaque-identity-do-not-display" || payload["magicDNSSuffix"] != "example.ts.net" {
 		t.Fatalf("payload = %+v, want exact identity and separate display suffix", payload)
 	}
-	const wantResponse = `{"version":1,"requestId":"start-1","result":{"accepted":true}}`
+	const wantResponse = `{"version":2,"requestId":"reconcile-1","result":{"entries":[{"portalId":"9f55ca93-d7b3-4eab-a871-310ea576005a","outcome":"converged"}]}}`
 	if lines[1] != wantResponse {
 		t.Fatalf("response = %q, want %q", lines[1], wantResponse)
 	}
 }
 
 func TestServeAuthenticatesCorrelatedPortalAndEmitsTransientURL(t *testing.T) {
-	runtime := &fakeRuntime{}
+	runtime := &fakeRuntime{reconcileEntries: []portal.ReconcileEntry{{
+		PortalID: "9f55ca93-d7b3-4eab-a871-310ea576005a", Outcome: portal.OutcomeConverged,
+	}}}
 	input := bytes.NewBufferString(
-		`{"version":1,"requestId":"start-1","command":"startPortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","portalName":"hermes","localAppPort":8787}}` + "\n" +
-			`{"version":1,"requestId":"auth-1","command":"authenticatePortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A"}}` + "\n",
+		`{"version":2,"requestId":"reconcile-1","command":"reconcilePortals","payload":{"portals":[{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","portalName":"hermes","localAppPort":8787,"desiredState":"enabled"}]}}` + "\n" +
+			`{"version":2,"requestId":"auth-1","command":"authenticatePortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A"}}` + "\n",
 	)
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
@@ -271,7 +300,7 @@ func TestServeAuthenticatesCorrelatedPortalAndEmitsTransientURL(t *testing.T) {
 func TestServeCleansUpOnlyCorrelatedRejectedPortal(t *testing.T) {
 	runtime := &fakeRuntime{}
 	input := bytes.NewBufferString(
-		`{"version":1,"requestId":"cleanup-1","command":"cleanupRejectedPortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A"}}` + "\n",
+		`{"version":2,"requestId":"cleanup-1","command":"cleanupRejectedPortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A"}}` + "\n",
 	)
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
@@ -281,55 +310,60 @@ func TestServeCleansUpOnlyCorrelatedRejectedPortal(t *testing.T) {
 	if exitCode != 0 || diagnostics.Len() != 0 || runtime.cleaned != "9f55ca93-d7b3-4eab-a871-310ea576005a" {
 		t.Fatalf("ServeWithRuntime = (exit %d, cleaned %q, diagnostics %q), want correlated cleanup", exitCode, runtime.cleaned, diagnostics.String())
 	}
-	const want = `{"version":1,"requestId":"cleanup-1","result":{"accepted":true}}` + "\n"
+	const want = `{"version":2,"requestId":"cleanup-1","result":{"accepted":true}}` + "\n"
 	if output.String() != want {
 		t.Fatalf("output = %q, want %q", output.String(), want)
 	}
 }
 
-func TestServeRejectsInvalidPortalPayloadWithoutLeakingIt(t *testing.T) {
-	const secret = "https://login.tailscale.com/a/do-not-copy"
-	input := bytes.NewBufferString(
-		`{"version":1,"requestId":"start-1","command":"startPortal","payload":{"portalId":"../` + secret + `","portalName":"hermes","localAppPort":8787}}` + "\n",
-	)
-	var output bytes.Buffer
-	var diagnostics bytes.Buffer
-
-	exitCode := ServeWithRuntime(input, &output, &diagnostics, &fakeRuntime{})
-
-	if exitCode != 0 || !strings.Contains(output.String(), `"code":"invalidPayload"`) {
-		t.Fatalf("ServeWithRuntime = (exit %d, output %q), want correlated invalid-payload error", exitCode, output.String())
+func TestServeRejectsInvalidReconciliationWithoutRuntimeMutationOrLeaks(t *testing.T) {
+	const secret = "untrusted-do-not-copy"
+	fixtures := map[string]string{
+		"missing portals": `{}`,
+		"null portals":    `{"portals":null}`,
+		"duplicate uuid": `{"portals":[` +
+			`{"portalId":"9f55ca93-d7b3-4eab-a871-310ea576005a","portalName":"hermes","localAppPort":8787,"desiredState":"enabled"},` +
+			`{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","portalName":"hermes","localAppPort":8787,"desiredState":"stopped"}]}`,
+		"invalid desired state": `{"portals":[{"portalId":"9f55ca93-d7b3-4eab-a871-310ea576005a","portalName":"hermes","localAppPort":8787,"desiredState":"paused"}]}`,
+		"unknown portal field":  `{"portals":[{"portalId":"9f55ca93-d7b3-4eab-a871-310ea576005a","portalName":"hermes","localAppPort":8787,"desiredState":"enabled","url":"` + secret + `"}]}`,
 	}
-	if strings.Contains(output.String(), secret) || strings.Contains(diagnostics.String(), secret) {
-		t.Fatal("invalid submitted value leaked to protocol or diagnostic output")
-	}
-}
-
-func TestServeRejectsDestinationFields(t *testing.T) {
-	for _, field := range []string{"host", "scheme", "path", "url"} {
-		t.Run(field, func(t *testing.T) {
-			const secret = "untrusted-destination-do-not-copy"
-			input := bytes.NewBufferString(
-				`{"version":1,"requestId":"start-1","command":"startPortal","payload":{"portalId":"9f55ca93-d7b3-4eab-a871-310ea576005a","portalName":"hermes","localAppPort":8787,"` + field + `":"` + secret + `"}}` + "\n",
-			)
+	for name, payload := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			runtime := &fakeRuntime{}
+			input := bytes.NewBufferString(`{"version":2,"requestId":"reconcile-1","command":"reconcilePortals","payload":` + payload + `}` + "\n")
 			var output bytes.Buffer
 			var diagnostics bytes.Buffer
 
-			exitCode := ServeWithRuntime(input, &output, &diagnostics, &fakeRuntime{})
+			exitCode := ServeWithRuntime(input, &output, &diagnostics, runtime)
 
-			if exitCode != 0 || !strings.Contains(output.String(), `"code":"invalidPayload"`) {
-				t.Fatalf("ServeWithRuntime = (exit %d, output %q), want invalid-payload response", exitCode, output.String())
+			if exitCode != 0 || !strings.Contains(output.String(), `"code":"invalidPayload"`) || len(runtime.reconciled) != 0 {
+				t.Fatalf("ServeWithRuntime = (exit %d, output %q, reconciled %+v), want zero-call invalid payload", exitCode, output.String(), runtime.reconciled)
 			}
 			if strings.Contains(output.String(), secret) || strings.Contains(diagnostics.String(), secret) {
-				t.Fatal("untrusted destination leaked to protocol or diagnostic output")
+				t.Fatal("invalid submitted value leaked to protocol or diagnostic output")
 			}
 		})
 	}
 }
 
+func TestServeRejectsImperativeStartPortalInProtocolVersionTwo(t *testing.T) {
+	input := bytes.NewBufferString(
+		`{"version":2,"requestId":"start-1","command":"startPortal","payload":{"portalId":"9f55ca93-d7b3-4eab-a871-310ea576005a","portalName":"hermes","localAppPort":8787}}` + "\n",
+	)
+	var output bytes.Buffer
+
+	if exitCode := ServeWithRuntime(input, &output, &bytes.Buffer{}, &fakeRuntime{}); exitCode != 0 {
+		t.Fatalf("ServeWithRuntime exit code = %d", exitCode)
+	}
+	const want = `{"version":2,"requestId":"start-1","error":{"code":"unknownCommand","message":"unsupported command"}}` + "\n"
+	if output.String() != want {
+		t.Fatalf("output = %q, want protocol-v1 lifecycle rejection", output.String())
+	}
+}
+
 func TestServeClosesRuntimeOnShutdown(t *testing.T) {
 	runtime := &fakeRuntime{}
-	input := bytes.NewBufferString(`{"version":1,"requestId":"shutdown-1","command":"shutdown","payload":{}}` + "\n")
+	input := bytes.NewBufferString(`{"version":2,"requestId":"shutdown-1","command":"shutdown","payload":{}}` + "\n")
 	var output bytes.Buffer
 
 	if exitCode := ServeWithRuntime(input, &output, &bytes.Buffer{}, runtime); exitCode != 0 || !runtime.closed {
@@ -339,7 +373,7 @@ func TestServeClosesRuntimeOnShutdown(t *testing.T) {
 
 func TestServeAcknowledgesShutdownAfterRuntimeCloseCompletes(t *testing.T) {
 	runtime := &fakeRuntime{closeEntered: make(chan struct{}), releaseClose: make(chan struct{})}
-	input := bytes.NewBufferString(`{"version":1,"requestId":"shutdown-1","command":"shutdown","payload":{}}` + "\n")
+	input := bytes.NewBufferString(`{"version":2,"requestId":"shutdown-1","command":"shutdown","payload":{}}` + "\n")
 	var output bytes.Buffer
 	done := make(chan int, 1)
 	go func() { done <- ServeWithRuntime(input, &output, &bytes.Buffer{}, runtime) }()
@@ -358,24 +392,28 @@ func TestServeAcknowledgesShutdownAfterRuntimeCloseCompletes(t *testing.T) {
 }
 
 type fakeRuntime struct {
-	started       portal.Config
-	authenticated string
-	cleaned       string
-	closed        bool
-	emit          func(portal.Event)
-	closeEntered  chan struct{}
-	releaseClose  chan struct{}
-	closeOnce     sync.Once
+	reconciled       []portal.Config
+	reconcileEntries []portal.ReconcileEntry
+	emitStatus       bool
+	authenticated    string
+	cleaned          string
+	closed           bool
+	emit             func(portal.Event)
+	closeEntered     chan struct{}
+	releaseClose     chan struct{}
+	closeOnce        sync.Once
 }
 
-func (r *fakeRuntime) Start(_ context.Context, config portal.Config, emit func(portal.Event)) error {
-	r.started = config
+func (r *fakeRuntime) Reconcile(_ context.Context, configs []portal.Config, emit func(portal.Event)) ([]portal.ReconcileEntry, error) {
+	r.reconciled = append([]portal.Config(nil), configs...)
 	r.emit = emit
-	emit(portal.Event{PortalID: config.ID, Status: &portal.StatusEvent{
-		State: portal.StateConnecting, Addresses: []string{},
-		TailnetName: "opaque-identity-do-not-display", MagicDNSSuffix: "example.ts.net",
-	}})
-	return nil
+	if r.emitStatus && len(configs) > 0 {
+		emit(portal.Event{PortalID: configs[0].ID, Status: &portal.StatusEvent{
+			State: portal.StateConnecting, Addresses: []string{},
+			TailnetName: "opaque-identity-do-not-display", MagicDNSSuffix: "example.ts.net",
+		}})
+	}
+	return append([]portal.ReconcileEntry(nil), r.reconcileEntries...), nil
 }
 
 func (r *fakeRuntime) Authenticate(_ context.Context, portalID string) error {
@@ -404,8 +442,8 @@ func (r *fakeRuntime) Close() error {
 
 func TestServeAcknowledgesShutdownAndStops(t *testing.T) {
 	input := bytes.NewBufferString(
-		`{"version":1,"requestId":"shutdown-1","command":"shutdown","payload":{}}` + "\n" +
-			`{"version":1,"requestId":"ignored","command":"handshake","payload":{}}` + "\n",
+		`{"version":2,"requestId":"shutdown-1","command":"shutdown","payload":{}}` + "\n" +
+			`{"version":2,"requestId":"ignored","command":"handshake","payload":{}}` + "\n",
 	)
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
@@ -415,7 +453,7 @@ func TestServeAcknowledgesShutdownAndStops(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("Serve() exit code = %d, want 0", exitCode)
 	}
-	const want = "{\"version\":1,\"requestId\":\"shutdown-1\",\"result\":{\"accepted\":true}}\n"
+	const want = "{\"version\":2,\"requestId\":\"shutdown-1\",\"result\":{\"accepted\":true}}\n"
 	if output.String() != want {
 		t.Fatalf("output = %q, want %q", output.String(), want)
 	}
@@ -425,7 +463,7 @@ func TestServeAcknowledgesShutdownAndStops(t *testing.T) {
 }
 
 func TestServeReturnsCorrelatedErrorForUnknownCommand(t *testing.T) {
-	input := bytes.NewBufferString(`{"version":1,"requestId":"unknown-1","command":"surprise","payload":{}}` + "\n")
+	input := bytes.NewBufferString(`{"version":2,"requestId":"unknown-1","command":"surprise","payload":{}}` + "\n")
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
 
@@ -434,7 +472,7 @@ func TestServeReturnsCorrelatedErrorForUnknownCommand(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("Serve() exit code = %d, want 0", exitCode)
 	}
-	const want = "{\"version\":1,\"requestId\":\"unknown-1\",\"error\":{\"code\":\"unknownCommand\",\"message\":\"unsupported command\"}}\n"
+	const want = "{\"version\":2,\"requestId\":\"unknown-1\",\"error\":{\"code\":\"unknownCommand\",\"message\":\"unsupported command\"}}\n"
 	if output.String() != want {
 		t.Fatalf("output = %q, want %q", output.String(), want)
 	}
@@ -444,7 +482,7 @@ func TestServeReturnsCorrelatedErrorForUnknownCommand(t *testing.T) {
 }
 
 func TestServeReturnsCorrelatedErrorForUnsupportedVersion(t *testing.T) {
-	input := bytes.NewBufferString(`{"version":2,"requestId":"version-1","command":"handshake","payload":{}}` + "\n")
+	input := bytes.NewBufferString(`{"version":1,"requestId":"version-1","command":"handshake","payload":{}}` + "\n")
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
 
@@ -453,7 +491,7 @@ func TestServeReturnsCorrelatedErrorForUnsupportedVersion(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("Serve() exit code = %d, want 0", exitCode)
 	}
-	const want = "{\"version\":1,\"requestId\":\"version-1\",\"error\":{\"code\":\"unsupportedVersion\",\"message\":\"unsupported protocol version\"}}\n"
+	const want = "{\"version\":2,\"requestId\":\"version-1\",\"error\":{\"code\":\"unsupportedVersion\",\"message\":\"unsupported protocol version\"}}\n"
 	if output.String() != want {
 		t.Fatalf("output = %q, want %q", output.String(), want)
 	}
@@ -464,7 +502,7 @@ func TestServeReturnsCorrelatedErrorForUnsupportedVersion(t *testing.T) {
 
 func TestServeRejectsMalformedInputWithoutLeakingIt(t *testing.T) {
 	const secret = "token=do-not-copy"
-	input := bytes.NewBufferString(`{"version":1,"requestId":"` + secret + `"` + "\n")
+	input := bytes.NewBufferString(`{"version":2,"requestId":"` + secret + `"` + "\n")
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
 
@@ -486,7 +524,7 @@ func TestServeRejectsMalformedInputWithoutLeakingIt(t *testing.T) {
 }
 
 func TestServeRejectsTrailingContentAfterRequest(t *testing.T) {
-	input := bytes.NewBufferString(`{"version":1,"requestId":"request-1","command":"handshake","payload":{}} trailing` + "\n")
+	input := bytes.NewBufferString(`{"version":2,"requestId":"request-1","command":"handshake","payload":{}} trailing` + "\n")
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
 
@@ -500,12 +538,12 @@ func TestServeRejectsTrailingContentAfterRequest(t *testing.T) {
 func TestServeRejectsStructurallyInvalidRequests(t *testing.T) {
 	fixtures := map[string]string{
 		"missing version":    `{"requestId":"request-1","command":"handshake","payload":{}}`,
-		"missing request ID": `{"version":1,"command":"handshake","payload":{}}`,
-		"missing command":    `{"version":1,"requestId":"request-1","payload":{}}`,
-		"missing payload":    `{"version":1,"requestId":"request-1","command":"handshake"}`,
-		"non-object payload": `{"version":1,"requestId":"request-1","command":"handshake","payload":[]}`,
-		"non-empty payload":  `{"version":1,"requestId":"request-1","command":"handshake","payload":{"unexpected":true}}`,
-		"unknown field":      `{"version":1,"requestId":"request-1","command":"handshake","payload":{},"extra":true}`,
+		"missing request ID": `{"version":2,"command":"handshake","payload":{}}`,
+		"missing command":    `{"version":2,"requestId":"request-1","payload":{}}`,
+		"missing payload":    `{"version":2,"requestId":"request-1","command":"handshake"}`,
+		"non-object payload": `{"version":2,"requestId":"request-1","command":"handshake","payload":[]}`,
+		"non-empty payload":  `{"version":2,"requestId":"request-1","command":"handshake","payload":{"unexpected":true}}`,
+		"unknown field":      `{"version":2,"requestId":"request-1","command":"handshake","payload":{},"extra":true}`,
 	}
 
 	for name, fixture := range fixtures {


### PR DESCRIPTION
Summary:
- persist Enabled and Stopped desired state in the version-2 installation record
- replace imperative startup IPC with strict protocol-v2 full-snapshot reconciliation
- preserve Portal identity and TLS listeners across live Local App port cutovers
- coalesce native edits and expose Start, Stop, and port controls in the menu-bar UI

Validation:
- xcodebuild full suite: 53 passed
- go test ./...
- go test -race ./internal/portal ./internal/protocol
- go build ./cmd/portico-helper

Closes #6