### PR TITLE
Remove a Portal safely

### DIFF
--- a/Portico/HelperProtocol.swift
+++ b/Portico/HelperProtocol.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-let helperProtocolVersion = 2
+let helperProtocolVersion = 3
 
 enum HelperCommand: String, Codable {
     case handshake
@@ -8,6 +8,7 @@ enum HelperCommand: String, Codable {
     case reconcilePortals
     case authenticatePortal
     case cleanupRejectedPortal
+    case removePortal
     case discoverLocalApps
 }
 
@@ -74,6 +75,14 @@ struct CleanupRejectedPortalPayload: Codable, Equatable {
 }
 
 struct CleanupRejectedPortalResult: Codable, Equatable {
+    let accepted: Bool
+}
+
+struct RemovePortalPayload: Codable, Equatable {
+    let portalId: UUID
+}
+
+struct RemovePortalResult: Codable, Equatable {
     let accepted: Bool
 }
 

--- a/Portico/HelperSupervisor.swift
+++ b/Portico/HelperSupervisor.swift
@@ -34,6 +34,7 @@ protocol PortalHelperClient: AnyObject {
     )
     func authenticatePortal(id: UUID, completion: @escaping (Result<Void, Error>) -> Void)
     func cleanupRejectedPortal(id: UUID, completion: @escaping (Result<Void, Error>) -> Void)
+    func removePortal(id: UUID, completion: @escaping (Result<Void, Error>) -> Void)
     func discoverLocalApps(completion: @escaping (Result<[LocalAppCandidatePayload], Error>) -> Void)
 }
 
