### PR TITLE
Document Remote App Portal Destinations

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,14 +1,15 @@
 # Portico
 
-Portico gives a local web app a durable private doorway on a Tailscale
-tailnet. This glossary defines the product language used in the app,
-documentation, and code.
+Portico gives a web service reachable from a Mac a durable private doorway on
+a Tailscale tailnet. This glossary defines the product language used in the
+app, documentation, and code.
 
 ## Language
 
 **Portal**:
-A durable private doorway from an HTTPS tailnet address to one Local App. A
-Portal retains its identity until it is removed.
+A durable private doorway from an HTTPS tailnet address to one Portal
+Destination. A Portal retains its identity until it is removed, even when it
+is repointed to a different Portal Destination.
 _Avoid_: Mapping, endpoint, tunnel
 
 **Portal Name**:
@@ -24,9 +25,24 @@ _Avoid_: Portal Name, requested name
 The HTTPS address issued for a Portal's Assigned Name on its tailnet.
 _Avoid_: Generated URL, requested URL
 
+**Portal Destination**:
+The web service a Portal makes available to its tailnet. It is either a Local
+App or a Remote App.
+_Avoid_: Backend, upstream, target
+
 **Local App**:
 An HTTP service on the same Mac that a Portal makes available to its tailnet.
-_Avoid_: Backend, upstream, target
+_Avoid_: Localhost app, on-device service
+
+**Remote App**:
+An HTTP or HTTPS service running on another host and reachable through the
+Mac's normal network. It may be on any non-loopback network the Mac can reach.
+_Avoid_: External App, Network App, remote target
+
+**Online Portal**:
+A Portal whose Tailscale node is connected and accepting tailnet requests. It
+does not imply that the Portal Destination is reachable or healthy.
+_Avoid_: Healthy Portal, available app
 
 **Enabled Portal**:
 A Portal whose desired state is to remain connected whenever Portico is

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -40,8 +40,9 @@ Mac's normal network. It may be on any non-loopback network the Mac can reach.
 _Avoid_: External App, Network App, remote target
 
 **Online Portal**:
-A Portal whose Tailscale node is connected and accepting tailnet requests. It
-does not imply that the Portal Destination is reachable or healthy.
+A Portal whose Tailscale node is connected to its tailnet. It does not imply
+that the Portal is accepting tailnet requests or that the Portal Destination
+is reachable or healthy.
 _Avoid_: Healthy Portal, available app
 
 **Enabled Portal**:

--- a/docs/adr/0007-route-destination-connections-through-the-mac.md
+++ b/docs/adr/0007-route-destination-connections-through-the-mac.md
@@ -1,0 +1,8 @@
+# Route destination connections through the Mac
+
+Portals connect to their web-service destinations through the Mac's normal
+network stack, rather than through each Portal's tsnet identity. This makes a
+destination reachable exactly when the Mac can reach it and avoids coupling
+destination access to the Portal's tailnet ACLs and subnet routes. A Remote App
+may use any non-loopback DNS name or IPv4 or IPv6 address reachable through
+that stack, including private, public, Tailscale, and routed networks.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,6 +22,8 @@
 
 ## Phase 2: Publishable 1.0
 
+- Add Remote Apps as Portal Destinations over explicit HTTP or HTTPS through
+  the Mac's normal network, with system-trusted HTTPS certificates.
 - Harden crash recovery, state migrations, redaction, and destructive path
   validation.
 - Complete accessibility, keyboard navigation, VoiceOver, localization
@@ -37,6 +39,5 @@
   architecture in advance.
 - Consider automatic updates, optional tagged-node provisioning, and narrower
   delegated cleanup credentials only as separately designed features.
-- Keep Funnel, Tailscale Services, non-loopback targets, raw forwarding, and
-  multi-tailnet installations outside 1.0 unless product scope is explicitly
-  reopened.
+- Keep Funnel, Tailscale Services, raw forwarding, and multi-tailnet
+  installations outside 1.0 unless product scope is explicitly reopened.


### PR DESCRIPTION
## Summary

- define Portal Destination, Remote App, and Online Portal in the domain glossary
- record that Portal destination connections use the Mac's normal network stack
- move Remote Apps into the Phase 2 / 1.0 roadmap while leaving raw forwarding out of scope

## Why

Issue #28 specifies Remote Apps as a new Portal Destination. These documentation changes capture the agreed product language, architectural boundary, and release scope before implementation begins.

## Impact

Documentation only. Swift and Go implementation remains tracked by #28.

## Validation

- `git diff --check`
- `review-and-simplify-changes` on the final committed diff
- `ponytail-review` on the final committed diff

Related to #28.
