### PR TITLE
Recover helper and expose safe diagnostics

### DIFF
--- a/Portico/AppDelegate.swift
+++ b/Portico/AppDelegate.swift
@@ -10,15 +10,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             .appendingPathComponent("Portico", isDirectory: true)
         let helperURL = Bundle.main.bundleURL
             .appendingPathComponent("Contents/Helpers/portico-helper", isDirectory: false)
+        let scheduler = MainQueueScheduler()
+        let history = DiagnosticHistory()
         let supervisor = HelperSupervisor(
             helperURL: helperURL,
             stateRootURL: applicationRoot.appendingPathComponent("tsnet", isDirectory: true),
-            launcher: ProcessHelperLauncher()
+            launcher: ProcessHelperLauncher(),
+            scheduler: scheduler,
+            history: history
         )
         self.supervisor = supervisor
         self.portalController = PortalController(
             store: PortalStore(rootURL: applicationRoot),
             helper: supervisor,
+            reachability: LocalAppReachability(probe: LoopbackTCPProbe(), scheduler: scheduler),
+            history: history,
             openURL: { NSWorkspace.shared.open($0) }
         )
         super.init()

--- a/Portico/Diagnostics.swift
+++ b/Portico/Diagnostics.swift
@@ -1,0 +1,203 @@
+import Foundation
+import Darwin
+
+enum DiagnosticEvent: Equatable {
+    case helper(HelperAvailability)
+    case portal(
+        name: String,
+        desired: PortalDesiredState,
+        tailscale: PortalTailscaleState?,
+        reachability: LocalAppReachabilityState,
+        stale: Bool
+    )
+}
+
+struct DiagnosticEntry: Equatable {
+    let timestamp: Date
+    let event: DiagnosticEvent
+}
+
+final class DiagnosticHistory {
+    private(set) var entries: [DiagnosticEntry] = []
+    var onChange: (([DiagnosticEntry]) -> Void)?
+
+    private let dateProvider: () -> Date
+
+    init(dateProvider: @escaping () -> Date = Date.init) {
+        self.dateProvider = dateProvider
+    }
+
+    func record(_ event: DiagnosticEvent) {
+        entries.append(DiagnosticEntry(timestamp: dateProvider(), event: event))
+        if entries.count > 200 {
+            entries.removeFirst(entries.count - 200)
+        }
+        onChange?(entries)
+    }
+}
+
+struct PortalDiagnosticFacts: Equatable {
+    let portalName: String
+    let assignedName: String?
+    let portalURL: URL?
+    let addresses: [String]
+    let magicDNSSuffix: String?
+    let desiredState: PortalDesiredState
+    let tailscaleState: PortalTailscaleState?
+    let reachability: LocalAppReachabilityState
+    let isStale: Bool
+
+}
+
+struct DiagnosticVersions: Equatable {
+    let porticoShort: String?
+    let porticoBuild: String?
+    let helperProtocol: Int
+
+    static var current: DiagnosticVersions {
+        DiagnosticVersions(
+            porticoShort: Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String,
+            porticoBuild: Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String,
+            helperProtocol: helperProtocolVersion
+        )
+    }
+}
+
+enum DiagnosticReportRenderer {
+    static func render(
+        versions: DiagnosticVersions,
+        helper: HelperAvailability,
+        portals: [PortalDiagnosticFacts],
+        history: [DiagnosticEntry]
+    ) -> String {
+        var lines: [String] = []
+        if let short = versions.porticoShort {
+            let build = versions.porticoBuild.map { " (\($0))" } ?? ""
+            lines.append("Portico \(short)\(build)")
+        }
+        lines.append("Helper protocol \(versions.helperProtocol)")
+        lines.append("Helper: \(describeHelper(helper))")
+        lines.append("")
+        lines.append("Portals")
+        for portal in portals.sorted(by: { $0.portalName < $1.portalName }) {
+            lines.append("- Portal Name: \(portal.portalName)")
+            append("  Assigned Name", portal.assignedName, to: &lines)
+            append("  Portal URL", portal.portalURL?.absoluteString, to: &lines)
+            if !portal.addresses.isEmpty {
+                lines.append("  Tailscale IPs: \(portal.addresses.joined(separator: ", "))")
+            }
+            append("  MagicDNS suffix", portal.magicDNSSuffix, to: &lines)
+            lines.append("  Desired: \(portal.desiredState.rawValue)")
+            lines.append("  Tailscale: \(portal.tailscaleState?.rawValue ?? "unknown")")
+            lines.append("  Reachability: \(portal.reachability.rawValue)")
+            lines.append("  Facts: \(portal.isStale ? "stale" : "current")")
+        }
+        lines.append("")
+        lines.append("History")
+        let formatter = ISO8601DateFormatter()
+        for entry in history {
+            lines.append("- \(formatter.string(from: entry.timestamp)) \(describe(entry.event))")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private static func append(_ label: String, _ value: String?, to lines: inout [String]) {
+        if let value, !value.isEmpty {
+            lines.append("\(label): \(value)")
+        }
+    }
+
+    private static func describe(_ event: DiagnosticEvent) -> String {
+        switch event {
+        case let .helper(availability):
+            switch availability {
+            case .connecting: return "Helper connecting"
+            case let .retrying(attempt, delay): return "Helper retry \(attempt) in \(Int(delay))s"
+            case .connected: return "Helper connected"
+            case .failed: return "Helper unavailable"
+            case .shuttingDown: return "Helper shutting down"
+            }
+        case let .portal(name, desired, tailscale, reachability, stale):
+            return "Portal \(name): desired \(desired.rawValue), Tailscale \(tailscale?.rawValue ?? "unknown"), reachability \(reachability.rawValue), facts \(stale ? "stale" : "current")"
+        }
+    }
+
+    private static func describeHelper(_ availability: HelperAvailability) -> String {
+        switch availability {
+        case .connecting: return "connecting"
+        case let .retrying(attempt, delay): return "retry \(attempt) in \(Int(delay))s"
+        case .connected: return "connected"
+        case .failed: return "unavailable"
+        case .shuttingDown: return "shutting down"
+        }
+    }
+}
+
+extension PortalStatusPayload {
+    func sanitizedForDisplay() -> PortalStatusPayload {
+        let safeAssignedName = SafePortalFact.assignedName(assignedName)
+        let safeSuffix = SafePortalFact.magicDNSSuffix(magicDNSSuffix)
+        return PortalStatusPayload(
+            state: state,
+            stableNodeId: nil,
+            assignedName: safeAssignedName,
+            portalURL: SafePortalFact.portalURL(
+                portalURL,
+                assignedName: safeAssignedName,
+                magicDNSSuffix: safeSuffix
+            ),
+            addresses: addresses.filter(SafePortalFact.isIPAddress),
+            magicDNSSuffix: safeSuffix
+        )
+    }
+}
+
+private enum SafePortalFact {
+    static func assignedName(_ value: String?) -> String? {
+        guard let value, isDNSLabel(value) else { return nil }
+        return value
+    }
+
+    static func magicDNSSuffix(_ value: String?) -> String? {
+        guard let value,
+              value.hasSuffix(".ts.net"),
+              value.split(separator: ".", omittingEmptySubsequences: false).allSatisfy({ isDNSLabel(String($0)) })
+        else { return nil }
+        return value
+    }
+
+    static func portalURL(_ value: URL?, assignedName: String?, magicDNSSuffix: String?) -> URL? {
+        guard let value, let assignedName, let magicDNSSuffix,
+              let components = URLComponents(url: value, resolvingAgainstBaseURL: false),
+              components.scheme == "https",
+              components.user == nil,
+              components.password == nil,
+              components.port == nil,
+              components.query == nil,
+              components.fragment == nil,
+              components.path.isEmpty || components.path == "/",
+              components.host?.lowercased() == "\(assignedName).\(magicDNSSuffix)"
+        else { return nil }
+        return value
+    }
+
+    static func isIPAddress(_ value: String) -> Bool {
+        var ipv4 = in_addr()
+        if value.withCString({ inet_pton(AF_INET, $0, &ipv4) }) == 1 {
+            return true
+        }
+        var ipv6 = in6_addr()
+        return value.withCString({ inet_pton(AF_INET6, $0, &ipv6) }) == 1
+    }
+
+    private static func isDNSLabel(_ value: String) -> Bool {
+        guard (1...63).contains(value.utf8.count),
+              value.unicodeScalars.allSatisfy({ $0.isASCII })
+        else { return false }
+        let bytes = Array(value.utf8)
+        let isAlphanumeric: (UInt8) -> Bool = { (48...57).contains($0) || (97...122).contains($0) }
+        return isAlphanumeric(bytes[0])
+            && isAlphanumeric(bytes[bytes.count - 1])
+            && bytes.allSatisfy { isAlphanumeric($0) || $0 == 45 }
+    }
+}

--- a/Portico/HelperSupervisor.swift
+++ b/Portico/HelperSupervisor.swift
@@ -2,8 +2,10 @@ import Foundation
 
 enum HelperAvailability: Equatable {
     case connecting
+    case retrying(attempt: Int, delay: TimeInterval)
     case connected
     case failed
+    case shuttingDown
 }
 
 enum PortalHelperEvent: Equatable {
@@ -21,7 +23,10 @@ enum HelperClientError: Error {
 protocol PortalHelperClient: AnyObject {
     var availability: HelperAvailability { get }
     var onConnected: (() -> Void)? { get set }
+    var onAvailabilityChange: ((HelperAvailability) -> Void)? { get set }
     var onEvent: ((PortalHelperEvent) -> Void)? { get set }
+
+    func retry()
 
     func reconcilePortals(
         _ portals: [PortalConfiguration],
@@ -52,20 +57,35 @@ protocol HelperLaunching {
 
 @MainActor
 final class HelperSupervisor: ObservableObject, PortalHelperClient {
-    @Published private(set) var availability: HelperAvailability = .connecting
+    @Published private(set) var availability: HelperAvailability = .connecting {
+        didSet {
+            guard oldValue != availability else { return }
+            history?.record(.helper(availability))
+            onAvailabilityChange?(availability)
+        }
+    }
     var onConnected: (() -> Void)?
+    var onAvailabilityChange: ((HelperAvailability) -> Void)?
     var onEvent: ((PortalHelperEvent) -> Void)?
 
     private let helperURL: URL
     private let stateRootURL: URL
     private let launcher: HelperLaunching
     private let requestIDProvider: () -> String
+    private let scheduler: PorticoScheduling
+    private let history: DiagnosticHistory?
     private let handshakeTimeout: TimeInterval
     private let shutdownGraceInterval: TimeInterval
     private var process: HelperProcess?
-    private var pendingResponses: [String: (Data?) -> Void] = [:]
-    private var handshakeTimeoutWorkItem: DispatchWorkItem?
-    private var shutdownTimeoutWorkItem: DispatchWorkItem?
+    private var pendingResponses: [String: (Data?) -> Bool] = [:]
+    private var handshakeTimeoutTask: ScheduledTask?
+    private var shutdownTimeoutTask: ScheduledTask?
+    private var retryTask: ScheduledTask?
+    private var stabilityTask: ScheduledTask?
+    private var processGeneration = 0
+    private var reconciliationGeneration = 0
+    private var retryDelayIndex = 0
+    private var failureHandled = false
     private var isShuttingDown = false
     private var isShutdownComplete = false
     private var shutdownCompletions: [() -> Void] = []
@@ -75,6 +95,8 @@ final class HelperSupervisor: ObservableObject, PortalHelperClient {
         stateRootURL: URL = HelperSupervisor.defaultStateRootURL(),
         launcher: HelperLaunching,
         requestIDProvider: @escaping () -> String = { UUID().uuidString },
+        scheduler: PorticoScheduling? = nil,
+        history: DiagnosticHistory? = nil,
         handshakeTimeout: TimeInterval = 3,
         shutdownGraceInterval: TimeInterval = 1
     ) {
@@ -82,38 +104,78 @@ final class HelperSupervisor: ObservableObject, PortalHelperClient {
         self.stateRootURL = stateRootURL
         self.launcher = launcher
         self.requestIDProvider = requestIDProvider
+        self.scheduler = scheduler ?? MainQueueScheduler()
+        self.history = history
         self.handshakeTimeout = handshakeTimeout
         self.shutdownGraceInterval = shutdownGraceInterval
     }
 
     func start() {
+        guard process == nil, retryTask == nil, !isShuttingDown else { return }
+        launch()
+    }
+
+    func retry() {
+        guard availability == .failed, !isShuttingDown else { return }
+        retryTask?.cancel()
+        retryTask = nil
+        stabilityTask?.cancel()
+        stabilityTask = nil
+        handshakeTimeoutTask?.cancel()
+        handshakeTimeoutTask = nil
+        processGeneration += 1
+        reconciliationGeneration += 1
+        failPendingResponses()
+        retryDelayIndex = 0
+        failureHandled = false
+        availability = .connecting
+        guard let process else {
+            launch()
+            return
+        }
+        process.closeInput()
+        if process.isRunning {
+            process.terminate()
+        } else {
+            self.process = nil
+            launch()
+        }
+    }
+
+    private func launch() {
+        guard process == nil, !isShuttingDown else { return }
+        processGeneration += 1
+        let generation = processGeneration
+        failureHandled = false
         availability = .connecting
         do {
             process = try launcher.launch(
                 at: helperURL,
                 arguments: ["--state-root", stateRootURL.path],
-                onLine: { [weak self] data in self?.receive(line: data) },
-                onEOF: { [weak self] in self?.processExited() },
-                onExit: { [weak self] _ in self?.processExited() }
+                onLine: { [weak self] data in self?.receive(line: data, generation: generation) },
+                onEOF: { [weak self] in self?.handleFailure(generation: generation) },
+                onExit: { [weak self] _ in self?.processExited(generation: generation) }
             )
             try sendRequest(command: .handshake, payload: EmptyPayload()) { [weak self] (result: Result<HandshakeResult, Error>) in
                 guard let self else { return }
+                guard generation == self.processGeneration, !self.failureHandled else { return }
                 guard case let .success(handshake) = result,
                       handshake.protocolVersion == helperProtocolVersion
                 else {
-                    self.fail()
+                    self.handleFailure(generation: generation)
                     return
                 }
-                self.handshakeTimeoutWorkItem?.cancel()
-                self.handshakeTimeoutWorkItem = nil
+                self.handshakeTimeoutTask?.cancel()
+                self.handshakeTimeoutTask = nil
                 self.availability = .connected
                 self.onConnected?()
             }
-            let workItem = DispatchWorkItem { [weak self] in self?.fail() }
-            handshakeTimeoutWorkItem = workItem
-            DispatchQueue.main.asyncAfter(deadline: .now() + handshakeTimeout, execute: workItem)
+            handshakeTimeoutTask = scheduler.schedule(after: handshakeTimeout) { [weak self] in
+                self?.handleFailure(generation: generation)
+            }
         } catch {
-            fail()
+            process = nil
+            handleFailure(generation: generation)
         }
     }
 
@@ -137,10 +199,34 @@ final class HelperSupervisor: ObservableObject, PortalHelperClient {
                     )
                 }
         )
+        reconciliationGeneration += 1
+        let requestedReconciliation = reconciliationGeneration
+        let requestedProcess = processGeneration
+        stabilityTask?.cancel()
+        stabilityTask = nil
         do {
-            try sendRequest(command: .reconcilePortals, payload: payload, completion: completion)
+            try sendRequest(command: .reconcilePortals, payload: payload) { [weak self] result in
+                completion(result)
+                guard let self,
+                      requestedProcess == self.processGeneration,
+                      requestedReconciliation == self.reconciliationGeneration,
+                      self.availability == .connected,
+                      case let .success(response) = result,
+                      response.entries.allSatisfy({ $0.outcome == .converged })
+                else { return }
+                self.stabilityTask = self.scheduler.schedule(after: 300) { [weak self] in
+                    guard let self,
+                          requestedProcess == self.processGeneration,
+                          requestedReconciliation == self.reconciliationGeneration,
+                          self.availability == .connected
+                    else { return }
+                    self.retryDelayIndex = 0
+                    self.stabilityTask = nil
+                }
+            }
         } catch {
             completion(.failure(error))
+            handleFailure(generation: requestedProcess)
         }
     }
 
@@ -155,6 +241,7 @@ final class HelperSupervisor: ObservableObject, PortalHelperClient {
             }
         } catch {
             completion(.failure(error))
+            handleFailure(generation: processGeneration)
         }
     }
 
@@ -169,6 +256,7 @@ final class HelperSupervisor: ObservableObject, PortalHelperClient {
             }
         } catch {
             completion(.failure(error))
+            handleFailure(generation: processGeneration)
         }
     }
 
@@ -183,6 +271,7 @@ final class HelperSupervisor: ObservableObject, PortalHelperClient {
             }
         } catch {
             completion(.failure(error))
+            handleFailure(generation: processGeneration)
         }
     }
 