@@ -252,6 +253,21 @@ final class HelperSupervisor: ObservableObject, PortalHelperClient {
         }
         do {
             try sendRequest(command: .cleanupRejectedPortal, payload: CleanupRejectedPortalPayload(portalId: id)) { (result: Result<CleanupRejectedPortalResult, Error>) in
+                completion(result.map { _ in () })
+            }
+        } catch {
+            completion(.failure(error))
+            handleFailure(generation: processGeneration)
+        }
+    }
+
+    func removePortal(id: UUID, completion: @escaping (Result<Void, Error>) -> Void) {
+        guard availability == .connected else {
+            completion(.failure(HelperClientError.unavailable))
+            return
+        }
+        do {
+            try sendRequest(command: .removePortal, payload: RemovePortalPayload(portalId: id)) { (result: Result<RemovePortalResult, Error>) in
                 completion(result.map { _ in () })
             }
         } catch {

--- a/Portico/PortalConfiguration.swift
+++ b/Portico/PortalConfiguration.swift
@@ -7,6 +7,7 @@ struct PortalConfiguration: Codable, Equatable {
     let createdAt: Date
     var desiredState: PortalDesiredState = .enabled
     var lifecycle: PortalLifecycle = .active
+    var removalAssignedName: String?
 }
 
 enum PortalDesiredState: String, Codable, Equatable {
@@ -22,6 +23,7 @@ extension PortalConfiguration {
         case createdAt
         case desiredState
         case lifecycle
+        case removalAssignedName
     }
 
     init(from decoder: Decoder) throws {
@@ -34,6 +36,9 @@ extension PortalConfiguration {
             ? container.decode(PortalDesiredState.self, forKey: .desiredState)
             : .enabled
         lifecycle = try container.decode(PortalLifecycle.self, forKey: .lifecycle)
+        removalAssignedName = lifecycle == .pendingRemoval
+            ? try container.decodeIfPresent(String.self, forKey: .removalAssignedName)
+            : nil
     }
 
     func encode(to encoder: Encoder) throws {
@@ -44,12 +49,16 @@ extension PortalConfiguration {
         try container.encode(createdAt, forKey: .createdAt)
         try container.encode(desiredState, forKey: .desiredState)
         try container.encode(lifecycle, forKey: .lifecycle)
+        if lifecycle == .pendingRemoval {
+            try container.encodeIfPresent(removalAssignedName, forKey: .removalAssignedName)
+        }
     }
 }
 
 enum PortalLifecycle: String, Codable, Equatable {
     case active
     case pendingTailnetRejection
+    case pendingRemoval
 }
 
 struct TailnetBinding: Codable, Equatable {

--- a/Portico/PortalController.swift
+++ b/Portico/PortalController.swift
@@ -1,5 +1,18 @@
 import Foundation
 
+enum PortalRemovalState: Equatable {
+    case waitingForHelper
+    case reconciling
+    case removing
+    case failed
+}
+
+struct PortalRemovalNotice: Equatable, Identifiable {
+    let id: UUID
+    let portalName: String
+    let assignedName: String?
+}
+
 @MainActor
 final class PortalController: ObservableObject {
     static let manualRemovalURL = URL(
@@ -19,12 +32,17 @@ final class PortalController: ObservableObject {
     @Published private(set) var reachabilityStates: [UUID: LocalAppReachabilityState] = [:]
     @Published private(set) var staleStatusIDs: Set<UUID> = []
     @Published private(set) var diagnosticEntries: [DiagnosticEntry] = []
+    @Published private(set) var removalStates: [UUID: PortalRemovalState] = [:]
+    @Published private(set) var removalNotices: [PortalRemovalNotice] = []
 
     var portal: PortalConfiguration? { portals.first }
     var status: PortalStatusPayload? { portal.flatMap { statuses[$0.id] } }
     var canResetTailnet: Bool { portals.isEmpty && installation.tailnetBinding != nil }
     var pendingPortals: [PortalConfiguration] {
         portals.filter { $0.lifecycle == .pendingTailnetRejection }
+    }
+    var pendingRemovalPortals: [PortalConfiguration] {
+        portals.filter { $0.lifecycle == .pendingRemoval }
     }
 
     private let store: PortalStore
@@ -42,6 +60,8 @@ final class PortalController: ObservableObject {
     private var reconciliationGeneration = 0
     private var reconciliationInFlight = false
     private var pendingReconciliation: PortalReconciliation?
+    private var removalAttemptTokens: [UUID: Int] = [:]
+    private var removalsAwaitingReconciliation: [UUID: Int] = [:]
 
     init(
         store: PortalStore,
@@ -72,6 +92,9 @@ final class PortalController: ObservableObject {
         do {
             installation = try store.loadInstallation()
             publishInstallation()
+            for portal in installation.portals where portal.lifecycle == .pendingRemoval {
+                queueRemovalAttempt(portal.id, schedule: false)
+            }
         } catch {
             message = "Saved Portal configuration could not be loaded."
         }
@@ -180,6 +203,58 @@ final class PortalController: ObservableObject {
 
     func stopPortal(id: UUID) {
         updateDesiredState(id: id, desiredState: .stopped)
+    }
+
+    func removalWarningText(for portal: PortalConfiguration) -> String {
+        let assignedName = statuses[portal.id]?.assignedName ?? portal.removalAssignedName
+        let device = assignedName.map { " The Tailscale device “\($0)”" }
+            ?? " Its remote Tailscale device"
+        return "Remove Portal “\(portal.name)” from this Mac? This permanently deletes its local configuration and local Tailscale identity state.\(device) may remain in the tailnet and may require manual removal."
+    }
+
+    func removalNoticeText(for notice: PortalRemovalNotice) -> String {
+        let device = notice.assignedName.map { " The Tailscale device “\($0)”" }
+            ?? " Its remote Tailscale device"
+        return "Removed Portal “\(notice.portalName)” from this Mac.\(device) may remain in the tailnet and may require manual removal."
+    }
+
+    func pendingRemovalWarningText(for portal: PortalConfiguration) -> String {
+        let device = portal.removalAssignedName.map { " The Tailscale device “\($0)”" }
+            ?? " Its remote Tailscale device"
+        return "Removing Portal “\(portal.name)” from this Mac permanently deletes its local configuration and local Tailscale identity state.\(device) may remain in the tailnet and may require manual removal."
+    }
+
+    func removePortal(id: UUID) {
+        guard let index = installation.portals.firstIndex(where: {
+            $0.id == id && $0.lifecycle == .active
+        }) else { return }
+        var updated = installation
+        updated.portals[index].lifecycle = .pendingRemoval
+        updated.portals[index].removalAssignedName = statuses[id]?.assignedName
+        do {
+            try store.save(updated)
+            installation = updated
+            authenticationPending.remove(id)
+            statuses.removeValue(forKey: id)
+            staleStatusIDs.remove(id)
+            reachabilityStates.removeValue(forKey: id)
+            publishInstallation()
+            message = nil
+            queueRemovalAttempt(id)
+        } catch {
+            message = "The Portal could not be saved for removal."
+        }
+    }
+
+    func retryRemoval(id: UUID) {
+        guard installation.portals.contains(where: {
+            $0.id == id && $0.lifecycle == .pendingRemoval
+        }), removalStates[id] == .failed else { return }
+        queueRemovalAttempt(id)
+    }
+
+    func dismissRemovalNotice(id: UUID) {
+        removalNotices.removeAll { $0.id == id }
     }
 
     func updateLocalAppPort(id: UUID, port: String) {
@@ -306,6 +381,16 @@ final class PortalController: ObservableObject {
         }
     }
 
+    private func queueRemovalAttempt(_ id: UUID, schedule: Bool = true) {
+        let token = (removalAttemptTokens[id] ?? 0) + 1
+        removalAttemptTokens[id] = token
+        removalsAwaitingReconciliation[id] = token
+        removalStates[id] = .waitingForHelper
+        if schedule {
+            scheduleReconciliation()
+        }
+    }
+
     private func scheduleReconciliation() {
         reconciliationGeneration += 1
         let reconciliation = PortalReconciliation(
@@ -322,6 +407,15 @@ final class PortalController: ObservableObject {
 
     private func send(_ reconciliation: PortalReconciliation) {
         reconciliationInFlight = true
+        let removalAttempts = removalsAwaitingReconciliation.filter { id, token in
+            removalAttemptTokens[id] == token && installation.portals.contains(where: {
+                $0.id == id && $0.lifecycle == .pendingRemoval
+            })
+        }
+        for (id, _) in removalAttempts {
+            removalsAwaitingReconciliation.removeValue(forKey: id)
+            removalStates[id] = .reconciling
+        }
         helper.reconcilePortals(reconciliation.portals) { [weak self] result in
             guard let self else { return }
             self.reconciliationInFlight = false
@@ -331,8 +425,16 @@ final class PortalController: ObservableObject {
                     self.message = response.entries.contains { $0.outcome != .converged }
                         ? "Some Portals could not be reconciled."
                         : nil
+                    self.continueRemovalAttempts(removalAttempts, after: response)
                 case .failure:
                     self.message = "Portals could not be reconciled."
+                    for (id, token) in removalAttempts {
+                        self.failRemovalAttempt(id: id, token: token)
+                    }
+                }
+            } else {
+                for (id, token) in removalAttempts where self.removalAttemptTokens[id] == token {
+                    self.removalsAwaitingReconciliation[id] = token
                 }
             }
             if let pending = self.pendingReconciliation {
@@ -343,10 +445,78 @@ final class PortalController: ObservableObject {
         }
     }
 
+    private func continueRemovalAttempts(
+        _ attempts: [UUID: Int],
+        after response: ReconcilePortalsResult
+    ) {
+        for (id, token) in attempts {
+            guard removalAttemptTokens[id] == token,
+                  installation.portals.contains(where: {
+                      $0.id == id && $0.lifecycle == .pendingRemoval
+                  })
+            else { continue }
+            if let entry = response.entries.first(where: { $0.portalId == id }),
+               entry.outcome != .converged {
+                failRemovalAttempt(id: id, token: token)
+                continue
+            }
+            removalStates[id] = .removing
+            helper.removePortal(id: id) { [weak self] result in
+                guard let self, self.removalAttemptTokens[id] == token else { return }
+                switch result {
+                case .success:
+                    self.finishRemoval(id: id, token: token)
+                case .failure:
+                    self.failRemovalAttempt(id: id, token: token)
+                }
+            }
+        }
+    }
+
+    private func failRemovalAttempt(id: UUID, token: Int) {
+        guard removalAttemptTokens[id] == token else { return }
+        removalStates[id] = .failed
+        message = "Portal removal could not be completed. Retry when ready."
+    }
+
+    private func finishRemoval(id: UUID, token: Int) {
+        guard removalAttemptTokens[id] == token,
+              let portal = installation.portals.first(where: {
+                  $0.id == id && $0.lifecycle == .pendingRemoval
+              })
+        else { return }
+        var updated = installation
+        updated.portals.removeAll { $0.id == id }
+        do {
+            try store.save(updated)
+            installation = updated
+            statuses.removeValue(forKey: id)
+            authenticationPending.remove(id)
+            staleStatusIDs.remove(id)
+            reachabilityStates.removeValue(forKey: id)
+            removalAttemptTokens.removeValue(forKey: id)
+            removalsAwaitingReconciliation.removeValue(forKey: id)
+            removalStates.removeValue(forKey: id)
+            removalNotices.removeAll { $0.id == id }
+            removalNotices.append(PortalRemovalNotice(
+                id: id,
+                portalName: portal.name,
+                assignedName: portal.removalAssignedName
+            ))
+            publishInstallation()
+            message = nil
+        } catch {
+            failRemovalAttempt(id: id, token: token)
+            message = "Local cleanup completed, but the Portal record could not be removed. Retry when ready."
+        }
+    }
+
     private func receive(_ event: PortalHelperEvent) {
         switch event {
         case let .status(id, status):
-            guard let portal = installation.portals.first(where: { $0.id == id }) else { return }
+            guard let portal = installation.portals.first(where: {
+                $0.id == id && $0.lifecycle == .active
+            }) else { return }
             let displayStatus = status.sanitizedForDisplay()
             statuses[id] = displayStatus
             staleStatusIDs.remove(id)
@@ -465,7 +635,7 @@ final class PortalController: ObservableObject {
         portals = installation.portals
         alerts = installation.alerts
         tailnetDisplaySuffix = installation.tailnetBinding?.magicDNSSuffix.nonEmpty
-        reachability?.update(portals: installation.portals)
+        reachability?.update(portals: installation.portals.filter { $0.lifecycle == .active })
     }
 
     private func recordPortalState(_ portal: PortalConfiguration) {

--- a/Portico/PorticoApp.swift
+++ b/Portico/PorticoApp.swift
@@ -22,6 +22,7 @@ private struct PortalView: View {
     @ObservedObject var controller: PortalController
     @ObservedObject var supervisor: HelperSupervisor
     @State private var showingResetConfirmation = false
+    @State private var removalCandidate: PortalConfiguration?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -38,11 +39,21 @@ private struct PortalView: View {
             ForEach(controller.pendingPortals, id: \.id) { portal in
                 pendingWarning(portal)
             }
+            ForEach(controller.pendingRemovalPortals, id: \.id) { portal in
+                pendingRemoval(portal)
+            }
+            ForEach(controller.removalNotices) { notice in
+                removalNotice(notice)
+            }
             ForEach(controller.alerts) { alert in
                 completedWarning(alert)
             }
             ForEach(controller.portals.filter { $0.lifecycle == .active }, id: \.id) { portal in
-                PortalStatusView(controller: controller, portal: portal)
+                PortalStatusView(
+                    controller: controller,
+                    portal: portal,
+                    onRemove: { removalCandidate = portal }
+                )
                 Divider()
             }
             addPortalForm
@@ -69,6 +80,31 @@ private struct PortalView: View {
                 controller.resetTailnet(confirmed: true)
             }
             Button("Cancel", role: .cancel) {}
+        }
+        .sheet(isPresented: Binding(
+            get: { removalCandidate != nil },
+            set: { if !$0 { removalCandidate = nil } }
+        )) {
+            if let portal = removalCandidate {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Remove Portal?").font(.headline)
+                    Text(controller.removalWarningText(for: portal))
+                    Link(
+                        "How to remove a Tailscale device",
+                        destination: PortalController.manualRemovalURL
+                    )
+                    HStack {
+                        Spacer()
+                        Button("Cancel") { removalCandidate = nil }
+                        Button("Remove Portal", role: .destructive) {
+                            controller.removePortal(id: portal.id)
+                            removalCandidate = nil
+                        }
+                    }
+                }
+                .padding()
+                .frame(width: 420)
+            }
         }
         Divider()
         Button("Quit Portico") {
@@ -138,17 +174,52 @@ private struct PortalView: View {
                 .controlSize(.small)
         }
     }
+
+    private func pendingRemoval(_ portal: PortalConfiguration) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Label("Removing Portal", systemImage: "trash")
+                .font(.headline)
+            Text(controller.pendingRemovalWarningText(for: portal))
+                .font(.caption)
+            Link("How to remove a Tailscale device", destination: PortalController.manualRemovalURL)
+                .font(.caption)
+            if controller.removalStates[portal.id] == .failed {
+                Button("Retry Removal") { controller.retryRemoval(id: portal.id) }
+                    .controlSize(.small)
+            } else {
+                ProgressView()
+                    .controlSize(.small)
+            }
+            Button("Diagnostics") { openWindow(id: "diagnostics") }
+                .controlSize(.small)
+        }
+    }
+
+    private func removalNotice(_ notice: PortalRemovalNotice) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Label("Portal removed from this Mac", systemImage: "exclamationmark.triangle.fill")
+                .font(.headline)
+            Text(controller.removalNoticeText(for: notice))
+                .font(.caption)
+            Link("How to remove a Tailscale device", destination: PortalController.manualRemovalURL)
+                .font(.caption)
+            Button("Dismiss") { controller.dismissRemovalNotice(id: notice.id) }
+                .controlSize(.small)
+        }
+    }
 }
 
 private struct PortalStatusView: View {
     @Environment(\.openWindow) private var openWindow
     @ObservedObject var controller: PortalController
     let portal: PortalConfiguration
+    let onRemove: () -> Void
     @State private var localAppPort: String
 
-    init(controller: PortalController, portal: PortalConfiguration) {
+    init(controller: PortalController, portal: PortalConfiguration, onRemove: @escaping () -> Void) {
         self.controller = controller
         self.portal = portal
+        self.onRemove = onRemove
         _localAppPort = State(initialValue: String(portal.localAppPort))
     }
 
@@ -201,6 +272,8 @@ private struct PortalStatusView: View {
             value: (controller.reachabilityStates[portal.id] ?? .unknown).title
         )
         Button("Diagnostics") { openWindow(id: "diagnostics") }
+            .controlSize(.small)
+        Button("Remove Portal", role: .destructive, action: onRemove)
             .controlSize(.small)
     }
 

--- a/PorticoTests/DiagnosticsTests.swift
+++ b/PorticoTests/DiagnosticsTests.swift
@@ -41,14 +41,14 @@ final class DiagnosticsTests: XCTestCase {
             isStale: true
         )
         let report = DiagnosticReportRenderer.render(
-            versions: DiagnosticVersions(porticoShort: "1.2", porticoBuild: "34", helperProtocol: 2),
+            versions: DiagnosticVersions(porticoShort: "1.2", porticoBuild: "34", helperProtocol: 3),
             helper: .failed,
             portals: [facts],
             history: history.entries
         )
 
         for value in [
-            "Portico 1.2 (34)", "Helper protocol 2", "hermes", "hermes-1",
+            "Portico 1.2 (34)", "Helper protocol 3", "hermes", "hermes-1",
             "https://hermes-1.example.ts.net/", "100.64.0.1", "example.ts.net",
             "Desired: enabled", "Tailscale: online", "Reachability: reachable", "Facts: stale",
             "Helper: unavailable",

--- a/PorticoTests/HelperProtocolTests.swift
+++ b/PorticoTests/HelperProtocolTests.swift
@@ -2,9 +2,9 @@ import XCTest
 @testable import Portico
 
 final class HelperProtocolTests: XCTestCase {
-    func testVersionTwoReconciliationFixturesRoundTrip() throws {
-        let requestFixture = #"{"version":2,"requestId":"reconcile-1","command":"reconcilePortals","payload":{"portals":[{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","portalName":"hermes","localAppPort":8787,"desiredState":"enabled"},{"portalId":"5EA74329-3144-4BA2-925F-138D14D61FCC","portalName":"atlas","localAppPort":8788,"desiredState":"stopped"}]}}"#
-        let responseFixture = #"{"version":2,"requestId":"reconcile-1","result":{"entries":[{"portalId":"5EA74329-3144-4BA2-925F-138D14D61FCC","outcome":"converged"},{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","outcome":"startFailed"}]}}"#
+    func testVersionThreeReconciliationFixturesRoundTrip() throws {
+        let requestFixture = #"{"version":3,"requestId":"reconcile-1","command":"reconcilePortals","payload":{"portals":[{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","portalName":"hermes","localAppPort":8787,"desiredState":"enabled"},{"portalId":"5EA74329-3144-4BA2-925F-138D14D61FCC","portalName":"atlas","localAppPort":8788,"desiredState":"stopped"}]}}"#
+        let responseFixture = #"{"version":3,"requestId":"reconcile-1","result":{"entries":[{"portalId":"5EA74329-3144-4BA2-925F-138D14D61FCC","outcome":"converged"},{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","outcome":"startFailed"}]}}"#
 
         try assertRoundTrip(requestFixture, as: HelperRequest<ReconcilePortalsPayload>.self)
         let response = try JSONDecoder().decode(
@@ -28,39 +28,43 @@ final class HelperProtocolTests: XCTestCase {
         try assertRoundTrip(responseFixture, as: HelperResponse<ReconcilePortalsResult>.self)
     }
 
-    func testDecodesVersionTwoHandshakeResponse() throws {
-        let fixture = Data(#"{"version":2,"requestId":"request-1","result":{"protocolVersion":2}}"#.utf8)
+    func testDecodesVersionThreeHandshakeResponse() throws {
+        let fixture = Data(#"{"version":3,"requestId":"request-1","result":{"protocolVersion":3}}"#.utf8)
 
         let response = try JSONDecoder().decode(HelperResponse<HandshakeResult>.self, from: fixture)
 
-        XCTAssertEqual(response.version, 2)
+        XCTAssertEqual(response.version, 3)
         XCTAssertEqual(response.requestId, "request-1")
-        XCTAssertEqual(response.result?.protocolVersion, 2)
+        XCTAssertEqual(response.result?.protocolVersion, 3)
         XCTAssertNil(response.error)
     }
 
     func testDecodesStructuredProtocolError() throws {
-        let fixture = Data(#"{"version":2,"requestId":"request-2","error":{"code":"unknownCommand","message":"unsupported command"}}"#.utf8)
+        let fixture = Data(#"{"version":3,"requestId":"request-2","error":{"code":"unknownCommand","message":"unsupported command"}}"#.utf8)
 
         let response = try JSONDecoder().decode(HelperResponse<HandshakeResult>.self, from: fixture)
 
-        XCTAssertEqual(response.version, 2)
+        XCTAssertEqual(response.version, 3)
         XCTAssertEqual(response.requestId, "request-2")
         XCTAssertNil(response.result)
         XCTAssertEqual(response.error, HelperProtocolError(code: "unknownCommand", message: "unsupported command"))
     }
 
-    func testVersionTwoPortalFixturesRoundTrip() throws {
+    func testVersionThreePortalFixturesRoundTrip() throws {
         let portalID = UUID(uuidString: "9f55ca93-d7b3-4eab-a871-310ea576005a")!
         try assertRoundTrip(
-            #"{"version":2,"requestId":"auth-1","command":"authenticatePortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A"}}"#,
+            #"{"version":3,"requestId":"auth-1","command":"authenticatePortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A"}}"#,
             as: HelperRequest<AuthenticatePortalPayload>.self
         )
         try assertRoundTrip(
-            #"{"version":2,"requestId":"cleanup-1","command":"cleanupRejectedPortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A"}}"#,
+            #"{"version":3,"requestId":"cleanup-1","command":"cleanupRejectedPortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A"}}"#,
             as: HelperRequest<CleanupRejectedPortalPayload>.self
         )
-        let statusFixture = #"{"version":2,"event":"portalStatus","portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","payload":{"state":"online","stableNodeId":"node-1","assignedName":"hermes-1","portalURL":"https:\/\/hermes-1.example.ts.net\/","addresses":["100.64.0.1","fd7a:115c:a1e0::1"],"tailnetName":"opaque-identity-do-not-display","magicDNSSuffix":"example.ts.net"}}"#
+        try assertRoundTrip(
+            #"{"version":3,"requestId":"remove-1","command":"removePortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A"}}"#,
+            as: HelperRequest<RemovePortalPayload>.self
+        )
+        let statusFixture = #"{"version":3,"event":"portalStatus","portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","payload":{"state":"online","stableNodeId":"node-1","assignedName":"hermes-1","portalURL":"https:\/\/hermes-1.example.ts.net\/","addresses":["100.64.0.1","fd7a:115c:a1e0::1"],"tailnetName":"opaque-identity-do-not-display","magicDNSSuffix":"example.ts.net"}}"#
         let status = try JSONDecoder().decode(HelperEvent<PortalStatusPayload>.self, from: Data(statusFixture.utf8))
         XCTAssertEqual(status.portalId, portalID)
         XCTAssertEqual(status.payload.state, .online)
@@ -69,12 +73,12 @@ final class HelperProtocolTests: XCTestCase {
         XCTAssertEqual(status.payload.magicDNSSuffix, "example.ts.net")
         try assertRoundTrip(statusFixture, as: HelperEvent<PortalStatusPayload>.self)
 
-        let authenticationFixture = #"{"version":2,"event":"authenticationURL","portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","payload":{"url":"https:\/\/login.tailscale.com\/a\/secret"}}"#
+        let authenticationFixture = #"{"version":3,"event":"authenticationURL","portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","payload":{"url":"https:\/\/login.tailscale.com\/a\/secret"}}"#
         try assertRoundTrip(authenticationFixture, as: HelperEvent<AuthenticationURLPayload>.self)
     }
 
-    func testDecodesVersionTwoDiscoverLocalAppsResult() throws {
-        let fixture = Data(#"{"version":2,"requestId":"discover-1","result":{"candidates":[{"localAppPort":3000,"processLabel":"node","suggestedPortalName":"hermes"},{"localAppPort":8787,"processLabel":"python3"}]}}"#.utf8)
+    func testDecodesVersionThreeDiscoverLocalAppsResult() throws {
+        let fixture = Data(#"{"version":3,"requestId":"discover-1","result":{"candidates":[{"localAppPort":3000,"processLabel":"node","suggestedPortalName":"hermes"},{"localAppPort":8787,"processLabel":"python3"}]}}"#.utf8)
 
         let response = try JSONDecoder().decode(HelperResponse<DiscoverLocalAppsResult>.self, from: fixture)
 

--- a/PorticoTests/HelperShutdownTests.swift
+++ b/PorticoTests/HelperShutdownTests.swift
@@ -15,7 +15,7 @@ final class HelperShutdownTests: XCTestCase {
             shutdownGraceInterval: 1
         )
         supervisor.start()
-        launcher.receive(line: #"{"version":2,"requestId":"handshake-1","result":{"protocolVersion":2}}"#)
+        launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
         var completionCount = 0
 
         supervisor.shutdown { completionCount += 1 }
@@ -28,7 +28,7 @@ final class HelperShutdownTests: XCTestCase {
         XCTAssertEqual(request.requestId, "shutdown-1")
         XCTAssertEqual(request.command, .shutdown)
 
-        launcher.receive(line: #"{"version":2,"requestId":"shutdown-1","result":{"accepted":true}}"#)
+        launcher.receive(line: #"{"version":3,"requestId":"shutdown-1","result":{"accepted":true}}"#)
         XCTAssertEqual(completionCount, 0)
         launcher.exit(status: 0)
 
@@ -47,7 +47,7 @@ final class HelperShutdownTests: XCTestCase {
             shutdownGraceInterval: 0.01
         )
         supervisor.start()
-        launcher.receive(line: #"{"version":2,"requestId":"handshake-1","result":{"protocolVersion":2}}"#)
+        launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
         var completionCount = 0
 
         supervisor.shutdown { completionCount += 1 }
@@ -84,7 +84,7 @@ final class HelperShutdownTests: XCTestCase {
             shutdownGraceInterval: 1
         )
         supervisor.start()
-        launcher.receive(line: #"{"version":2,"requestId":"handshake-1","result":{"protocolVersion":2}}"#)
+        launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
         var completionCount = 0
 
         supervisor.shutdown { completionCount += 1 }

--- a/PorticoTests/HelperSupervisorTests.swift
+++ b/PorticoTests/HelperSupervisorTests.swift
@@ -60,18 +60,18 @@ final class HelperSupervisorTests: XCTestCase {
         supervisor.start()
         launcher.exit(status: 1)
         scheduler.runNext()
-        launcher.receive(line: #"{"version":2,"requestId":"handshake-2","result":{"protocolVersion":2}}"#)
+        launcher.receive(line: #"{"version":3,"requestId":"handshake-2","result":{"protocolVersion":3}}"#)
         supervisor.reconcilePortals([]) { _ in }
-        launcher.receive(line: #"{"version":2,"requestId":"reconcile-2","result":{"entries":[]}}"#)
+        launcher.receive(line: #"{"version":3,"requestId":"reconcile-2","result":{"entries":[]}}"#)
 
         XCTAssertTrue(scheduler.pendingDelays.contains(300))
         launcher.exit(status: 1)
         XCTAssertEqual(supervisor.availability, .retrying(attempt: 2, delay: 2))
 
         scheduler.run(delay: 2)
-        launcher.receive(line: #"{"version":2,"requestId":"handshake-3","result":{"protocolVersion":2}}"#)
+        launcher.receive(line: #"{"version":3,"requestId":"handshake-3","result":{"protocolVersion":3}}"#)
         supervisor.reconcilePortals([]) { _ in }
-        launcher.receive(line: #"{"version":2,"requestId":"reconcile-3","result":{"entries":[]}}"#)
+        launcher.receive(line: #"{"version":3,"requestId":"reconcile-3","result":{"entries":[]}}"#)
         scheduler.run(delay: 300)
         launcher.exit(status: 1)
 
@@ -92,14 +92,14 @@ final class HelperSupervisorTests: XCTestCase {
         XCTAssertEqual(supervisor.availability, .connecting)
         let requestData = try XCTUnwrap(launcher.process.sent.first)
         let request = try JSONDecoder().decode(HelperRequest<EmptyPayload>.self, from: requestData)
-        XCTAssertEqual(request.version, 2)
+        XCTAssertEqual(request.version, 3)
         XCTAssertEqual(request.requestId, "request-1")
         XCTAssertEqual(request.command, .handshake)
 
-        launcher.receive(line: #"{"version":2,"requestId":"other","result":{"protocolVersion":2}}"#)
+        launcher.receive(line: #"{"version":3,"requestId":"other","result":{"protocolVersion":3}}"#)
         XCTAssertEqual(supervisor.availability, .connecting)
 
-        launcher.receive(line: #"{"version":2,"requestId":"request-1","result":{"protocolVersion":2}}"#)
+        launcher.receive(line: #"{"version":3,"requestId":"request-1","result":{"protocolVersion":3}}"#)
         XCTAssertEqual(supervisor.availability, .connected)
     }
 
@@ -124,7 +124,7 @@ final class HelperSupervisorTests: XCTestCase {
     func testHandshakeFailuresEnterSharedRecoveryBudgetAfterChildExit() {
         let failures: [(String, Bool, (FakeHelperLauncher) -> Void)] = [
             ("malformed line", false, { $0.receive(line: "{") }),
-            ("correlated error", false, { $0.receive(line: #"{"version":2,"requestId":"request-1","error":{"code":"unsupportedVersion","message":"unsupported protocol version"}}"#) }),
+            ("correlated error", false, { $0.receive(line: #"{"version":3,"requestId":"request-1","error":{"code":"unsupportedVersion","message":"unsupported protocol version"}}"#) }),
             ("unsupported response version", false, { $0.receive(line: #"{"version":1,"requestId":"request-1","result":{"protocolVersion":1}}"#) }),
             ("EOF", false, { $0.receiveEOF() }),
             ("nonzero exit", true, { $0.exit(status: 1) }),
@@ -166,7 +166,7 @@ final class HelperSupervisorTests: XCTestCase {
         supervisor.onEvent = { events.append($0) }
         supervisor.start()
         XCTAssertEqual(launcher.arguments, ["--state-root", "/trusted/tsnet"])
-        launcher.receive(line: #"{"version":2,"requestId":"handshake-1","result":{"protocolVersion":2}}"#)
+        launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
         let laterPortal = PortalConfiguration(
             id: UUID(uuidString: "9f55ca93-d7b3-4eab-a871-310ea576005a")!,
             name: "hermes",
@@ -205,10 +205,10 @@ final class HelperSupervisorTests: XCTestCase {
                 ),
             ]
         )
-        launcher.receive(line: #"{"version":2,"event":"portalStatus","portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","payload":{"state":"connecting","addresses":[]}}"#)
+        launcher.receive(line: #"{"version":3,"event":"portalStatus","portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","payload":{"state":"connecting","addresses":[]}}"#)
         XCTAssertEqual(events, [.status(laterPortal.id, PortalStatusPayload(state: .connecting, stableNodeId: nil, assignedName: nil, portalURL: nil, addresses: []))])
         XCTAssertNil(result)
-        launcher.receive(line: #"{"version":2,"requestId":"reconcile-1","result":{"entries":[{"portalId":"5EA74329-3144-4BA2-925F-138D14D61FCC","outcome":"converged"},{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","outcome":"startFailed"}]}}"#)
+        launcher.receive(line: #"{"version":3,"requestId":"reconcile-1","result":{"entries":[{"portalId":"5EA74329-3144-4BA2-925F-138D14D61FCC","outcome":"converged"},{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","outcome":"startFailed"}]}}"#)
         XCTAssertEqual(
             try result?.get().entries,
             [
@@ -228,7 +228,7 @@ final class HelperSupervisorTests: XCTestCase {
             handshakeTimeout: 1
         )
         supervisor.start()
-        launcher.receive(line: #"{"version":2,"requestId":"handshake-1","result":{"protocolVersion":2}}"#)
+        launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
         var result: Result<ReconcilePortalsResult, Error>?
 
         supervisor.reconcilePortals([]) { result = $0 }
@@ -249,7 +249,7 @@ final class HelperSupervisorTests: XCTestCase {
             handshakeTimeout: 1
         )
         supervisor.start()
-        launcher.receive(line: #"{"version":2,"requestId":"handshake-1","result":{"protocolVersion":2}}"#)
+        launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
         var result: Result<[LocalAppCandidatePayload], Error>?
 
         supervisor.discoverLocalApps { result = $0 }
@@ -258,7 +258,7 @@ final class HelperSupervisorTests: XCTestCase {
         let request = try JSONDecoder().decode(HelperRequest<EmptyPayload>.self, from: requestData)
         XCTAssertEqual(request.command, .discoverLocalApps)
         XCTAssertEqual(request.requestId, "discover-1")
-        launcher.receive(line: #"{"version":2,"requestId":"discover-1","result":{"candidates":[{"localAppPort":3000,"processLabel":"node","suggestedPortalName":"hermes"}]}}"#)
+        launcher.receive(line: #"{"version":3,"requestId":"discover-1","result":{"candidates":[{"localAppPort":3000,"processLabel":"node","suggestedPortalName":"hermes"}]}}"#)
         XCTAssertEqual(
             try result?.get(),
             [LocalAppCandidatePayload(localAppPort: 3000, processLabel: "node", suggestedPortalName: "hermes")]
@@ -275,7 +275,7 @@ final class HelperSupervisorTests: XCTestCase {
             handshakeTimeout: 1
         )
         supervisor.start()
-        launcher.receive(line: #"{"version":2,"requestId":"handshake-1","result":{"protocolVersion":2}}"#)
+        launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
         let portalID = UUID(uuidString: "9f55ca93-d7b3-4eab-a871-310ea576005a")!
         var result: Result<Void, Error>?
 
@@ -286,8 +286,43 @@ final class HelperSupervisorTests: XCTestCase {
         XCTAssertEqual(request.command, .cleanupRejectedPortal)
         XCTAssertEqual(request.payload.portalId, portalID)
         XCTAssertNil(result)
-        launcher.receive(line: #"{"version":2,"requestId":"cleanup-1","result":{"accepted":true}}"#)
+        launcher.receive(line: #"{"version":3,"requestId":"cleanup-1","result":{"accepted":true}}"#)
         XCTAssertNoThrow(try result?.get())
+    }
+
+    func testRemovalRequestIsUUIDOnlyAndFailsWhenProcessGenerationIsLost() throws {
+        let launcher = FakeHelperLauncher()
+        var requestIDs = ["handshake-1", "remove-1"]
+        let supervisor = HelperSupervisor(
+            helperURL: URL(fileURLWithPath: "/unused/portico-helper"),
+            launcher: launcher,
+            requestIDProvider: { requestIDs.removeFirst() },
+            handshakeTimeout: 1
+        )
+        supervisor.start()
+        launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
+        let portalID = UUID(uuidString: "9f55ca93-d7b3-4eab-a871-310ea576005a")!
+        var result: Result<Void, Error>?
+
+        supervisor.removePortal(id: portalID) { result = $0 }
+
+        let requestData = try XCTUnwrap(launcher.process.sent.last)
+        let request = try JSONDecoder().decode(HelperRequest<RemovePortalPayload>.self, from: requestData)
+        XCTAssertEqual(request.command, .removePortal)
+        XCTAssertEqual(request.payload, RemovePortalPayload(portalId: portalID))
+        XCTAssertEqual(try JSONSerialization.jsonObject(with: requestData) as? NSDictionary, [
+            "version": 3,
+            "requestId": "remove-1",
+            "command": "removePortal",
+            "payload": ["portalId": portalID.uuidString],
+        ])
+        XCTAssertNil(result)
+
+        launcher.receiveEOF()
+
+        guard case .failure(HelperClientError.protocolFailure) = result else {
+            return XCTFail("expected unresolved removal to fail after process loss")
+        }
     }
 
     func testReturnsFixedHelperDiscoveryFailure() throws {
@@ -300,11 +335,11 @@ final class HelperSupervisorTests: XCTestCase {
             handshakeTimeout: 1
         )
         supervisor.start()
-        launcher.receive(line: #"{"version":2,"requestId":"handshake-1","result":{"protocolVersion":2}}"#)
+        launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
         var result: Result<[LocalAppCandidatePayload], Error>?
 
         supervisor.discoverLocalApps { result = $0 }
-        launcher.receive(line: #"{"version":2,"requestId":"discover-1","error":{"code":"discoveryFailure","message":"local app discovery failed"}}"#)
+        launcher.receive(line: #"{"version":3,"requestId":"discover-1","error":{"code":"discoveryFailure","message":"local app discovery failed"}}"#)
 
         guard case let .failure(HelperClientError.helper(error)) = result else {
             return XCTFail("expected fixed helper discovery failure")

--- a/PorticoTests/PortalControllerTests.swift
+++ b/PorticoTests/PortalControllerTests.swift
@@ -363,6 +363,182 @@ final class PortalControllerTests: XCTestCase {
         XCTAssertEqual(controller.message, "Some Portals could not be reconciled.")
     }
 
+    func testRemovalCommitsBeforePublishingAndOmitsPortalBeforeDeletingState() throws {
+        let otherID = UUID(uuidString: "5ea74329-3144-4ba2-925f-138d14d61fcc")!
+        let removedPortal = PortalConfiguration(
+            id: portalID,
+            name: "hermes",
+            localAppPort: 8787,
+            createdAt: Date()
+        )
+        let otherPortal = PortalConfiguration(
+            id: otherID,
+            name: "atlas",
+            localAppPort: 8788,
+            createdAt: Date()
+        )
+        let store = PortalStore(rootURL: temporaryRoot())
+        try store.save(InstallationRecord(portals: [removedPortal, otherPortal]))
+        let client = FakePortalHelperClient(availability: .connecting)
+        client.completeReconciliationImmediately = false
+        client.completeRemovalImmediately = false
+        let controller = PortalController(store: store, helper: client, openURL: { _ in })
+        client.send(.status(portalID, PortalStatusPayload(
+            state: .connecting,
+            stableNodeId: "secret-node",
+            assignedName: "hermes-1",
+            portalURL: nil,
+            addresses: []
+        )))
+
+        XCTAssertEqual(
+            controller.removalWarningText(for: removedPortal),
+            "Remove Portal “hermes” from this Mac? This permanently deletes its local configuration and local Tailscale identity state. The Tailscale device “hermes-1” may remain in the tailnet and may require manual removal."
+        )
+        controller.removePortal(id: portalID)
+
+        let persisted = try XCTUnwrap(store.loadInstallation().portals.first(where: { $0.id == portalID }))
+        XCTAssertEqual(persisted.lifecycle, .pendingRemoval)
+        XCTAssertEqual(persisted.removalAssignedName, "hermes-1")
+        XCTAssertEqual(controller.pendingRemovalPortals.map(\.id), [portalID])
+        XCTAssertEqual(
+            controller.pendingRemovalWarningText(for: persisted),
+            "Removing Portal “hermes” from this Mac permanently deletes its local configuration and local Tailscale identity state. The Tailscale device “hermes-1” may remain in the tailnet and may require manual removal."
+        )
+        XCTAssertNil(controller.statuses[portalID])
+        XCTAssertTrue(client.removed.isEmpty)
+
+        client.connect()
+
+        XCTAssertEqual(client.reconciliations, [[otherPortal]])
+        XCTAssertTrue(client.removed.isEmpty)
+        client.completeReconciliation(.success(ReconcilePortalsResult(entries: [])))
+        XCTAssertEqual(client.removed, [portalID])
+        XCTAssertEqual(controller.removalStates[portalID], .removing)
+
+        controller.startPortal(id: portalID)
+        controller.updateLocalAppPort(id: portalID, port: "9999")
+        controller.authenticate(id: portalID)
+        XCTAssertEqual(client.authenticated, [])
+        XCTAssertEqual(try store.loadInstallation().portals.first(where: { $0.id == portalID }), persisted)
+    }
+
+    func testPendingRemovalGetsOneAutomaticCycleAcrossReconnectsAndExplicitRetryAddsOne() throws {
+        let pending = PortalConfiguration(
+            id: portalID,
+            name: "hermes",
+            localAppPort: 8787,
+            createdAt: Date(),
+            lifecycle: .pendingRemoval,
+            removalAssignedName: "hermes-1"
+        )
+        let store = PortalStore(rootURL: temporaryRoot())
+        try store.save(InstallationRecord(portals: [pending]))
+        let client = FakePortalHelperClient(availability: .connecting)
+        client.completeRemovalImmediately = false
+        let controller = PortalController(store: store, helper: client, openURL: { _ in })
+
+        client.connect()
+        XCTAssertEqual(client.reconciliations, [[]])
+        XCTAssertEqual(client.removed, [portalID])
+        client.completeRemoval(.failure(NSError(domain: "secret", code: 1)))
+        XCTAssertEqual(controller.removalStates[portalID], .failed)
+
+        client.disconnect(as: .retrying(attempt: 1, delay: 1))
+        client.connect()
+        XCTAssertEqual(client.reconciliations, [[], []])
+        XCTAssertEqual(client.removed, [portalID])
+
+        controller.retryRemoval(id: portalID)
+        XCTAssertEqual(client.reconciliations, [[], [], []])
+        XCTAssertEqual(client.removed, [portalID, portalID])
+    }
+
+    func testRemovalWaitsForNewestActiveOnlyReconciliationAndSuppressesStaleEvents() throws {
+        let pending = PortalConfiguration(
+            id: portalID,
+            name: "hermes",
+            localAppPort: 8787,
+            createdAt: Date(),
+            lifecycle: .pendingRemoval,
+            removalAssignedName: "hermes-1"
+        )
+        let store = PortalStore(rootURL: temporaryRoot())
+        try store.save(InstallationRecord(portals: [pending]))
+        let client = FakePortalHelperClient(availability: .connecting)
+        client.completeReconciliationImmediately = false
+        let controller = PortalController(store: store, helper: client, openURL: { _ in })
+
+        client.connect()
+        client.send(.status(portalID, PortalStatusPayload(
+            state: .online,
+            stableNodeId: "stale-node",
+            assignedName: "stale-name",
+            portalURL: URL(string: "https://stale.example.ts.net/"),
+            addresses: ["100.64.0.1"]
+        )))
+        client.send(.authenticationURL(portalID, URL(string: "https://login.tailscale.com/a/stale")!))
+
+        XCTAssertNil(controller.statuses[portalID])
+        client.completeReconciliation(.success(ReconcilePortalsResult(entries: [
+            ReconcilePortalEntry(portalId: portalID, outcome: .closeFailed)
+        ])))
+        XCTAssertTrue(client.removed.isEmpty)
+        XCTAssertEqual(controller.removalStates[portalID], .failed)
+
+        controller.retryRemoval(id: portalID)
+        client.completeReconciliation(.success(ReconcilePortalsResult(entries: [])), at: 1)
+        XCTAssertEqual(client.removed, [portalID])
+    }
+
+    func testRemovalCompletionRetainsPendingRecordUntilAtomicSaveSucceeds() throws {
+        let root = temporaryRoot()
+        let seedStore = PortalStore(rootURL: root)
+        let pending = PortalConfiguration(
+            id: portalID,
+            name: "hermes",
+            localAppPort: 8787,
+            createdAt: Date(),
+            lifecycle: .pendingRemoval,
+            removalAssignedName: "hermes-1"
+        )
+        try seedStore.save(InstallationRecord(
+            tailnetBinding: TailnetBinding(name: "opaque-tailnet", magicDNSSuffix: "example.ts.net"),
+            portals: [pending]
+        ))
+        var failNextWrite = true
+        let store = PortalStore(rootURL: root, writeData: { data, url in
+            if failNextWrite {
+                failNextWrite = false
+                throw NSError(domain: "secret", code: 1)
+            }
+            try data.write(to: url, options: .atomic)
+        })
+        let client = FakePortalHelperClient()
+        let controller = PortalController(store: store, helper: client, openURL: { _ in })
+
+        XCTAssertEqual(client.removed, [portalID])
+        XCTAssertEqual(try store.loadInstallation().portals, [pending])
+        XCTAssertEqual(controller.pendingRemovalPortals, [pending])
+        XCTAssertEqual(controller.removalStates[portalID], .failed)
+        XCTAssertTrue(controller.removalNotices.isEmpty)
+
+        controller.retryRemoval(id: portalID)
+
+        XCTAssertEqual(client.removed, [portalID, portalID])
+        XCTAssertTrue(try store.loadInstallation().portals.isEmpty)
+        XCTAssertTrue(controller.portals.isEmpty)
+        XCTAssertEqual(controller.tailnetDisplaySuffix, "example.ts.net")
+        XCTAssertEqual(
+            controller.removalNotices,
+            [PortalRemovalNotice(id: portalID, portalName: "hermes", assignedName: "hermes-1")]
+        )
+        XCTAssertEqual(
+            controller.removalNoticeText(for: controller.removalNotices[0]),
+            "Removed Portal “hermes” from this Mac. The Tailscale device “hermes-1” may remain in the tailnet and may require manual removal."
+        )
+    }
+
     func testPresentsOnlyMatchingStructuredStatus() throws {
         let store = PortalStore(rootURL: temporaryRoot())
         let saved = PortalConfiguration(id: portalID, name: "hermes", localAppPort: 8787, createdAt: Date())
@@ -702,12 +878,12 @@ final class PortalControllerTests: XCTestCase {
         )
         let controller = PortalController(store: store, helper: supervisor, openURL: { _ in })
         supervisor.start()
-        launcher.receive(line: #"{"version":2,"requestId":"handshake-1","result":{"protocolVersion":2}}"#)
+        launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
         controller.stopPortal(id: portalID)
 
         launcher.exit(status: 1)
         scheduler.run(delay: 1)
-        launcher.receive(line: #"{"version":2,"requestId":"handshake-2","result":{"protocolVersion":2}}"#)
+        launcher.receive(line: #"{"version":3,"requestId":"handshake-2","result":{"protocolVersion":3}}"#)
 
         let request = try JSONDecoder().decode(
             HelperRequest<ReconcilePortalsPayload>.self,
@@ -817,10 +993,13 @@ final class FakePortalHelperClient: PortalHelperClient {
     var started: [PortalConfiguration] { reconciliations.flatMap { $0 } }
     private(set) var authenticated: [UUID] = []
     private(set) var cleaned: [UUID] = []
+    private(set) var removed: [UUID] = []
     private(set) var discoveryCompletions: [(Result<[LocalAppCandidatePayload], Error>) -> Void] = []
     private(set) var cleanupCompletions: [(Result<Void, Error>) -> Void] = []
+    private(set) var removalCompletions: [(Result<Void, Error>) -> Void] = []
     private(set) var reconciliationCompletions: [(Result<ReconcilePortalsResult, Error>) -> Void] = []
     var completeCleanupImmediately = true
+    var completeRemovalImmediately = true
     var completeReconciliationImmediately = true
     var onCleanup: ((UUID) -> Void)?
     var onReconcile: (([PortalConfiguration]) -> Void)?
@@ -862,6 +1041,15 @@ final class FakePortalHelperClient: PortalHelperClient {
         }
     }
 
+    func removePortal(id: UUID, completion: @escaping (Result<Void, Error>) -> Void) {
+        removed.append(id)
+        if completeRemovalImmediately {
+            completion(.success(()))
+        } else {
+            removalCompletions.append(completion)
+        }
+    }
+
     func discoverLocalApps(completion: @escaping (Result<[LocalAppCandidatePayload], Error>) -> Void) {
         discoveryCompletions.append(completion)
     }
@@ -885,6 +1073,10 @@ final class FakePortalHelperClient: PortalHelperClient {
 
     func completeCleanup(_ result: Result<Void, Error>, at index: Int = 0) {
         cleanupCompletions[index](result)
+    }
+
+    func completeRemoval(_ result: Result<Void, Error>, at index: Int = 0) {
+        removalCompletions[index](result)
     }
 
     func completeReconciliation(

--- a/PorticoTests/PortalStoreTests.swift
+++ b/PorticoTests/PortalStoreTests.swift
@@ -113,6 +113,27 @@ final class PortalStoreTests: XCTestCase {
         XCTAssertEqual(try store.loadInstallation(), installation)
     }
 
+    func testHistoricalVersionTwoDefaultsRemovalAssignedNameAndPendingRemovalRoundTrips() throws {
+        let store = PortalStore(rootURL: temporaryRoot())
+        try FileManager.default.createDirectory(at: store.rootURL, withIntermediateDirectories: true)
+        let historical = Data(
+            #"{"version":2,"portals":[{"id":"9F55CA93-D7B3-4EAB-A871-310EA576005A","name":"hermes","localAppPort":8787,"createdAt":807692800,"desiredState":"enabled","lifecycle":"active"}],"alerts":[]}"#.utf8
+        )
+        try historical.write(to: store.installationURL)
+
+        var installation = try store.loadInstallation()
+
+        XCTAssertEqual(installation.version, 2)
+        XCTAssertNil(installation.portals[0].removalAssignedName)
+
+        installation.portals[0].lifecycle = .pendingRemoval
+        installation.portals[0].removalAssignedName = "hermes-1"
+        try store.save(installation)
+
+        XCTAssertEqual(try store.loadInstallation(), installation)
+        XCTAssertEqual(try store.loadInstallation().version, 2)
+    }
+
     func testExplicitNullDesiredStateIsCorruptRatherThanDefaulting() throws {
         let store = PortalStore(rootURL: temporaryRoot())
         try FileManager.default.createDirectory(at: store.rootURL, withIntermediateDirectories: true)

--- a/docs/adr/0006-require-exact-helper-protocol-versions.md
+++ b/docs/adr/0006-require-exact-helper-protocol-versions.md
@@ -4,7 +4,10 @@ The macOS app and bundled helper support only exact-matching protocol versions.
 Full desired-set reconciliation introduces protocol version 2 because it
 replaces imperative lifecycle commands and a new app must not pass a version-1
 handshake with a helper that cannot fulfil that contract; version 2 has no
-version-1 command fallback. Compatible optional fields may evolve within a
+version-1 command fallback. Guarded Portal removal introduces protocol version
+3 because `removePortal` is a new required command; version 3 retains the
+version-2 reconciliation contract and accepts neither version 1 nor version 2
+peers. Compatible optional fields may evolve within a
 version only when older peers remain correct, while any new required command,
 field, outcome, or semantic change bumps the version and ships in the same app
 bundle as its helper.

--- a/docs/portico-mvp-spec.md
+++ b/docs/portico-mvp-spec.md
@@ -185,19 +185,21 @@ The protocol is versioned JSON Lines over standard input and output:
   diagnostics-only.
 
 The macOS app and bundled helper require an exact protocol-version match. Full
-desired-set reconciliation establishes protocol version 2; there is no
-protocol-v1 fallback. A new required command, field, outcome, or semantic
-change requires another version bump, while an optional field may remain in a
-version only when older peers can safely ignore its presence or absence. The
-app and helper ship together.
+desired-set reconciliation established protocol version 2. Guarded Portal
+removal establishes protocol version 3 because it adds the required
+`removePortal` command; version 3 retains the version-2 reconciliation
+semantics and accepts neither version 1 nor version 2 peers. A new required
+command, field, outcome, or semantic change requires another version bump,
+while an optional field may remain in a version only when older peers can
+safely ignore its presence or absence. The app and helper ship together.
 
-Protocol version 2 uses `reconcilePortals` as the only command that starts or
+Protocol version 3 uses `reconcilePortals` as the only command that starts or
 stops a Portal or changes its Local App port. The command carries the complete
 set of Portal records whose cleanup lifecycle is `active`:
 
 ```json
 {
-  "version": 2,
+  "version": 3,
   "requestId": "request-42",
   "command": "reconcilePortals",
   "payload": {
@@ -226,7 +228,7 @@ union, in the same order:
 
 ```json
 {
-  "version": 2,
+  "version": 3,
   "requestId": "request-42",
   "result": {
     "entries": [
@@ -278,10 +280,41 @@ for a superseded generation cannot update current UI state; after that request
 completes, Swift immediately sends the latest snapshot. Desired state is never
 rolled back after a failed outcome.
 
-Handshake, authentication, guarded identity cleanup, listener discovery, and
-graceful shutdown remain separate commands. Authentication remains transient.
-Imperative protocol-v1 `startPortal` is not accepted as a lifecycle fallback
-by a protocol-v2 helper.
+After a Portal's durable lifecycle becomes `pendingRemoval`, Swift omits it
+from active reconciliation and sends one automatic cleanup cycle during that
+controller session. A cycle first awaits the newest active-only reconciliation
+result. A missing or `converged` entry permits the UUID-only removal request;
+`closeFailed`, another non-converged outcome, an envelope failure, or helper
+loss retains the pending record and requires an explicit Retry. Helper
+reconnection does not replenish the automatic attempt.
+
+```json
+{
+  "version": 3,
+  "requestId": "request-43",
+  "command": "removePortal",
+  "payload": {
+    "portalId": "9f55ca93-d7b3-4eab-a871-310ea576005a"
+  }
+}
+```
+
+The removal payload contains no path or hostname. The helper normalizes and
+validates the UUID, opens the canonical trusted state root with rooted
+filesystem operations, rejects a symlink or non-directory target, closes the
+addressed runtime, and removes only that direct UUID child. An absent child is
+idempotent success. Runtime ownership is released only after close and deletion
+both succeed; fixed protocol errors never expose underlying paths or errors.
+Swift removes the pending record only after helper success and a successful
+atomic configuration save. A save failure retains the pending record for an
+explicit idempotent retry. Completion is a session-only notice and always
+explains that the remote Tailscale device may require manual removal; the
+installation tailnet binding is unchanged.
+
+Handshake, authentication, cross-tailnet rejected-identity cleanup, listener
+discovery, and graceful shutdown remain separate commands. Authentication
+remains transient. Imperative protocol-v1 `startPortal` is not accepted as a
+lifecycle fallback by a protocol-v3 helper.
 
 If the helper exits unexpectedly, Swift restarts it with bounded exponential
 backoff and restores Enabled Portals. After the retry budget is exhausted,

--- a/helper/internal/portal/runtime.go
+++ b/helper/internal/portal/runtime.go
@@ -254,26 +254,94 @@ func (r *Runtime) Authenticate(ctx context.Context, portalID string) error {
 }
 
 func (r *Runtime) CleanupRejectedPortal(portalID string) error {
+	return r.cleanupPortal(portalID)
+}
+
+func (r *Runtime) RemovePortal(portalID string) error {
+	return r.cleanupPortal(portalID)
+}
+
+func (r *Runtime) cleanupPortal(portalID string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	portalID, err := normalizePortalID(portalID)
 	if err != nil {
 		return errors.New("invalid portal ID")
 	}
-	stateDirectory, err := validatedStateDirectory(r.stateRoot, portalID)
-	if err != nil {
+	stateRoot, targetExists, err := openPortalStateRoot(r.stateRoot, portalID)
+	if err != nil && !os.IsNotExist(err) {
 		return err
+	}
+	if stateRoot != nil {
+		defer stateRoot.Close()
 	}
 	if portal := r.portals[portalID]; portal != nil {
 		if err := portal.close(); err != nil {
 			return err
 		}
 	}
-	if err := os.RemoveAll(stateDirectory); err != nil {
-		return errors.New("remove portal state")
+	if stateRoot == nil {
+		stateRoot, targetExists, err = openPortalStateRoot(r.stateRoot, portalID)
+		if err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		if stateRoot != nil {
+			defer stateRoot.Close()
+		}
+	} else {
+		targetExists, err = portalStateTargetExists(stateRoot, portalID)
+		if err != nil {
+			return err
+		}
+	}
+	if targetExists {
+		if err := stateRoot.RemoveAll(portalID); err != nil {
+			return errors.New("remove portal state")
+		}
 	}
 	delete(r.portals, portalID)
 	return nil
+}
+
+func openPortalStateRoot(stateRoot, portalID string) (*os.Root, bool, error) {
+	root, err := filepath.Abs(filepath.Clean(stateRoot))
+	if err != nil {
+		return nil, false, errors.New("resolve state root")
+	}
+	root, err = filepath.EvalSymlinks(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, false, err
+		}
+		return nil, false, errors.New("resolve state root")
+	}
+	openedRoot, err := os.OpenRoot(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, false, err
+		}
+		return nil, false, errors.New("open state root")
+	}
+	targetExists, err := portalStateTargetExists(openedRoot, portalID)
+	if err != nil {
+		_ = openedRoot.Close()
+		return nil, false, err
+	}
+	return openedRoot, targetExists, nil
+}
+
+func portalStateTargetExists(root *os.Root, portalID string) (bool, error) {
+	info, err := root.Lstat(portalID)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, errors.New("inspect portal state")
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return false, errors.New("invalid portal state directory")
+	}
+	return true, nil
 }
 
 func (r *Runtime) Close() error {
@@ -296,22 +364,6 @@ func normalizePortalID(portalID string) (string, error) {
 		return "", errors.New("invalid portal ID")
 	}
 	return portalID, nil
-}
-
-func validatedStateDirectory(stateRoot, portalID string) (string, error) {
-	portalID, err := normalizePortalID(portalID)
-	if err != nil {
-		return "", err
-	}
-	root, err := filepath.Abs(filepath.Clean(stateRoot))
-	if err != nil {
-		return "", errors.New("resolve state root")
-	}
-	target := filepath.Join(root, portalID)
-	if filepath.Dir(target) != root || filepath.Base(target) != portalID {
-		return "", errors.New("invalid portal state directory")
-	}
-	return target, nil
 }
 
 func (r *portalRuntime) start(ctx context.Context, config Config, node Node, emit func(Event)) error {

--- a/helper/internal/portal/runtime_test.go
+++ b/helper/internal/portal/runtime_test.go
@@ -408,6 +408,179 @@ func TestCleanupRejectedPortalClosesAndDeletesOnlyAddressedPortal(t *testing.T) 
 	}
 }
 
+func TestRemovePortalClosesAndDeletesOnlyAddressedPortal(t *testing.T) {
+	root := t.TempDir()
+	nodes := make(map[string]*fakeNode)
+	runtime := NewRuntime(root, func(dir, _ string) Node {
+		node := &fakeNode{watcher: newFakeWatcher(), status: Status{BackendState: "Starting"}}
+		nodes[filepath.Base(dir)] = node
+		return node
+	})
+	configs := []Config{
+		{ID: testPortalID, Name: "hermes", Port: 8787, DesiredState: DesiredStateEnabled},
+		{ID: secondPortalID, Name: "atlas", Port: 8788, DesiredState: DesiredStateEnabled},
+	}
+	if _, err := runtime.Reconcile(context.Background(), configs, func(Event) {}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	for _, config := range configs {
+		if err := os.MkdirAll(filepath.Join(root, config.ID), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Cleanup(func() { _ = runtime.Close() })
+
+	if err := runtime.RemovePortal(strings.ToUpper(testPortalID)); err != nil {
+		t.Fatalf("RemovePortal: %v", err)
+	}
+	if !nodes[testPortalID].closed {
+		t.Fatal("removed Portal node was not closed")
+	}
+	if _, err := os.Stat(filepath.Join(root, testPortalID)); !os.IsNotExist(err) {
+		t.Fatalf("removed Portal state still exists: %v", err)
+	}
+	if nodes[secondPortalID].closed {
+		t.Fatal("unrelated Portal node was closed")
+	}
+	if _, err := os.Stat(filepath.Join(root, secondPortalID)); err != nil {
+		t.Fatalf("unrelated Portal state was affected: %v", err)
+	}
+	if err := runtime.RemovePortal(testPortalID); err != nil {
+		t.Fatalf("repeated removal should be idempotent: %v", err)
+	}
+}
+
+func TestRemovePortalDeletesStateCreatedWhileRuntimeCloses(t *testing.T) {
+	root := t.TempDir()
+	node := &fakeNode{watcher: newFakeWatcher(), status: Status{BackendState: "Starting"}}
+	node.observeClose = func() {
+		if err := os.MkdirAll(filepath.Join(root, testPortalID), 0o700); err != nil {
+			t.Errorf("create close-time state: %v", err)
+		}
+	}
+	runtime := NewRuntime(root, func(_, _ string) Node { return node })
+	if _, err := runtime.Reconcile(context.Background(), []Config{{
+		ID: testPortalID, Name: "hermes", Port: 8787, DesiredState: DesiredStateEnabled,
+	}}, func(Event) {}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	if err := runtime.RemovePortal(testPortalID); err != nil {
+		t.Fatalf("RemovePortal: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, testPortalID)); !os.IsNotExist(err) {
+		t.Fatalf("close-time Portal state still exists: %v", err)
+	}
+}
+
+func TestRemovePortalRejectsUntrustedTargetsWithoutClosingRuntime(t *testing.T) {
+	outside := t.TempDir()
+	protected := filepath.Join(outside, "protected")
+	if err := os.WriteFile(protected, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	node := &fakeNode{watcher: newFakeWatcher(), status: Status{BackendState: "Starting"}}
+	runtime := NewRuntime(root, func(_, _ string) Node { return node })
+	if err := reconcileOne(runtime, Config{ID: testPortalID, Name: "hermes", Port: 8787}, func(Event) {}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	t.Cleanup(func() { _ = runtime.Close() })
+	if err := os.Symlink(outside, filepath.Join(root, testPortalID)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runtime.RemovePortal(testPortalID); err == nil {
+		t.Fatal("RemovePortal = nil, want symlink rejection")
+	}
+	if node.closeCalls != 0 {
+		t.Fatalf("close calls = %d, want zero before target validation", node.closeCalls)
+	}
+	if got, err := os.ReadFile(protected); err != nil || string(got) != "keep" {
+		t.Fatalf("protected state = %q, %v", got, err)
+	}
+	if _, err := os.Lstat(filepath.Join(root, testPortalID)); err != nil {
+		t.Fatalf("rejected symlink was changed: %v", err)
+	}
+	if err := runtime.Authenticate(context.Background(), testPortalID); err != nil {
+		t.Fatalf("runtime ownership was lost: %v", err)
+	}
+}
+
+func TestRemovePortalPreservesStateAndOwnershipWhenCloseFails(t *testing.T) {
+	root := t.TempDir()
+	node := &fakeNode{
+		watcher:      newFakeWatcher(),
+		status:       Status{BackendState: "Starting"},
+		closeResults: []error{errors.New("close failed"), nil},
+	}
+	runtime := NewRuntime(root, func(_, _ string) Node { return node })
+	if err := reconcileOne(runtime, Config{ID: testPortalID, Name: "hermes", Port: 8787}, func(Event) {}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	stateDirectory := filepath.Join(root, testPortalID)
+	if err := os.MkdirAll(stateDirectory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	sentinel := filepath.Join(stateDirectory, "identity")
+	if err := os.WriteFile(sentinel, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = runtime.Close() })
+
+	if err := runtime.RemovePortal(testPortalID); err == nil {
+		t.Fatal("RemovePortal = nil, want close failure")
+	}
+	if got, err := os.ReadFile(sentinel); err != nil || string(got) != "keep" {
+		t.Fatalf("identity state = %q, %v", got, err)
+	}
+	if err := runtime.Authenticate(context.Background(), testPortalID); err != nil {
+		t.Fatalf("runtime ownership was lost: %v", err)
+	}
+	if err := runtime.RemovePortal(testPortalID); err != nil {
+		t.Fatalf("RemovePortal retry: %v", err)
+	}
+	if _, err := os.Stat(stateDirectory); !os.IsNotExist(err) {
+		t.Fatalf("state directory remains after confirmed close: %v", err)
+	}
+}
+
+func TestRemovePortalTreatsMissingStateRootAsAbsentState(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "missing")
+	runtime := NewRuntime(root, func(_, _ string) Node { return &fakeNode{watcher: newFakeWatcher()} })
+
+	if err := runtime.RemovePortal(testPortalID); err != nil {
+		t.Fatalf("RemovePortal: %v", err)
+	}
+}
+
+func TestRemovePortalCanonicalizesSymlinkedTrustedRoot(t *testing.T) {
+	parent := t.TempDir()
+	canonicalRoot := filepath.Join(parent, "canonical")
+	if err := os.Mkdir(canonicalRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	stateDirectory := filepath.Join(canonicalRoot, testPortalID)
+	if err := os.Mkdir(stateDirectory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	root := filepath.Join(parent, "root-link")
+	if err := os.Symlink(canonicalRoot, root); err != nil {
+		t.Fatal(err)
+	}
+	runtime := NewRuntime(root, func(_, _ string) Node { return &fakeNode{watcher: newFakeWatcher()} })
+
+	if err := runtime.RemovePortal(testPortalID); err != nil {
+		t.Fatalf("RemovePortal: %v", err)
+	}
+	if _, err := os.Stat(stateDirectory); !os.IsNotExist(err) {
+		t.Fatalf("state directory remains: %v", err)
+	}
+	if info, err := os.Lstat(root); err != nil || info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("trusted root spelling changed: %v, %v", info, err)
+	}
+}
+
 func TestCleanupRejectedPortalRejectsUntrustedDeletionTargets(t *testing.T) {
 	root := t.TempDir()
 	protected := filepath.Join(root, secondPortalID)

--- a/helper/internal/protocol/server.go
+++ b/helper/internal/protocol/server.go
@@ -16,7 +16,7 @@ import (
 	"github.com/chrisbanes/portico/helper/internal/portal"
 )
 
-const Version = 2
+const Version = 3
 
 const invalidRequestDiagnostic = "portico-helper: invalid request\n"
 
@@ -24,6 +24,7 @@ type PortalRuntime interface {
 	Reconcile(context.Context, []portal.Config, func(portal.Event)) ([]portal.ReconcileEntry, error)
 	Authenticate(context.Context, string) error
 	CleanupRejectedPortal(string) error
+	RemovePortal(string) error
 	Close() error
 }
 
@@ -87,6 +88,10 @@ type authenticatePortalPayload struct {
 }
 
 type cleanupRejectedPortalPayload struct {
+	PortalID string `json:"portalId"`
+}
+
+type removePortalPayload struct {
 	PortalID string `json:"portalId"`
 }
 
@@ -303,6 +308,30 @@ func ServeWithServices(input io.Reader, output, diagnostics io.Writer, services 
 				continue
 			}
 			if err := runtime.CleanupRejectedPortal(portalID); err != nil {
+				if writer.write(errorResponse(request.RequestID, "runtimeFailure", "portal runtime failed")) != nil {
+					return 1
+				}
+				continue
+			}
+			if writer.write(response{Version: Version, RequestID: request.RequestID, Result: acceptedResult{Accepted: true}}) != nil {
+				return 1
+			}
+		case "removePortal":
+			var payload removePortalPayload
+			if runtime == nil || decodePayload(request.Payload, &payload) != nil {
+				if writer.write(errorResponse(request.RequestID, "invalidPayload", "invalid portal request")) != nil {
+					return 1
+				}
+				continue
+			}
+			portalID, valid := validatedPortalID(payload.PortalID)
+			if !valid {
+				if writer.write(errorResponse(request.RequestID, "invalidPayload", "invalid portal request")) != nil {
+					return 1
+				}
+				continue
+			}
+			if err := runtime.RemovePortal(portalID); err != nil {
 				if writer.write(errorResponse(request.RequestID, "runtimeFailure", "portal runtime failed")) != nil {
 					return 1
 				}

--- a/helper/internal/protocol/server_test.go
+++ b/helper/internal/protocol/server_test.go
@@ -15,13 +15,13 @@ import (
 	"github.com/chrisbanes/portico/helper/internal/portal"
 )
 
-func TestServeReconcilesLiteralProtocolVersionTwoSnapshot(t *testing.T) {
+func TestServeReconcilesLiteralProtocolVersionThreeSnapshot(t *testing.T) {
 	runtime := &fakeRuntime{reconcileEntries: []portal.ReconcileEntry{
 		{PortalID: "5ea74329-3144-4ba2-925f-138d14d61fcc", Outcome: portal.OutcomeConverged},
 		{PortalID: "9f55ca93-d7b3-4eab-a871-310ea576005a", Outcome: portal.OutcomeStartFailed},
 	}}
 	input := bytes.NewBufferString(
-		`{"version":2,"requestId":"reconcile-1","command":"reconcilePortals","payload":{"portals":[` +
+		`{"version":3,"requestId":"reconcile-1","command":"reconcilePortals","payload":{"portals":[` +
 			`{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","portalName":"hermes","localAppPort":8787,"desiredState":"enabled"},` +
 			`{"portalId":"5EA74329-3144-4BA2-925F-138D14D61FCC","portalName":"atlas","localAppPort":8788,"desiredState":"stopped"}` +
 			`]}}` + "\n",
@@ -37,9 +37,9 @@ func TestServeReconcilesLiteralProtocolVersionTwoSnapshot(t *testing.T) {
 	if len(runtime.reconciled) != 2 || runtime.reconciled[0].ID != "9f55ca93-d7b3-4eab-a871-310ea576005a" || runtime.reconciled[1].DesiredState != portal.DesiredStateStopped {
 		t.Fatalf("reconciled = %+v, want normalized complete snapshot", runtime.reconciled)
 	}
-	const want = `{"version":2,"requestId":"reconcile-1","result":{"entries":[{"portalId":"5ea74329-3144-4ba2-925f-138d14d61fcc","outcome":"converged"},{"portalId":"9f55ca93-d7b3-4eab-a871-310ea576005a","outcome":"startFailed"}]}}` + "\n"
+	const want = `{"version":3,"requestId":"reconcile-1","result":{"entries":[{"portalId":"5ea74329-3144-4ba2-925f-138d14d61fcc","outcome":"converged"},{"portalId":"9f55ca93-d7b3-4eab-a871-310ea576005a","outcome":"startFailed"}]}}` + "\n"
 	if output.String() != want {
-		t.Fatalf("output = %q, want exact protocol-v2 result %q", output.String(), want)
+		t.Fatalf("output = %q, want exact protocol-v3 result %q", output.String(), want)
 	}
 }
 
@@ -50,7 +50,7 @@ func TestDiscoverLocalAppsReturnsOnlyStableSanitizedCandidates(t *testing.T) {
 		{LocalAppPort: 9000, ProcessLabel: "hermes", SuggestedPortalName: "hermes"},
 		{LocalAppPort: 7000, ProcessLabel: "first", SuggestedPortalName: "first"},
 	}}
-	input := bytes.NewBufferString(`{"version":2,"requestId":"discover-1","command":"discoverLocalApps","payload":{}}` + "\n")
+	input := bytes.NewBufferString(`{"version":3,"requestId":"discover-1","command":"discoverLocalApps","payload":{}}` + "\n")
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
 
@@ -59,7 +59,7 @@ func TestDiscoverLocalAppsReturnsOnlyStableSanitizedCandidates(t *testing.T) {
 	if exitCode != 0 || diagnostics.Len() != 0 {
 		t.Fatalf("ServeWithServices = (exit %d, diagnostics %q), want success", exitCode, diagnostics.String())
 	}
-	const want = `{"version":2,"requestId":"discover-1","result":{"candidates":[{"localAppPort":7000,"processLabel":"first","suggestedPortalName":"first"},{"localAppPort":8000,"processLabel":"atlas","suggestedPortalName":"atlas"},{"localAppPort":9000,"processLabel":"hermes","suggestedPortalName":"hermes"}]}}` + "\n"
+	const want = `{"version":3,"requestId":"discover-1","result":{"candidates":[{"localAppPort":7000,"processLabel":"first","suggestedPortalName":"first"},{"localAppPort":8000,"processLabel":"atlas","suggestedPortalName":"atlas"},{"localAppPort":9000,"processLabel":"hermes","suggestedPortalName":"hermes"}]}}` + "\n"
 	if output.String() != want {
 		t.Fatalf("output = %q, want %q", output.String(), want)
 	}
@@ -70,13 +70,13 @@ func TestDiscoverLocalAppsCollapsesDisagreeingDuplicateOwners(t *testing.T) {
 		{LocalAppPort: 8787, ProcessLabel: "python3", SuggestedPortalName: "hermes"},
 		{LocalAppPort: 8787, ProcessLabel: "node", SuggestedPortalName: "atlas"},
 	}}
-	input := bytes.NewBufferString(`{"version":2,"requestId":"discover-1","command":"discoverLocalApps","payload":{}}` + "\n")
+	input := bytes.NewBufferString(`{"version":3,"requestId":"discover-1","command":"discoverLocalApps","payload":{}}` + "\n")
 	var output bytes.Buffer
 
 	if exitCode := ServeWithServices(input, &output, &bytes.Buffer{}, Services{LocalAppDiscoverer: discoverer}); exitCode != 0 {
 		t.Fatalf("ServeWithServices exit code = %d, want success", exitCode)
 	}
-	const want = `{"version":2,"requestId":"discover-1","result":{"candidates":[{"localAppPort":8787,"processLabel":"Port 8787"}]}}` + "\n"
+	const want = `{"version":3,"requestId":"discover-1","result":{"candidates":[{"localAppPort":8787,"processLabel":"Port 8787"}]}}` + "\n"
 	if output.String() != want {
 		t.Fatalf("output = %q, want %q", output.String(), want)
 	}
@@ -84,7 +84,7 @@ func TestDiscoverLocalAppsCollapsesDisagreeingDuplicateOwners(t *testing.T) {
 
 func TestDiscoverLocalAppsRequiresEmptyPayload(t *testing.T) {
 	const secret = "do-not-copy"
-	input := bytes.NewBufferString(`{"version":2,"requestId":"discover-1","command":"discoverLocalApps","payload":{"unexpected":"` + secret + `"}}` + "\n")
+	input := bytes.NewBufferString(`{"version":3,"requestId":"discover-1","command":"discoverLocalApps","payload":{"unexpected":"` + secret + `"}}` + "\n")
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
 
@@ -100,7 +100,7 @@ func TestDiscoverLocalAppsRequiresEmptyPayload(t *testing.T) {
 
 func TestDiscoverLocalAppsReturnsFixedSecretFreeFailure(t *testing.T) {
 	const secret = "token=do-not-copy"
-	input := bytes.NewBufferString(`{"version":2,"requestId":"discover-1","command":"discoverLocalApps","payload":{}}` + "\n")
+	input := bytes.NewBufferString(`{"version":3,"requestId":"discover-1","command":"discoverLocalApps","payload":{}}` + "\n")
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
 
@@ -109,7 +109,7 @@ func TestDiscoverLocalAppsReturnsFixedSecretFreeFailure(t *testing.T) {
 	if exitCode != 0 || diagnostics.Len() != 0 {
 		t.Fatalf("ServeWithServices = (exit %d, diagnostics %q), want correlated failure", exitCode, diagnostics.String())
 	}
-	const want = `{"version":2,"requestId":"discover-1","error":{"code":"discoveryFailure","message":"local app discovery failed"}}` + "\n"
+	const want = `{"version":3,"requestId":"discover-1","error":{"code":"discoveryFailure","message":"local app discovery failed"}}` + "\n"
 	if output.String() != want {
 		t.Fatalf("output = %q, want %q", output.String(), want)
 	}
@@ -131,10 +131,10 @@ func TestDiscoverLocalAppsCancelsBeforeRuntimeCloseAndShutdownAcknowledgement(t 
 		})
 	}()
 
-	_, _ = io.WriteString(input, `{"version":2,"requestId":"discover-1","command":"discoverLocalApps","payload":{}}`+"\n")
+	_, _ = io.WriteString(input, `{"version":3,"requestId":"discover-1","command":"discoverLocalApps","payload":{}}`+"\n")
 	<-discoverer.started
 	go func() {
-		_, _ = io.WriteString(input, `{"version":2,"requestId":"shutdown-1","command":"shutdown","payload":{}}`+"\n")
+		_, _ = io.WriteString(input, `{"version":3,"requestId":"shutdown-1","command":"shutdown","payload":{}}`+"\n")
 		_ = input.Close()
 	}()
 
@@ -144,14 +144,14 @@ func TestDiscoverLocalAppsCancelsBeforeRuntimeCloseAndShutdownAcknowledgement(t 
 	if !runtime.closedAfterDiscoveryCancellation {
 		t.Fatal("runtime closed before in-flight discovery observed cancellation")
 	}
-	const want = `{"version":2,"requestId":"shutdown-1","result":{"accepted":true}}` + "\n"
+	const want = `{"version":3,"requestId":"shutdown-1","result":{"accepted":true}}` + "\n"
 	if output.String() != want || diagnostics.Len() != 0 {
 		t.Fatalf("ServeWithServices = (output %q, diagnostics %q), want only post-close shutdown acknowledgement", output.String(), diagnostics.String())
 	}
 }
 
 func TestDiscoverLocalAppsFailsServeWhenResponseCannotBeWritten(t *testing.T) {
-	input := bytes.NewBufferString(`{"version":2,"requestId":"discover-1","command":"discoverLocalApps","payload":{}}` + "\n")
+	input := bytes.NewBufferString(`{"version":3,"requestId":"discover-1","command":"discoverLocalApps","payload":{}}` + "\n")
 
 	exitCode := ServeWithServices(input, errorWriter{}, &bytes.Buffer{}, Services{LocalAppDiscoverer: fakeDiscoverer{}})
 
@@ -202,6 +202,8 @@ func (*shutdownOrderingRuntime) Authenticate(context.Context, string) error { re
 
 func (*shutdownOrderingRuntime) CleanupRejectedPortal(string) error { return nil }
 
+func (*shutdownOrderingRuntime) RemovePortal(string) error { return nil }
+
 func (r *shutdownOrderingRuntime) Close() error {
 	select {
 	case <-r.discoveryCanceled:
@@ -212,7 +214,7 @@ func (r *shutdownOrderingRuntime) Close() error {
 }
 
 func TestServeCorrelatesHandshakeResponse(t *testing.T) {
-	input := bytes.NewBufferString(`{"version":2,"requestId":"request-1","command":"handshake","payload":{}}` + "\n")
+	input := bytes.NewBufferString(`{"version":3,"requestId":"request-1","command":"handshake","payload":{}}` + "\n")
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
 
@@ -229,8 +231,8 @@ func TestServeCorrelatesHandshakeResponse(t *testing.T) {
 	if err := json.NewDecoder(&output).Decode(&response); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if response.Version != 2 || response.RequestID != "request-1" || string(response.Result) != `{"protocolVersion":2}` {
-		t.Fatalf("response = %+v, want correlated version-two handshake", response)
+	if response.Version != 3 || response.RequestID != "request-1" || string(response.Result) != `{"protocolVersion":3}` {
+		t.Fatalf("response = %+v, want correlated version-three handshake", response)
 	}
 	if diagnostics.Len() != 0 {
 		t.Fatalf("diagnostics = %q, want empty", diagnostics.String())
@@ -242,7 +244,7 @@ func TestServeReconciliationSerializesStructuredStatusEvent(t *testing.T) {
 		PortalID: "9f55ca93-d7b3-4eab-a871-310ea576005a", Outcome: portal.OutcomeConverged,
 	}}}
 	input := bytes.NewBufferString(
-		`{"version":2,"requestId":"reconcile-1","command":"reconcilePortals","payload":{"portals":[{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","portalName":"hermes","localAppPort":8787,"desiredState":"enabled"}]}}` + "\n",
+		`{"version":3,"requestId":"reconcile-1","command":"reconcilePortals","payload":{"portals":[{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","portalName":"hermes","localAppPort":8787,"desiredState":"enabled"}]}}` + "\n",
 	)
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
@@ -267,7 +269,7 @@ func TestServeReconciliationSerializesStructuredStatusEvent(t *testing.T) {
 	if payload["tailnetName"] != "opaque-identity-do-not-display" || payload["magicDNSSuffix"] != "example.ts.net" {
 		t.Fatalf("payload = %+v, want exact identity and separate display suffix", payload)
 	}
-	const wantResponse = `{"version":2,"requestId":"reconcile-1","result":{"entries":[{"portalId":"9f55ca93-d7b3-4eab-a871-310ea576005a","outcome":"converged"}]}}`
+	const wantResponse = `{"version":3,"requestId":"reconcile-1","result":{"entries":[{"portalId":"9f55ca93-d7b3-4eab-a871-310ea576005a","outcome":"converged"}]}}`
 	if lines[1] != wantResponse {
 		t.Fatalf("response = %q, want %q", lines[1], wantResponse)
 	}
@@ -278,8 +280,8 @@ func TestServeAuthenticatesCorrelatedPortalAndEmitsTransientURL(t *testing.T) {
 		PortalID: "9f55ca93-d7b3-4eab-a871-310ea576005a", Outcome: portal.OutcomeConverged,
 	}}}
 	input := bytes.NewBufferString(
-		`{"version":2,"requestId":"reconcile-1","command":"reconcilePortals","payload":{"portals":[{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","portalName":"hermes","localAppPort":8787,"desiredState":"enabled"}]}}` + "\n" +
-			`{"version":2,"requestId":"auth-1","command":"authenticatePortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A"}}` + "\n",
+		`{"version":3,"requestId":"reconcile-1","command":"reconcilePortals","payload":{"portals":[{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","portalName":"hermes","localAppPort":8787,"desiredState":"enabled"}]}}` + "\n" +
+			`{"version":3,"requestId":"auth-1","command":"authenticatePortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A"}}` + "\n",
 	)
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
@@ -300,7 +302,7 @@ func TestServeAuthenticatesCorrelatedPortalAndEmitsTransientURL(t *testing.T) {
 func TestServeCleansUpOnlyCorrelatedRejectedPortal(t *testing.T) {
 	runtime := &fakeRuntime{}
 	input := bytes.NewBufferString(
-		`{"version":2,"requestId":"cleanup-1","command":"cleanupRejectedPortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A"}}` + "\n",
+		`{"version":3,"requestId":"cleanup-1","command":"cleanupRejectedPortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A"}}` + "\n",
 	)
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
@@ -310,9 +312,68 @@ func TestServeCleansUpOnlyCorrelatedRejectedPortal(t *testing.T) {
 	if exitCode != 0 || diagnostics.Len() != 0 || runtime.cleaned != "9f55ca93-d7b3-4eab-a871-310ea576005a" {
 		t.Fatalf("ServeWithRuntime = (exit %d, cleaned %q, diagnostics %q), want correlated cleanup", exitCode, runtime.cleaned, diagnostics.String())
 	}
-	const want = `{"version":2,"requestId":"cleanup-1","result":{"accepted":true}}` + "\n"
+	const want = `{"version":3,"requestId":"cleanup-1","result":{"accepted":true}}` + "\n"
 	if output.String() != want {
 		t.Fatalf("output = %q, want %q", output.String(), want)
+	}
+}
+
+func TestServeRemovesOnlyCorrelatedPortalWithProtocolVersionThree(t *testing.T) {
+	runtime := &fakeRuntime{}
+	input := bytes.NewBufferString(
+		`{"version":3,"requestId":"remove-1","command":"removePortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A"}}` + "\n",
+	)
+	var output bytes.Buffer
+	var diagnostics bytes.Buffer
+
+	exitCode := ServeWithRuntime(input, &output, &diagnostics, runtime)
+
+	if exitCode != 0 || diagnostics.Len() != 0 || runtime.removed != "9f55ca93-d7b3-4eab-a871-310ea576005a" {
+		t.Fatalf("ServeWithRuntime = (exit %d, removed %q, diagnostics %q), want correlated removal", exitCode, runtime.removed, diagnostics.String())
+	}
+	const want = `{"version":3,"requestId":"remove-1","result":{"accepted":true}}` + "\n"
+	if output.String() != want {
+		t.Fatalf("output = %q, want %q", output.String(), want)
+	}
+}
+
+func TestServeRejectsUntrustedRemovalPayloadWithoutRuntimeCall(t *testing.T) {
+	fixtures := map[string]string{
+		"missing ID": `{}`,
+		"invalid ID": `{"portalId":"../outside"}`,
+		"path":       `{"portalId":"9f55ca93-d7b3-4eab-a871-310ea576005a","path":"/private/secret"}`,
+		"hostname":   `{"portalId":"9f55ca93-d7b3-4eab-a871-310ea576005a","hostname":"other"}`,
+	}
+	for name, payload := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			runtime := &fakeRuntime{}
+			input := bytes.NewBufferString(`{"version":3,"requestId":"remove-1","command":"removePortal","payload":` + payload + `}` + "\n")
+			var output bytes.Buffer
+
+			if exitCode := ServeWithRuntime(input, &output, &bytes.Buffer{}, runtime); exitCode != 0 {
+				t.Fatalf("ServeWithRuntime exit code = %d, want correlated rejection", exitCode)
+			}
+			if runtime.removeCalls != 0 || !strings.Contains(output.String(), `"code":"invalidPayload"`) {
+				t.Fatalf("remove calls = %d, output = %q, want zero-call invalid payload", runtime.removeCalls, output.String())
+			}
+		})
+	}
+}
+
+func TestServeMapsRemovalFailureToFixedRuntimeError(t *testing.T) {
+	const secret = "path=/private/secret"
+	runtime := &fakeRuntime{removeErr: errors.New(secret)}
+	input := bytes.NewBufferString(
+		`{"version":3,"requestId":"remove-1","command":"removePortal","payload":{"portalId":"9f55ca93-d7b3-4eab-a871-310ea576005a"}}` + "\n",
+	)
+	var output bytes.Buffer
+
+	if exitCode := ServeWithRuntime(input, &output, &bytes.Buffer{}, runtime); exitCode != 0 {
+		t.Fatalf("ServeWithRuntime exit code = %d, want correlated failure", exitCode)
+	}
+	const want = `{"version":3,"requestId":"remove-1","error":{"code":"runtimeFailure","message":"portal runtime failed"}}` + "\n"
+	if output.String() != want || strings.Contains(output.String(), secret) {
+		t.Fatalf("output = %q, want fixed secret-free runtime error", output.String())
 	}
 }
 
@@ -330,7 +391,7 @@ func TestServeRejectsInvalidReconciliationWithoutRuntimeMutationOrLeaks(t *testi
 	for name, payload := range fixtures {
 		t.Run(name, func(t *testing.T) {
 			runtime := &fakeRuntime{}
-			input := bytes.NewBufferString(`{"version":2,"requestId":"reconcile-1","command":"reconcilePortals","payload":` + payload + `}` + "\n")
+			input := bytes.NewBufferString(`{"version":3,"requestId":"reconcile-1","command":"reconcilePortals","payload":` + payload + `}` + "\n")
 			var output bytes.Buffer
 			var diagnostics bytes.Buffer
 
@@ -346,16 +407,16 @@ func TestServeRejectsInvalidReconciliationWithoutRuntimeMutationOrLeaks(t *testi
 	}
 }
 
-func TestServeRejectsImperativeStartPortalInProtocolVersionTwo(t *testing.T) {
+func TestServeRejectsImperativeStartPortalInProtocolVersionThree(t *testing.T) {
 	input := bytes.NewBufferString(
-		`{"version":2,"requestId":"start-1","command":"startPortal","payload":{"portalId":"9f55ca93-d7b3-4eab-a871-310ea576005a","portalName":"hermes","localAppPort":8787}}` + "\n",
+		`{"version":3,"requestId":"start-1","command":"startPortal","payload":{"portalId":"9f55ca93-d7b3-4eab-a871-310ea576005a","portalName":"hermes","localAppPort":8787}}` + "\n",
 	)
 	var output bytes.Buffer
 
 	if exitCode := ServeWithRuntime(input, &output, &bytes.Buffer{}, &fakeRuntime{}); exitCode != 0 {
 		t.Fatalf("ServeWithRuntime exit code = %d", exitCode)
 	}
-	const want = `{"version":2,"requestId":"start-1","error":{"code":"unknownCommand","message":"unsupported command"}}` + "\n"
+	const want = `{"version":3,"requestId":"start-1","error":{"code":"unknownCommand","message":"unsupported command"}}` + "\n"
 	if output.String() != want {
 		t.Fatalf("output = %q, want protocol-v1 lifecycle rejection", output.String())
 	}
@@ -363,7 +424,7 @@ func TestServeRejectsImperativeStartPortalInProtocolVersionTwo(t *testing.T) {
 
 func TestServeClosesRuntimeOnShutdown(t *testing.T) {
 	runtime := &fakeRuntime{}
-	input := bytes.NewBufferString(`{"version":2,"requestId":"shutdown-1","command":"shutdown","payload":{}}` + "\n")
+	input := bytes.NewBufferString(`{"version":3,"requestId":"shutdown-1","command":"shutdown","payload":{}}` + "\n")
 	var output bytes.Buffer
 
 	if exitCode := ServeWithRuntime(input, &output, &bytes.Buffer{}, runtime); exitCode != 0 || !runtime.closed {
@@ -373,7 +434,7 @@ func TestServeClosesRuntimeOnShutdown(t *testing.T) {
 
 func TestServeAcknowledgesShutdownAfterRuntimeCloseCompletes(t *testing.T) {
 	runtime := &fakeRuntime{closeEntered: make(chan struct{}), releaseClose: make(chan struct{})}
-	input := bytes.NewBufferString(`{"version":2,"requestId":"shutdown-1","command":"shutdown","payload":{}}` + "\n")
+	input := bytes.NewBufferString(`{"version":3,"requestId":"shutdown-1","command":"shutdown","payload":{}}` + "\n")
 	var output bytes.Buffer
 	done := make(chan int, 1)
 	go func() { done <- ServeWithRuntime(input, &output, &bytes.Buffer{}, runtime) }()
@@ -397,6 +458,9 @@ type fakeRuntime struct {
 	emitStatus       bool
 	authenticated    string
 	cleaned          string
+	removed          string
+	removeCalls      int
+	removeErr        error
 	closed           bool
 	emit             func(portal.Event)
 	closeEntered     chan struct{}
@@ -429,6 +493,12 @@ func (r *fakeRuntime) CleanupRejectedPortal(portalID string) error {
 	return nil
 }
 
+func (r *fakeRuntime) RemovePortal(portalID string) error {
+	r.removeCalls++
+	r.removed = strings.ToLower(portalID)
+	return r.removeErr
+}
+
 func (r *fakeRuntime) Close() error {
 	r.closeOnce.Do(func() {
 		if r.closeEntered != nil {
@@ -442,8 +512,8 @@ func (r *fakeRuntime) Close() error {
 
 func TestServeAcknowledgesShutdownAndStops(t *testing.T) {
 	input := bytes.NewBufferString(
-		`{"version":2,"requestId":"shutdown-1","command":"shutdown","payload":{}}` + "\n" +
-			`{"version":2,"requestId":"ignored","command":"handshake","payload":{}}` + "\n",
+		`{"version":3,"requestId":"shutdown-1","command":"shutdown","payload":{}}` + "\n" +
+			`{"version":3,"requestId":"ignored","command":"handshake","payload":{}}` + "\n",
 	)
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
@@ -453,7 +523,7 @@ func TestServeAcknowledgesShutdownAndStops(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("Serve() exit code = %d, want 0", exitCode)
 	}
-	const want = "{\"version\":2,\"requestId\":\"shutdown-1\",\"result\":{\"accepted\":true}}\n"
+	const want = "{\"version\":3,\"requestId\":\"shutdown-1\",\"result\":{\"accepted\":true}}\n"
 	if output.String() != want {
 		t.Fatalf("output = %q, want %q", output.String(), want)
 	}
@@ -463,7 +533,7 @@ func TestServeAcknowledgesShutdownAndStops(t *testing.T) {
 }
 
 func TestServeReturnsCorrelatedErrorForUnknownCommand(t *testing.T) {
-	input := bytes.NewBufferString(`{"version":2,"requestId":"unknown-1","command":"surprise","payload":{}}` + "\n")
+	input := bytes.NewBufferString(`{"version":3,"requestId":"unknown-1","command":"surprise","payload":{}}` + "\n")
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
 
@@ -472,7 +542,7 @@ func TestServeReturnsCorrelatedErrorForUnknownCommand(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("Serve() exit code = %d, want 0", exitCode)
 	}
-	const want = "{\"version\":2,\"requestId\":\"unknown-1\",\"error\":{\"code\":\"unknownCommand\",\"message\":\"unsupported command\"}}\n"
+	const want = "{\"version\":3,\"requestId\":\"unknown-1\",\"error\":{\"code\":\"unknownCommand\",\"message\":\"unsupported command\"}}\n"
 	if output.String() != want {
 		t.Fatalf("output = %q, want %q", output.String(), want)
 	}
@@ -482,7 +552,7 @@ func TestServeReturnsCorrelatedErrorForUnknownCommand(t *testing.T) {
 }
 
 func TestServeReturnsCorrelatedErrorForUnsupportedVersion(t *testing.T) {
-	input := bytes.NewBufferString(`{"version":1,"requestId":"version-1","command":"handshake","payload":{}}` + "\n")
+	input := bytes.NewBufferString(`{"version":2,"requestId":"version-2","command":"handshake","payload":{}}` + "\n")
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
 
@@ -491,7 +561,7 @@ func TestServeReturnsCorrelatedErrorForUnsupportedVersion(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("Serve() exit code = %d, want 0", exitCode)
 	}
-	const want = "{\"version\":2,\"requestId\":\"version-1\",\"error\":{\"code\":\"unsupportedVersion\",\"message\":\"unsupported protocol version\"}}\n"
+	const want = "{\"version\":3,\"requestId\":\"version-2\",\"error\":{\"code\":\"unsupportedVersion\",\"message\":\"unsupported protocol version\"}}\n"
 	if output.String() != want {
 		t.Fatalf("output = %q, want %q", output.String(), want)
 	}
@@ -502,7 +572,7 @@ func TestServeReturnsCorrelatedErrorForUnsupportedVersion(t *testing.T) {
 
 func TestServeRejectsMalformedInputWithoutLeakingIt(t *testing.T) {
 	const secret = "token=do-not-copy"
-	input := bytes.NewBufferString(`{"version":2,"requestId":"` + secret + `"` + "\n")
+	input := bytes.NewBufferString(`{"version":3,"requestId":"` + secret + `"` + "\n")
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
 
@@ -524,7 +594,7 @@ func TestServeRejectsMalformedInputWithoutLeakingIt(t *testing.T) {
 }
 
 func TestServeRejectsTrailingContentAfterRequest(t *testing.T) {
-	input := bytes.NewBufferString(`{"version":2,"requestId":"request-1","command":"handshake","payload":{}} trailing` + "\n")
+	input := bytes.NewBufferString(`{"version":3,"requestId":"request-1","command":"handshake","payload":{}} trailing` + "\n")
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
 
@@ -538,12 +608,12 @@ func TestServeRejectsTrailingContentAfterRequest(t *testing.T) {
 func TestServeRejectsStructurallyInvalidRequests(t *testing.T) {
 	fixtures := map[string]string{
 		"missing version":    `{"requestId":"request-1","command":"handshake","payload":{}}`,
-		"missing request ID": `{"version":2,"command":"handshake","payload":{}}`,
-		"missing command":    `{"version":2,"requestId":"request-1","payload":{}}`,
-		"missing payload":    `{"version":2,"requestId":"request-1","command":"handshake"}`,
-		"non-object payload": `{"version":2,"requestId":"request-1","command":"handshake","payload":[]}`,
-		"non-empty payload":  `{"version":2,"requestId":"request-1","command":"handshake","payload":{"unexpected":true}}`,
-		"unknown field":      `{"version":2,"requestId":"request-1","command":"handshake","payload":{},"extra":true}`,
+		"missing request ID": `{"version":3,"command":"handshake","payload":{}}`,
+		"missing command":    `{"version":3,"requestId":"request-1","payload":{}}`,
+		"missing payload":    `{"version":3,"requestId":"request-1","command":"handshake"}`,
+		"non-object payload": `{"version":3,"requestId":"request-1","command":"handshake","payload":[]}`,
+		"non-empty payload":  `{"version":3,"requestId":"request-1","command":"handshake","payload":{"unexpected":true}}`,
+		"unknown field":      `{"version":3,"requestId":"request-1","command":"handshake","payload":{},"extra":true}`,
 	}
 
 	for name, fixture := range fixtures {


### PR DESCRIPTION
## Summary

- persist crash-safe pending-removal intent and exclude removing Portals from active reconciliation, reachability, diagnostics, and controls
- advance the bundled helper protocol to exact version 3 with a UUID-only removal command and rooted, symlink-safe, close-before-delete cleanup
- add explicit retry, safe completion feedback, destructive confirmation UI, and interruption/isolation/security coverage

## Testing

- `./Scripts/verify-xcode-project-generation.sh`
- `xcodebuild -project Portico.xcodeproj -scheme Portico -destination platform=macOS -derivedDataPath /private/tmp/portico-issue9-final-swift.3BSFk3 test` — 70 tests, 0 failures
- `cd helper && go test ./...`
- `cd helper && go test -race ./internal/portal ./internal/protocol`
- `cd helper && go build -o /private/tmp/portico-issue9-helper-final ./cmd/portico-helper`
- `git diff --check`

## Review

- review-and-simplify-changes found one close-time state-creation race; a failing regression test reproduced it and the cleanup now rechecks through the held root after runtime closure
- final review-and-simplify and ponytail-review passes found no remaining findings

## Manual validation

Not run: this change does not mutate a real tailnet, and the live two-Portal menu-bar interruption/removal flow was not exercised manually. The equivalent ordering, reconnect, retry, isolation, and persistence boundaries are covered by automated Swift and Go tests.

Closes #9