@@ -194,8 +283,13 @@ final class HelperSupervisor: ObservableObject, PortalHelperClient {
         shutdownCompletions.append(completion)
         guard !isShuttingDown else { return }
         isShuttingDown = true
-        handshakeTimeoutWorkItem?.cancel()
-        handshakeTimeoutWorkItem = nil
+        availability = .shuttingDown
+        handshakeTimeoutTask?.cancel()
+        handshakeTimeoutTask = nil
+        retryTask?.cancel()
+        retryTask = nil
+        stabilityTask?.cancel()
+        stabilityTask = nil
 
         guard process?.isRunning == true else {
             finishShutdown()
@@ -204,9 +298,9 @@ final class HelperSupervisor: ObservableObject, PortalHelperClient {
         do {
             try sendWithoutResponse(command: .shutdown, requestID: requestIDProvider(), payload: EmptyPayload())
             process?.closeInput()
-            let workItem = DispatchWorkItem { [weak self] in self?.forceShutdown() }
-            shutdownTimeoutWorkItem = workItem
-            DispatchQueue.main.asyncAfter(deadline: .now() + shutdownGraceInterval, execute: workItem)
+            shutdownTimeoutTask = scheduler.schedule(after: shutdownGraceInterval) { [weak self] in
+                self?.forceShutdown()
+            }
         } catch {
             process?.closeInput()
             process?.terminate()
@@ -214,20 +308,23 @@ final class HelperSupervisor: ObservableObject, PortalHelperClient {
         }
     }
 
-    private func receive(line: Data) {
+    private func receive(line: Data, generation: Int) {
+        guard generation == processGeneration, !failureHandled else { return }
         guard !isShuttingDown else { return }
         guard let envelope = try? JSONDecoder().decode(IncomingHelperEnvelope.self, from: line),
               envelope.version == helperProtocolVersion
         else {
-            fail()
+            handleFailure(generation: generation)
             return
         }
         if let requestID = envelope.requestId {
-            pendingResponses.removeValue(forKey: requestID)?(line)
+            if pendingResponses.removeValue(forKey: requestID)?(line) == false {
+                handleFailure(generation: generation)
+            }
             return
         }
         guard let event = envelope.event else {
-            fail()
+            handleFailure(generation: generation)
             return
         }
         switch event {
@@ -235,7 +332,7 @@ final class HelperSupervisor: ObservableObject, PortalHelperClient {
             guard let message = try? JSONDecoder().decode(HelperEvent<PortalStatusPayload>.self, from: line),
                   message.event == .portalStatus
             else {
-                fail()
+                handleFailure(generation: generation)
                 return
             }
             onEvent?(.status(message.portalId, message.payload))
@@ -243,7 +340,7 @@ final class HelperSupervisor: ObservableObject, PortalHelperClient {
             guard let message = try? JSONDecoder().decode(HelperEvent<AuthenticationURLPayload>.self, from: line),
                   message.event == .authenticationURL
             else {
-                fail()
+                handleFailure(generation: generation)
                 return
             }
             onEvent?(.authenticationURL(message.portalId, message.payload.url))
@@ -263,7 +360,7 @@ final class HelperSupervisor: ObservableObject, PortalHelperClient {
                   response.requestId == requestID
             else {
                 completion(.failure(HelperClientError.protocolFailure))
-                return
+                return false
             }
             if let error = response.error {
                 completion(.failure(HelperClientError.helper(error)))
@@ -271,7 +368,9 @@ final class HelperSupervisor: ObservableObject, PortalHelperClient {
                 completion(.success(result))
             } else {
                 completion(.failure(HelperClientError.protocolFailure))
+                return false
             }
+            return true
         }
         do {
             try sendWithoutResponse(command: command, requestID: requestID, payload: payload)
@@ -290,28 +389,68 @@ final class HelperSupervisor: ObservableObject, PortalHelperClient {
         try process.send(data)
     }
 
-    private func fail() {
-        guard availability != .failed else { return }
-        handshakeTimeoutWorkItem?.cancel()
-        handshakeTimeoutWorkItem = nil
-        availability = .failed
-        let pending = pendingResponses.values
-        pendingResponses.removeAll()
-        pending.forEach { $0(nil) }
-        process?.closeInput()
-        if process?.isRunning == true {
-            process?.terminate()
+    private func handleFailure(generation: Int) {
+        guard generation == processGeneration, !failureHandled, !isShuttingDown else { return }
+        failureHandled = true
+        handshakeTimeoutTask?.cancel()
+        handshakeTimeoutTask = nil
+        stabilityTask?.cancel()
+        stabilityTask = nil
+        reconciliationGeneration += 1
+        availability = .connecting
+        failPendingResponses()
+        guard let process else {
+            scheduleRetry(generation: generation)
+            return
+        }
+        process.closeInput()
+        if process.isRunning {
+            process.terminate()
+        } else {
+            self.process = nil
+            scheduleRetry(generation: generation)
         }
     }
 
-    private func processExited() {
-        if isShuttingDown { finishShutdown() } else { fail() }
+    private func failPendingResponses() {
+        let pending = pendingResponses.values
+        pendingResponses.removeAll()
+        pending.forEach { _ = $0(nil) }
+    }
+
+    private func scheduleRetry(generation: Int) {
+        guard generation == processGeneration, !isShuttingDown else { return }
+        let delays: [TimeInterval] = [1, 2, 4, 8, 16]
+        guard retryDelayIndex < delays.count else {
+            availability = .failed
+            return
+        }
+        let delay = delays[retryDelayIndex]
+        retryDelayIndex += 1
+        availability = .retrying(attempt: retryDelayIndex, delay: delay)
+        retryTask = scheduler.schedule(after: delay) { [weak self] in
+            guard let self, generation == self.processGeneration, !self.isShuttingDown else { return }
+            self.retryTask = nil
+            self.launch()
+        }
+    }
+
+    private func processExited(generation: Int) {
+        guard generation == processGeneration, process != nil else { return }
+        process = nil
+        if isShuttingDown {
+            finishShutdown()
+        } else if failureHandled {
+            scheduleRetry(generation: generation)
+        } else {
+            handleFailure(generation: generation)
+        }
     }
 
     private func finishShutdown() {
         guard !isShutdownComplete else { return }
-        shutdownTimeoutWorkItem?.cancel()
-        shutdownTimeoutWorkItem = nil
+        shutdownTimeoutTask?.cancel()
+        shutdownTimeoutTask = nil
         isShutdownComplete = true
         let completions = shutdownCompletions
         shutdownCompletions.removeAll()

--- a/Portico/LocalAppReachability.swift
+++ b/Portico/LocalAppReachability.swift
@@ -1,0 +1,154 @@
+import Foundation
+import Network
+
+enum LocalAppReachabilityState: String, Equatable {
+    case unknown
+    case reachable
+    case unavailable
+}
+
+protocol LocalAppProbing {
+    func probe(port: UInt16, timeout: TimeInterval, completion: @escaping (Bool) -> Void)
+}
+
+final class LoopbackTCPProbe: LocalAppProbing {
+    func probe(port: UInt16, timeout: TimeInterval, completion: @escaping (Bool) -> Void) {
+        guard port != 0, let endpointPort = NWEndpoint.Port(rawValue: port) else {
+            completion(false)
+            return
+        }
+        let connection = NWConnection(
+            host: NWEndpoint.Host("127.0.0.1"),
+            port: endpointPort,
+            using: .tcp
+        )
+        let queue = DispatchQueue(label: "dev.chrisbanes.portico.reachability")
+        let lock = NSLock()
+        var finished = false
+        var timeoutWorkItem: DispatchWorkItem?
+        let finish: (Bool) -> Void = { reachable in
+            lock.lock()
+            guard !finished else {
+                lock.unlock()
+                return
+            }
+            finished = true
+            lock.unlock()
+            timeoutWorkItem?.cancel()
+            connection.cancel()
+            DispatchQueue.main.async { completion(reachable) }
+        }
+        connection.stateUpdateHandler = { state in
+            switch state {
+            case .ready:
+                finish(true)
+            case .failed, .cancelled:
+                finish(false)
+            default:
+                break
+            }
+        }
+        let workItem = DispatchWorkItem { finish(false) }
+        timeoutWorkItem = workItem
+        queue.asyncAfter(deadline: .now() + timeout, execute: workItem)
+        connection.start(queue: queue)
+    }
+}
+
+@MainActor
+final class LocalAppReachability: ObservableObject {
+    @Published private(set) var states: [UUID: LocalAppReachabilityState] = [:]
+    var onChange: (([UUID: LocalAppReachabilityState]) -> Void)?
+
+    private let probe: LocalAppProbing
+    private let scheduler: PorticoScheduling
+    private var portalPorts: [UUID: UInt16] = [:]
+    private var cycle = 0
+    private var activeRemaining: Set<UUID>?
+    private var pendingCycle: Int?
+    private var periodicTask: ScheduledTask?
+
+    init(probe: LocalAppProbing, scheduler: PorticoScheduling) {
+        self.probe = probe
+        self.scheduler = scheduler
+        schedulePeriodicProbe()
+    }
+
+    func update(portals: [PortalConfiguration]) {
+        let updated = Dictionary(uniqueKeysWithValues: portals
+            .filter { $0.lifecycle == .active }
+            .map { ($0.id, $0.localAppPort) })
+        let previous = portalPorts
+        guard updated != previous else { return }
+        portalPorts = updated
+        states = states.filter { updated[$0.key] != nil }
+        for (id, port) in updated where previous[id] != port || states[id] == nil {
+            states[id] = .unknown
+        }
+        publish()
+        trigger()
+    }
+
+    func refresh() {
+        trigger()
+    }
+
+    func helperRecovered() {
+        trigger()
+    }
+
+    private func trigger() {
+        cycle += 1
+        let requestedCycle = cycle
+        guard activeRemaining == nil else {
+            pendingCycle = requestedCycle
+            return
+        }
+        startBatch(cycle: requestedCycle)
+    }
+
+    private func startBatch(cycle requestedCycle: Int) {
+        let snapshot = portalPorts
+        let ids = Set(snapshot.keys)
+        guard !ids.isEmpty else {
+            activeRemaining = nil
+            return
+        }
+        activeRemaining = ids
+        for (id, port) in snapshot.sorted(by: {
+            $0.key.uuidString.lowercased() < $1.key.uuidString.lowercased()
+        }) {
+            probe.probe(port: port, timeout: 0.5) { [weak self] reachable in
+                guard let self else { return }
+                self.complete(id: id, port: port, cycle: requestedCycle, reachable: reachable)
+            }
+        }
+    }
+
+    private func complete(id: UUID, port: UInt16, cycle completedCycle: Int, reachable: Bool) {
+        guard activeRemaining?.remove(id) != nil else { return }
+        if completedCycle == cycle, portalPorts[id] == port {
+            states[id] = reachable ? .reachable : .unavailable
+            publish()
+        }
+        guard activeRemaining?.isEmpty == true else { return }
+        activeRemaining = nil
+        if let pendingCycle {
+            self.pendingCycle = nil
+            startBatch(cycle: pendingCycle)
+        }
+    }
+
+    private func schedulePeriodicProbe() {
+        periodicTask = scheduler.schedule(after: 10) { [weak self] in
+            guard let self else { return }
+            self.periodicTask = nil
+            self.trigger()
+            self.schedulePeriodicProbe()
+        }
+    }
+
+    private func publish() {
+        onChange?(states)
+    }
+}

--- a/Portico/PortalController.swift
+++ b/Portico/PortalController.swift
@@ -16,6 +16,9 @@ final class PortalController: ObservableObject {
     @Published private(set) var localApps: [LocalAppCandidatePayload] = []
     @Published private(set) var isRefreshingLocalApps = false
     @Published private(set) var localAppsMessage: String?
+    @Published private(set) var reachabilityStates: [UUID: LocalAppReachabilityState] = [:]
+    @Published private(set) var staleStatusIDs: Set<UUID> = []
+    @Published private(set) var diagnosticEntries: [DiagnosticEntry] = []
 
     var portal: PortalConfiguration? { portals.first }
     var status: PortalStatusPayload? { portal.flatMap { statuses[$0.id] } }
@@ -29,6 +32,9 @@ final class PortalController: ObservableObject {
     private let uuidProvider: () -> UUID
     private let dateProvider: () -> Date
     private let openURL: (URL) -> Void
+    private let reachability: LocalAppReachability?
+    private let history: DiagnosticHistory
+    private let diagnosticVersions: DiagnosticVersions
     private var installation = InstallationRecord()
     private var authenticationPending: Set<UUID> = []
     private var cleanupInFlight: Set<UUID> = []
@@ -42,13 +48,27 @@ final class PortalController: ObservableObject {
         helper: PortalHelperClient,
         uuidProvider: @escaping () -> UUID = UUID.init,
         dateProvider: @escaping () -> Date = Date.init,
+        reachability: LocalAppReachability? = nil,
+        history: DiagnosticHistory? = nil,
+        diagnosticVersions: DiagnosticVersions = .current,
         openURL: @escaping (URL) -> Void
     ) {
         self.store = store
         self.helper = helper
         self.uuidProvider = uuidProvider
         self.dateProvider = dateProvider
+        self.reachability = reachability
+        self.history = history ?? DiagnosticHistory(dateProvider: dateProvider)
+        self.diagnosticVersions = diagnosticVersions
         self.openURL = openURL
+        self.history.onChange = { [weak self] entries in self?.diagnosticEntries = entries }
+        self.reachability?.onChange = { [weak self] states in
+            guard let self else { return }
+            self.reachabilityStates = states
+            for portal in self.installation.portals where portal.lifecycle == .active {
+                self.recordPortalState(portal)
+            }
+        }
         do {
             installation = try store.loadInstallation()
             publishInstallation()
@@ -56,7 +76,9 @@ final class PortalController: ObservableObject {
             message = "Saved Portal configuration could not be loaded."
         }
         helper.onConnected = { [weak self] in self?.helperConnected() }
+        helper.onAvailabilityChange = { [weak self] in self?.helperAvailabilityChanged($0) }
         helper.onEvent = { [weak self] event in self?.receive(event) }
+        helperAvailabilityChanged(helper.availability)
         if helper.availability == .connected {
             helperConnected()
         }
@@ -77,6 +99,38 @@ final class PortalController: ObservableObject {
                 self.localAppsMessage = "Local Apps could not be refreshed."
             }
         }
+    }
+
+    func refreshReachability() {
+        reachability?.refresh()
+    }
+
+    func retryHelper() {
+        helper.retry()
+    }
+
+    func diagnosticReport() -> String {
+        DiagnosticReportRenderer.render(
+            versions: diagnosticVersions,
+            helper: helper.availability,
+            portals: installation.portals
+                .filter { $0.lifecycle == .active }
+                .map {
+                    let status = statuses[$0.id]
+                    return PortalDiagnosticFacts(
+                        portalName: $0.name,
+                        assignedName: status?.assignedName,
+                        portalURL: status?.portalURL,
+                        addresses: status?.addresses ?? [],
+                        magicDNSSuffix: status?.magicDNSSuffix,
+                        desiredState: $0.desiredState,
+                        tailscaleState: status?.state,
+                        reachability: reachabilityStates[$0.id] ?? .unknown,
+                        isStale: staleStatusIDs.contains($0.id)
+                    )
+                },
+            history: history.entries
+        )
     }
 
     func selectLocalApp(_ candidate: LocalAppCandidatePayload) {
@@ -145,7 +199,7 @@ final class PortalController: ObservableObject {
         guard installation.portals[index].localAppPort != localAppPort else { return }
         var updated = installation
         updated.portals[index].localAppPort = localAppPort
-        savePortalOperation(updated)
+        _ = savePortalOperation(updated)
     }
 
     func authenticate() {
@@ -209,6 +263,7 @@ final class PortalController: ObservableObject {
     }
 
     private func helperConnected() {
+        reachability?.helperRecovered()
         refreshLocalApps()
         scheduleReconciliation()
         for portal in installation.portals {
@@ -218,24 +273,36 @@ final class PortalController: ObservableObject {
         }
     }
 
+    private func helperAvailabilityChanged(_ availability: HelperAvailability) {
+        guard availability != .connected else { return }
+        staleStatusIDs.formUnion(statuses.keys)
+        for portal in installation.portals where portal.lifecycle == .active {
+            recordPortalState(portal)
+        }
+    }
+
     private func updateDesiredState(id: UUID, desiredState: PortalDesiredState) {
         guard let index = installation.portals.firstIndex(where: {
             $0.id == id && $0.lifecycle == .active
         }), installation.portals[index].desiredState != desiredState else { return }
         var updated = installation
         updated.portals[index].desiredState = desiredState
-        savePortalOperation(updated)
+        if savePortalOperation(updated) {
+            recordPortalState(updated.portals[index])
+        }
     }
 
-    private func savePortalOperation(_ updated: InstallationRecord) {
+    private func savePortalOperation(_ updated: InstallationRecord) -> Bool {
         do {
             try store.save(updated)
             installation = updated
             publishInstallation()
             message = nil
             scheduleReconciliation()
+            return true
         } catch {
             message = "The Portal could not be saved."
+            return false
         }
     }
 
@@ -280,10 +347,13 @@ final class PortalController: ObservableObject {
         switch event {
         case let .status(id, status):
             guard let portal = installation.portals.first(where: { $0.id == id }) else { return }
-            statuses[id] = status.redactingTailnetName()
+            let displayStatus = status.sanitizedForDisplay()
+            statuses[id] = displayStatus
+            staleStatusIDs.remove(id)
+            recordPortalState(portal)
             if portal.lifecycle == .active, status.state == .online,
                let tailnetName = status.tailnetName, !tailnetName.isEmpty {
-                receiveOnlineStatus(for: portal, status: status, tailnetName: tailnetName)
+                receiveOnlineStatus(for: portal, displayStatus: displayStatus, tailnetName: tailnetName)
             }
         case let .authenticationURL(id, url):
             guard authenticationPending.remove(id) != nil,
@@ -295,14 +365,15 @@ final class PortalController: ObservableObject {
 
     private func receiveOnlineStatus(
         for portal: PortalConfiguration,
-        status: PortalStatusPayload,
+        displayStatus: PortalStatusPayload,
         tailnetName: String
     ) {
         guard let binding = installation.tailnetBinding else {
+            guard let suffix = displayStatus.magicDNSSuffix else { return }
             var updated = installation
             updated.tailnetBinding = TailnetBinding(
                 name: tailnetName,
-                magicDNSSuffix: status.magicDNSSuffix ?? ""
+                magicDNSSuffix: suffix
             )
             do {
                 try store.save(updated)
@@ -315,11 +386,18 @@ final class PortalController: ObservableObject {
             return
         }
         guard binding.name == tailnetName else {
-            reject(portal, status: status)
+            reject(
+                portal,
+                evidence: RejectionEvidence(
+                    assignedName: displayStatus.assignedName,
+                    rejectedMagicDNSSuffix: displayStatus.magicDNSSuffix
+                )
+            )
             return
         }
-        let suffix = status.magicDNSSuffix ?? ""
-        guard suffix != binding.magicDNSSuffix else { return }
+        guard let suffix = displayStatus.magicDNSSuffix,
+              suffix != binding.magicDNSSuffix
+        else { return }
         var updated = installation
         updated.tailnetBinding?.magicDNSSuffix = suffix
         do {
@@ -331,7 +409,7 @@ final class PortalController: ObservableObject {
         }
     }
 
-    private func reject(_ portal: PortalConfiguration, status: PortalStatusPayload) {
+    private func reject(_ portal: PortalConfiguration, evidence: RejectionEvidence) {
         guard let index = installation.portals.firstIndex(where: { $0.id == portal.id && $0.lifecycle == .active }) else {
             return
         }
@@ -342,13 +420,7 @@ final class PortalController: ObservableObject {
             installation = updated
             publishInstallation()
             scheduleReconciliation()
-            cleanupRejectedPortal(
-                updated.portals[index],
-                evidence: RejectionEvidence(
-                    assignedName: status.assignedName,
-                    rejectedMagicDNSSuffix: status.magicDNSSuffix
-                )
-            )
+            cleanupRejectedPortal(updated.portals[index], evidence: evidence)
         } catch {
             message = "The rejected Portal could not be saved for cleanup."
         }
@@ -393,6 +465,17 @@ final class PortalController: ObservableObject {
         portals = installation.portals
         alerts = installation.alerts
         tailnetDisplaySuffix = installation.tailnetBinding?.magicDNSSuffix.nonEmpty
+        reachability?.update(portals: installation.portals)
+    }
+
+    private func recordPortalState(_ portal: PortalConfiguration) {
+        history.record(.portal(
+            name: portal.name,
+            desired: portal.desiredState,
+            tailscale: statuses[portal.id]?.state,
+            reachability: reachabilityStates[portal.id] ?? .unknown,
+            stale: staleStatusIDs.contains(portal.id)
+        ))
     }
 }
 
@@ -408,17 +491,4 @@ private struct PortalReconciliation {
 
 private extension String {
     var nonEmpty: String? { isEmpty ? nil : self }
-}
-
-private extension PortalStatusPayload {
-    func redactingTailnetName() -> PortalStatusPayload {
-        PortalStatusPayload(
-            state: state,
-            stableNodeId: stableNodeId,
-            assignedName: assignedName,
-            portalURL: portalURL,
-            addresses: addresses,
-            magicDNSSuffix: magicDNSSuffix
-        )
-    }
 }

--- a/Portico/PorticoApp.swift
+++ b/Portico/PorticoApp.swift
@@ -10,10 +10,15 @@ struct PorticoApp: App {
             PortalView(controller: appDelegate.portalController, supervisor: appDelegate.supervisor)
         }
         .menuBarExtraStyle(.window)
+        Window("Portico Diagnostics", id: "diagnostics") {
+            DiagnosticsView(controller: appDelegate.portalController)
+        }
+        .defaultSize(width: 720, height: 520)
     }
 }
 
 private struct PortalView: View {
+    @Environment(\.openWindow) private var openWindow
     @ObservedObject var controller: PortalController
     @ObservedObject var supervisor: HelperSupervisor
     @State private var showingResetConfirmation = false
@@ -21,9 +26,14 @@ private struct PortalView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             Label(supervisor.availability.title, systemImage: supervisor.availability.symbolName)
+            if supervisor.availability == .failed {
+                Button("Retry Helper") { controller.retryHelper() }
+                    .buttonStyle(.borderedProminent)
+            }
             if let suffix = controller.tailnetDisplaySuffix {
                 LabeledContent("Tailnet", value: suffix)
             }
+            Button("Diagnostics") { openWindow(id: "diagnostics") }
             Divider()
             ForEach(controller.pendingPortals, id: \.id) { portal in
                 pendingWarning(portal)
@@ -131,6 +141,7 @@ private struct PortalView: View {
 }
 
 private struct PortalStatusView: View {
+    @Environment(\.openWindow) private var openWindow
     @ObservedObject var controller: PortalController
     let portal: PortalConfiguration
     @State private var localAppPort: String
@@ -176,10 +187,21 @@ private struct PortalStatusView: View {
                 Button("Authenticate") { controller.authenticate(id: portal.id) }
                     .buttonStyle(.borderedProminent)
             }
+            if controller.staleStatusIDs.contains(portal.id) {
+                Text("Last known Tailscale facts — stale")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
         } else {
             Text("Waiting for Portal status…")
                 .foregroundStyle(.secondary)
         }
+        LabeledContent(
+            "Local App",
+            value: (controller.reachabilityStates[portal.id] ?? .unknown).title
+        )
+        Button("Diagnostics") { openWindow(id: "diagnostics") }
+            .controlSize(.small)
     }
 
     private func updatePort() {
@@ -187,20 +209,58 @@ private struct PortalStatusView: View {
     }
 }
 
+private struct DiagnosticsView: View {
+    @ObservedObject var controller: PortalController
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Portico Diagnostics").font(.title2)
+            HStack {
+                Button("Refresh Local App Reachability") { controller.refreshReachability() }
+                Spacer()
+                Button("Copy Report") {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(controller.diagnosticReport(), forType: .string)
+                }
+            }
+            ScrollView {
+                Text(controller.diagnosticReport())
+                    .font(.system(.body, design: .monospaced))
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .padding()
+    }
+}
+
+private extension LocalAppReachabilityState {
+    var title: String {
+        switch self {
+        case .unknown: "Unknown"
+        case .reachable: "Reachable"
+        case .unavailable: "Unavailable"
+        }
+    }
+}
+
 private extension HelperAvailability {
     var title: String {
         switch self {
         case .connecting: "Connecting"
+        case let .retrying(attempt, delay): "Retry \(attempt) in \(Int(delay))s"
         case .connected: "Connected"
         case .failed: "Helper unavailable"
+        case .shuttingDown: "Shutting down"
         }
     }
 
     var symbolName: String {
         switch self {
-        case .connecting: "ellipsis.circle"
+        case .connecting, .retrying: "ellipsis.circle"
         case .connected: "checkmark.circle"
         case .failed: "exclamationmark.triangle"
+        case .shuttingDown: "stop.circle"
         }
     }
 }

--- a/Portico/Scheduling.swift
+++ b/Portico/Scheduling.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+protocol ScheduledTask: AnyObject {
+    func cancel()
+}
+
+@MainActor
+protocol PorticoScheduling: AnyObject {
+    @discardableResult
+    func schedule(after delay: TimeInterval, _ action: @escaping () -> Void) -> ScheduledTask
+}
+
+@MainActor
+final class MainQueueScheduler: PorticoScheduling {
+    func schedule(after delay: TimeInterval, _ action: @escaping () -> Void) -> ScheduledTask {
+        let workItem = DispatchWorkItem(block: action)
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+        return DispatchScheduledTask(workItem: workItem)
+    }
+}
+
+private final class DispatchScheduledTask: ScheduledTask {
+    private let workItem: DispatchWorkItem
+
+    init(workItem: DispatchWorkItem) {
+        self.workItem = workItem
+    }
+
+    func cancel() {
+        workItem.cancel()
+    }
+}

--- a/PorticoTests/DiagnosticsTests.swift
+++ b/PorticoTests/DiagnosticsTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import Portico
+
+final class DiagnosticsTests: XCTestCase {
+    func testHistoryEvictsOldestAndReportContainsOnlyAllowlistedFacts() {
+        var nextTimestamp: TimeInterval = 0
+        let history = DiagnosticHistory(dateProvider: {
+            defer { nextTimestamp += 1 }
+            return Date(timeIntervalSince1970: nextTimestamp)
+        })
+        history.record(.helper(.failed))
+        for _ in 0..<200 {
+            history.record(.portal(
+                name: "hermes",
+                desired: .enabled,
+                tailscale: .online,
+                reachability: .reachable,
+                stale: false
+            ))
+        }
+
+        XCTAssertEqual(history.entries.count, 200)
+        XCTAssertEqual(history.entries.first?.timestamp, Date(timeIntervalSince1970: 1))
+        XCTAssertEqual(history.entries.last?.timestamp, Date(timeIntervalSince1970: 200))
+
+        let portal = PortalConfiguration(
+            id: UUID(uuidString: "11111111-1111-1111-1111-111111111111")!,
+            name: "hermes",
+            localAppPort: 8787,
+            createdAt: Date()
+        )
+        let facts = PortalDiagnosticFacts(
+            portalName: "hermes",
+            assignedName: "hermes-1",
+            portalURL: URL(string: "https://hermes-1.example.ts.net/"),
+            addresses: ["100.64.0.1"],
+            magicDNSSuffix: "example.ts.net",
+            desiredState: portal.desiredState,
+            tailscaleState: .online,
+            reachability: .reachable,
+            isStale: true
+        )
+        let report = DiagnosticReportRenderer.render(
+            versions: DiagnosticVersions(porticoShort: "1.2", porticoBuild: "34", helperProtocol: 2),
+            helper: .failed,
+            portals: [facts],
+            history: history.entries
+        )
+
+        for value in [
+            "Portico 1.2 (34)", "Helper protocol 2", "hermes", "hermes-1",
+            "https://hermes-1.example.ts.net/", "100.64.0.1", "example.ts.net",
+            "Desired: enabled", "Tailscale: online", "Reachability: reachable", "Facts: stale",
+            "Helper: unavailable",
+        ] {
+            XCTAssertTrue(report.contains(value), value)
+        }
+        for excluded in [
+            portal.id.uuidString, "secret-stable-node-id", "secret-opaque-tailnet",
+            "https://login.tailscale.com/a/secret", "/Users/chris/private",
+            "Authorization: Bearer secret", "Cookie: secret", "--secret-argument", "request-body-secret",
+        ] {
+            XCTAssertFalse(report.contains(excluded), excluded)
+        }
+    }
+}

--- a/PorticoTests/HelperSupervisorTests.swift
+++ b/PorticoTests/HelperSupervisorTests.swift
@@ -4,6 +4,80 @@ import XCTest
 
 @MainActor
 final class HelperSupervisorTests: XCTestCase {
+    func testRetriesUnexpectedExitWithOneChildAndFixedSharedBudget() {
+        let launcher = FakeHelperLauncher()
+        let scheduler = FakePorticoScheduler()
+        let supervisor = HelperSupervisor(
+            helperURL: URL(fileURLWithPath: "/unused/portico-helper"),
+            launcher: launcher,
+            requestIDProvider: { UUID().uuidString },
+            scheduler: scheduler,
+            handshakeTimeout: 60
+        )
+
+        supervisor.start()
+        for expectedDelay in [1.0, 2.0, 4.0, 8.0, 16.0] {
+            launcher.exit(status: 1)
+
+            XCTAssertEqual(
+                supervisor.availability,
+                .retrying(attempt: launcher.processes.count, delay: expectedDelay)
+            )
+            XCTAssertEqual(scheduler.pendingDelays, [expectedDelay])
+            XCTAssertLessThanOrEqual(launcher.processes.filter(\.isRunning).count, 0)
+
+            scheduler.runNext()
+            XCTAssertEqual(supervisor.availability, .connecting)
+            XCTAssertEqual(launcher.processes.filter(\.isRunning).count, 1)
+        }
+
+        launcher.exit(status: 1)
+
+        XCTAssertEqual(supervisor.availability, .failed)
+        XCTAssertTrue(scheduler.pendingDelays.isEmpty)
+        XCTAssertEqual(scheduler.recordedDelays.filter { $0 < 60 }, [1, 2, 4, 8, 16])
+        XCTAssertEqual(launcher.processes.count, 6)
+
+        supervisor.retry()
+
+        XCTAssertEqual(supervisor.availability, .connecting)
+        XCTAssertEqual(launcher.processes.count, 7)
+        XCTAssertEqual(launcher.processes.filter(\.isRunning).count, 1)
+    }
+
+    func testRetryBudgetResetsOnlyAfterLatestConvergenceStaysConnectedForFiveMinutes() {
+        let launcher = FakeHelperLauncher()
+        let scheduler = FakePorticoScheduler()
+        var requestIDs = ["handshake-1", "handshake-2", "reconcile-2", "handshake-3", "reconcile-3"]
+        let supervisor = HelperSupervisor(
+            helperURL: URL(fileURLWithPath: "/unused/portico-helper"),
+            launcher: launcher,
+            requestIDProvider: { requestIDs.removeFirst() },
+            scheduler: scheduler,
+            handshakeTimeout: 60
+        )
+
+        supervisor.start()
+        launcher.exit(status: 1)
+        scheduler.runNext()
+        launcher.receive(line: #"{"version":2,"requestId":"handshake-2","result":{"protocolVersion":2}}"#)
+        supervisor.reconcilePortals([]) { _ in }
+        launcher.receive(line: #"{"version":2,"requestId":"reconcile-2","result":{"entries":[]}}"#)
+
+        XCTAssertTrue(scheduler.pendingDelays.contains(300))
+        launcher.exit(status: 1)
+        XCTAssertEqual(supervisor.availability, .retrying(attempt: 2, delay: 2))
+
+        scheduler.run(delay: 2)
+        launcher.receive(line: #"{"version":2,"requestId":"handshake-3","result":{"protocolVersion":2}}"#)
+        supervisor.reconcilePortals([]) { _ in }
+        launcher.receive(line: #"{"version":2,"requestId":"reconcile-3","result":{"entries":[]}}"#)
+        scheduler.run(delay: 300)
+        launcher.exit(status: 1)
+
+        XCTAssertEqual(supervisor.availability, .retrying(attempt: 1, delay: 1))
+    }
+
     func testConnectsOnlyForCorrelatedHandshake() throws {
         let launcher = FakeHelperLauncher()
         let supervisor = HelperSupervisor(
@@ -40,22 +114,23 @@ final class HelperSupervisorTests: XCTestCase {
 
         supervisor.start()
         try await Task.sleep(nanoseconds: 50_000_000)
+        launcher.exit(status: 1)
 
-        XCTAssertEqual(supervisor.availability, .failed)
+        XCTAssertEqual(supervisor.availability, .retrying(attempt: 1, delay: 1))
         XCTAssertTrue(launcher.process.inputClosed)
         XCTAssertTrue(launcher.process.terminated)
     }
 
-    func testHandshakeFailuresBecomeUnavailable() {
-        let failures: [(String, (FakeHelperLauncher) -> Void)] = [
-            ("malformed line", { $0.receive(line: "{") }),
-            ("correlated error", { $0.receive(line: #"{"version":2,"requestId":"request-1","error":{"code":"unsupportedVersion","message":"unsupported protocol version"}}"#) }),
-            ("unsupported response version", { $0.receive(line: #"{"version":1,"requestId":"request-1","result":{"protocolVersion":1}}"#) }),
-            ("EOF", { $0.receiveEOF() }),
-            ("nonzero exit", { $0.exit(status: 1) }),
+    func testHandshakeFailuresEnterSharedRecoveryBudgetAfterChildExit() {
+        let failures: [(String, Bool, (FakeHelperLauncher) -> Void)] = [
+            ("malformed line", false, { $0.receive(line: "{") }),
+            ("correlated error", false, { $0.receive(line: #"{"version":2,"requestId":"request-1","error":{"code":"unsupportedVersion","message":"unsupported protocol version"}}"#) }),
+            ("unsupported response version", false, { $0.receive(line: #"{"version":1,"requestId":"request-1","result":{"protocolVersion":1}}"#) }),
+            ("EOF", false, { $0.receiveEOF() }),
+            ("nonzero exit", true, { $0.exit(status: 1) }),
         ]
 
-        for (name, trigger) in failures {
+        for (name, alreadyExited, trigger) in failures {
             let launcher = FakeHelperLauncher()
             let supervisor = HelperSupervisor(
                 helperURL: URL(fileURLWithPath: "/unused/portico-helper"),
@@ -66,9 +141,14 @@ final class HelperSupervisorTests: XCTestCase {
             supervisor.start()
 
             trigger(launcher)
+            if !alreadyExited {
+                launcher.exit(status: 1)
+            }
 
-            XCTAssertEqual(supervisor.availability, .failed, name)
-            XCTAssertTrue(launcher.process.inputClosed, name)
+            XCTAssertEqual(supervisor.availability, .retrying(attempt: 1, delay: 1), name)
+            if !alreadyExited {
+                XCTAssertTrue(launcher.process.inputClosed, name)
+            }
         }
     }
 
@@ -234,7 +314,8 @@ final class HelperSupervisorTests: XCTestCase {
 }
 
 final class FakeHelperLauncher: HelperLaunching {
-    let process = FakeHelperProcess()
+    private(set) var processes: [FakeHelperProcess] = []
+    var process: FakeHelperProcess { processes.last! }
     private var onLine: ((Data) -> Void)?
     private var onEOF: (() -> Void)?
     private var onExit: ((Int32) -> Void)?
@@ -247,6 +328,8 @@ final class FakeHelperLauncher: HelperLaunching {
         onEOF: @escaping () -> Void,
         onExit: @escaping (Int32) -> Void
     ) throws -> HelperProcess {
+        let process = FakeHelperProcess()
+        processes.append(process)
         self.arguments = arguments
         self.onLine = onLine
         self.onEOF = onEOF
@@ -266,6 +349,50 @@ final class FakeHelperLauncher: HelperLaunching {
         process.isRunning = false
         onExit?(status)
     }
+}
+
+@MainActor
+final class FakePorticoScheduler: PorticoScheduling {
+    private struct Entry {
+        let delay: TimeInterval
+        let task: FakeScheduledTask
+        let action: () -> Void
+    }
+
+    private var entries: [Entry] = []
+    private(set) var recordedDelays: [TimeInterval] = []
+    var pendingDelays: [TimeInterval] {
+        entries.filter { !$0.task.isCancelled }.map(\.delay)
+    }
+
+    func schedule(after delay: TimeInterval, _ action: @escaping () -> Void) -> ScheduledTask {
+        let task = FakeScheduledTask()
+        recordedDelays.append(delay)
+        entries.append(Entry(delay: delay, task: task, action: action))
+        return task
+    }
+
+    func runNext() {
+        while !entries.isEmpty {
+            let entry = entries.removeFirst()
+            guard !entry.task.isCancelled else { continue }
+            entry.action()
+            return
+        }
+    }
+
+    func run(delay: TimeInterval) {
+        guard let index = entries.firstIndex(where: { $0.delay == delay && !$0.task.isCancelled }) else {
+            return
+        }
+        let entry = entries.remove(at: index)
+        entry.action()
+    }
+}
+
+final class FakeScheduledTask: ScheduledTask {
+    private(set) var isCancelled = false
+    func cancel() { isCancelled = true }
 }
 
 final class FakeHelperProcess: HelperProcess {

--- a/PorticoTests/LocalAppReachabilityTests.swift
+++ b/PorticoTests/LocalAppReachabilityTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+@testable import Portico
+
+@MainActor
+final class LocalAppReachabilityTests: XCTestCase {
+    func testLoopbackProbeTreatsZeroPortAsUnavailable() {
+        var result: Bool?
+
+        LoopbackTCPProbe().probe(port: 0, timeout: 0.5) { reachable in
+            result = reachable
+        }
+
+        XCTAssertEqual(result, false)
+    }
+
+    func testUnchangedPortalTargetsDoNotScheduleAnotherBatch() {
+        let probe = FakeLocalAppProbe()
+        let monitor = LocalAppReachability(probe: probe, scheduler: FakePorticoScheduler())
+        let portal = portal(id: "11111111-1111-1111-1111-111111111111", port: 3000)
+
+        monitor.update(portals: [portal])
+        monitor.update(portals: [portal])
+        probe.complete(index: 0, reachable: true)
+
+        XCTAssertEqual(probe.requests.count, 1)
+        XCTAssertEqual(monitor.states[portal.id], .reachable)
+    }
+
+    func testProbesAllNonCleanupPortalsAndCoalescesSupersededBatches() {
+        let probe = FakeLocalAppProbe()
+        let scheduler = FakePorticoScheduler()
+        let monitor = LocalAppReachability(probe: probe, scheduler: scheduler)
+        let enabled = portal(id: "11111111-1111-1111-1111-111111111111", port: 3000)
+        let stopped = portal(id: "22222222-2222-2222-2222-222222222222", port: 4000, desiredState: .stopped)
+        let cleanup = portal(id: "33333333-3333-3333-3333-333333333333", port: 5000, lifecycle: .pendingTailnetRejection)
+
+        monitor.update(portals: [enabled, stopped, cleanup])
+
+        XCTAssertEqual(probe.requests.map(\.port), [3000, 4000])
+        XCTAssertEqual(probe.requests.map(\.timeout), [0.5, 0.5])
+        XCTAssertEqual(monitor.states, [enabled.id: .unknown, stopped.id: .unknown])
+        XCTAssertEqual(scheduler.pendingDelays, [10])
+
+        monitor.refresh()
+        var changed = enabled
+        changed.localAppPort = 3001
+        monitor.update(portals: [changed, stopped])
+        XCTAssertEqual(probe.requests.count, 2)
+
+        probe.complete(index: 0, reachable: true)
+        probe.complete(index: 1, reachable: false)
+
+        XCTAssertEqual(monitor.states[enabled.id], .unknown)
+        XCTAssertEqual(monitor.states[stopped.id], .unknown)
+        XCTAssertEqual(probe.requests.map(\.port), [3000, 4000, 3001, 4000])
+
+        probe.complete(index: 2, reachable: true)
+        probe.complete(index: 3, reachable: false)
+
+        XCTAssertEqual(monitor.states[enabled.id], .reachable)
+        XCTAssertEqual(monitor.states[stopped.id], .unavailable)
+    }
+
+    private func portal(
+        id: String,
+        port: UInt16,
+        desiredState: PortalDesiredState = .enabled,
+        lifecycle: PortalLifecycle = .active
+    ) -> PortalConfiguration {
+        PortalConfiguration(
+            id: UUID(uuidString: id)!,
+            name: "portal-\(port)",
+            localAppPort: port,
+            createdAt: Date(),
+            desiredState: desiredState,
+            lifecycle: lifecycle
+        )
+    }
+}
+
+final class FakeLocalAppProbe: LocalAppProbing {
+    struct Request {
+        let port: UInt16
+        let timeout: TimeInterval
+        let completion: (Bool) -> Void
+    }
+
+    private(set) var requests: [Request] = []
+
+    func probe(port: UInt16, timeout: TimeInterval, completion: @escaping (Bool) -> Void) {
+        requests.append(Request(port: port, timeout: timeout, completion: completion))
+    }
+
+    func complete(index: Int, reachable: Bool) {
+        requests[index].completion(reachable)
+    }
+}

--- a/PorticoTests/PortalControllerTests.swift
+++ b/PorticoTests/PortalControllerTests.swift
@@ -287,6 +287,58 @@ final class PortalControllerTests: XCTestCase {
         XCTAssertEqual(try store.loadInstallation().portals.first?.desiredState, .stopped)
     }
 
+    func testCommittedStartAndStopRecordDesiredStateWithoutReachabilityProbe() throws {
+        let saved = PortalConfiguration(
+            id: portalID,
+            name: "hermes",
+            localAppPort: 8787,
+            createdAt: Date()
+        )
+        let store = PortalStore(rootURL: temporaryRoot())
+        try store.save(saved)
+        let history = DiagnosticHistory()
+        let probe = FakeLocalAppProbe()
+        let reachability = LocalAppReachability(
+            probe: probe,
+            scheduler: FakePorticoScheduler()
+        )
+        let controller = PortalController(
+            store: store,
+            helper: FakePortalHelperClient(),
+            reachability: reachability,
+            history: history,
+            openURL: { _ in }
+        )
+
+        controller.stopPortal(id: portalID)
+        controller.startPortal(id: portalID)
+
+        XCTAssertEqual(history.entries.map(\.event), [
+            .portal(
+                name: "hermes",
+                desired: .enabled,
+                tailscale: nil,
+                reachability: .unknown,
+                stale: false
+            ),
+            .portal(
+                name: "hermes",
+                desired: .stopped,
+                tailscale: nil,
+                reachability: .unknown,
+                stale: false
+            ),
+            .portal(
+                name: "hermes",
+                desired: .enabled,
+                tailscale: nil,
+                reachability: .unknown,
+                stale: false
+            ),
+        ])
+        XCTAssertEqual(probe.requests.count, 1)
+    }
+
     func testCurrentPartialFailureKeepsCommittedDesiredState() throws {
         let saved = PortalConfiguration(
             id: portalID,
@@ -322,13 +374,22 @@ final class PortalControllerTests: XCTestCase {
             stableNodeId: "node-1",
             assignedName: "hermes-1",
             portalURL: URL(string: "https://hermes-1.example.ts.net/"),
-            addresses: ["100.64.0.1"]
+            addresses: ["100.64.0.1"],
+            magicDNSSuffix: "example.ts.net"
+        )
+        let displayStatus = PortalStatusPayload(
+            state: .online,
+            stableNodeId: nil,
+            assignedName: "hermes-1",
+            portalURL: URL(string: "https://hermes-1.example.ts.net/"),
+            addresses: ["100.64.0.1"],
+            magicDNSSuffix: "example.ts.net"
         )
 
         client.send(.status(UUID(), status))
         XCTAssertNil(controller.status)
         client.send(.status(portalID, status))
-        XCTAssertEqual(controller.status, status)
+        XCTAssertEqual(controller.status, displayStatus)
     }
 
     func testOpensAuthenticationURLOnlyForPendingExplicitAction() throws {
@@ -586,6 +647,145 @@ final class PortalControllerTests: XCTestCase {
         XCTAssertNil(try store.loadInstallation().tailnetBinding)
     }
 
+    func testRecoveryMarksFactsStaleAndReconcilesNewestCommittedSnapshot() throws {
+        let store = PortalStore(rootURL: temporaryRoot())
+        let saved = PortalConfiguration(id: portalID, name: "hermes", localAppPort: 8787, createdAt: Date())
+        try store.save(InstallationRecord(portals: [saved]))
+        let client = FakePortalHelperClient(availability: .connecting)
+        let controller = PortalController(store: store, helper: client, openURL: { _ in })
+        client.connect()
+        client.send(.status(portalID, onlineStatus(tailnetName: "opaque", suffix: "example.ts.net")))
+
+        XCTAssertEqual(client.reconciliations, [[saved]])
+        XCTAssertFalse(controller.staleStatusIDs.contains(portalID))
+
+        client.disconnect(as: .retrying(attempt: 1, delay: 1))
+        controller.stopPortal(id: portalID)
+        XCTAssertTrue(controller.staleStatusIDs.contains(portalID))
+        XCTAssertEqual(client.reconciliations.count, 1)
+
+        client.connect()
+
+        XCTAssertEqual(client.reconciliations.count, 2)
+        XCTAssertEqual(client.reconciliations.last?.first?.desiredState, .stopped)
+        XCTAssertTrue(controller.staleStatusIDs.contains(portalID))
+        client.send(.status(portalID, PortalStatusPayload(
+            state: .stopped,
+            stableNodeId: nil,
+            assignedName: "hermes-1",
+            portalURL: URL(string: "https://hermes-1.example.ts.net/"),
+            addresses: ["100.64.0.1"],
+            magicDNSSuffix: "example.ts.net"
+        )))
+        XCTAssertFalse(controller.staleStatusIDs.contains(portalID))
+
+        controller.retryHelper()
+        XCTAssertEqual(client.retryCount, 1)
+    }
+
+    func testConnectionLossCannotStrandPendingNewestReconciliation() throws {
+        let store = PortalStore(rootURL: temporaryRoot())
+        let saved = PortalConfiguration(id: portalID, name: "hermes", localAppPort: 8787, createdAt: Date())
+        try store.save(InstallationRecord(portals: [saved]))
+        let launcher = FakeHelperLauncher()
+        let scheduler = FakePorticoScheduler()
+        var requestIDs = [
+            "handshake-1", "discover-1", "reconcile-1",
+            "handshake-2", "discover-2", "reconcile-2",
+        ]
+        let supervisor = HelperSupervisor(
+            helperURL: URL(fileURLWithPath: "/unused/portico-helper"),
+            launcher: launcher,
+            requestIDProvider: { requestIDs.removeFirst() },
+            scheduler: scheduler,
+            handshakeTimeout: 60
+        )
+        let controller = PortalController(store: store, helper: supervisor, openURL: { _ in })
+        supervisor.start()
+        launcher.receive(line: #"{"version":2,"requestId":"handshake-1","result":{"protocolVersion":2}}"#)
+        controller.stopPortal(id: portalID)
+
+        launcher.exit(status: 1)
+        scheduler.run(delay: 1)
+        launcher.receive(line: #"{"version":2,"requestId":"handshake-2","result":{"protocolVersion":2}}"#)
+
+        let request = try JSONDecoder().decode(
+            HelperRequest<ReconcilePortalsPayload>.self,
+            from: XCTUnwrap(launcher.process.sent.last)
+        )
+        XCTAssertEqual(request.command, .reconcilePortals)
+        XCTAssertEqual(request.payload.portals.first?.desiredState, .stopped)
+    }
+
+    func testHostileHelperFactsAreExcludedFromDisplayAndReport() throws {
+        let store = PortalStore(rootURL: temporaryRoot())
+        let saved = PortalConfiguration(id: portalID, name: "hermes", localAppPort: 8787, createdAt: Date())
+        try store.save(InstallationRecord(portals: [saved]))
+        let client = FakePortalHelperClient()
+        let controller = PortalController(store: store, helper: client, openURL: { _ in })
+
+        client.send(.status(portalID, PortalStatusPayload(
+            state: .connecting,
+            stableNodeId: "secret-stable-node",
+            assignedName: "login",
+            portalURL: URL(string: "file:///Users/chris/private/auth"),
+            addresses: ["Authorization: Bearer secret"],
+            magicDNSSuffix: "tailscale.com"
+        )))
+
+        XCTAssertNil(controller.statuses[portalID]?.stableNodeId)
+        XCTAssertEqual(controller.statuses[portalID]?.assignedName, "login")
+        XCTAssertNil(controller.statuses[portalID]?.portalURL)
+        XCTAssertTrue(controller.statuses[portalID]?.addresses.isEmpty == true)
+        XCTAssertNil(controller.statuses[portalID]?.magicDNSSuffix)
+        let report = controller.diagnosticReport()
+        for excluded in ["secret-stable-node", "file:///Users/chris/private/auth", "Bearer secret", "tailscale.com"] {
+            XCTAssertFalse(report.contains(excluded), excluded)
+        }
+    }
+
+    func testOnlineHostileFactsCannotBindOrPersistRejectionEvidence() throws {
+        let store = PortalStore(rootURL: temporaryRoot())
+        let saved = PortalConfiguration(id: portalID, name: "hermes", localAppPort: 8787, createdAt: Date())
+        try store.save(InstallationRecord(portals: [saved]))
+        let client = FakePortalHelperClient()
+        let controller = PortalController(store: store, helper: client, openURL: { _ in })
+        let unsafeSuffix = "file:///Users/chris/private"
+
+        client.send(.status(portalID, PortalStatusPayload(
+            state: .online,
+            stableNodeId: "secret-node",
+            assignedName: "bad\nname",
+            portalURL: URL(string: "file:///Users/chris/private/auth"),
+            addresses: ["Authorization: Bearer secret"],
+            tailnetName: "opaque-first",
+            magicDNSSuffix: unsafeSuffix
+        )))
+
+        XCTAssertNil(try store.loadInstallation().tailnetBinding)
+        XCTAssertNil(controller.tailnetDisplaySuffix)
+
+        try store.save(InstallationRecord(
+            tailnetBinding: TailnetBinding(name: "opaque-expected", magicDNSSuffix: "expected.ts.net"),
+            portals: [saved]
+        ))
+        let rebound = PortalController(store: store, helper: client, openURL: { _ in })
+        client.send(.status(portalID, PortalStatusPayload(
+            state: .online,
+            stableNodeId: "secret-node",
+            assignedName: "bad\nname",
+            portalURL: URL(string: "file:///Users/chris/private/auth"),
+            addresses: ["Authorization: Bearer secret"],
+            tailnetName: "opaque-different",
+            magicDNSSuffix: unsafeSuffix
+        )))
+
+        let alert = try XCTUnwrap(rebound.alerts.first)
+        XCTAssertNil(alert.assignedName)
+        XCTAssertNil(alert.rejectedMagicDNSSuffix)
+        XCTAssertFalse(rebound.completedWarningText(for: alert).contains(unsafeSuffix))
+    }
+
     private func onlineStatus(
         tailnetName: String,
         suffix: String,
@@ -611,6 +811,7 @@ final class PortalControllerTests: XCTestCase {
 final class FakePortalHelperClient: PortalHelperClient {
     var availability: HelperAvailability
     var onConnected: (() -> Void)?
+    var onAvailabilityChange: ((HelperAvailability) -> Void)?
     var onEvent: ((PortalHelperEvent) -> Void)?
     private(set) var reconciliations: [[PortalConfiguration]] = []
     var started: [PortalConfiguration] { reconciliations.flatMap { $0 } }
@@ -623,6 +824,7 @@ final class FakePortalHelperClient: PortalHelperClient {
     var completeReconciliationImmediately = true
     var onCleanup: ((UUID) -> Void)?
     var onReconcile: (([PortalConfiguration]) -> Void)?
+    private(set) var retryCount = 0
 
     init(availability: HelperAvailability = .connected) {
         self.availability = availability
@@ -642,6 +844,8 @@ final class FakePortalHelperClient: PortalHelperClient {
             reconciliationCompletions.append(completion)
         }
     }
+
+    func retry() { retryCount += 1 }
 
     func authenticatePortal(id: UUID, completion: @escaping (Result<Void, Error>) -> Void) {
         authenticated.append(id)
@@ -664,7 +868,13 @@ final class FakePortalHelperClient: PortalHelperClient {
 
     func connect() {
         availability = .connected
+        onAvailabilityChange?(.connected)
         onConnected?()
+    }
+
+    func disconnect(as availability: HelperAvailability) {
+        self.availability = availability
+        onAvailabilityChange?(availability)
     }
 
     func send(_ event: PortalHelperEvent) { onEvent?(event) }


### PR DESCRIPTION
## Summary

- recover the single owned helper with generation-fenced 1/2/4/8/16-second retries, stable-budget reset, and manual Retry
- monitor saved Portal loopback reachability independently with bounded/coalesced probes
- add session-only typed diagnostics, strict safe-fact projections, a native diagnostics window, and allowlisted Copy Report
- preserve protocol v2 and the existing full-snapshot reconciliation contract

## Validation

- xcodebuild -project Portico.xcodeproj -scheme Portico -destination platform=macOS test (64 tests)
- go build ./cmd/portico-helper
- go test ./...
- ./Scripts/verify-xcode-project-generation.sh
- review-and-simplify-changes: no actionable findings
- ponytail-review: Lean already. Ship.

## Residual validation

The automated UI compiles and all controller/report paths are covered, but the full controlled helper-interruption flow was not manually exercised in the running menu-bar app.

Closes #8