### PR TITLE
Complete the native menu-bar experience

### DIFF
--- a/Portico/AppDelegate.swift
+++ b/Portico/AppDelegate.swift
@@ -4,34 +4,115 @@ import AppKit
 final class AppDelegate: NSObject, NSApplicationDelegate {
     let supervisor: HelperSupervisor
     let portalController: PortalController
+    let launchAtLoginController: LaunchAtLoginController
 
     override init() {
-        let applicationRoot = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
-            .appendingPathComponent("Portico", isDirectory: true)
+        let productionRoot = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        )[0].appendingPathComponent("Portico", isDirectory: true)
+        let scheduler = MainQueueScheduler()
+
+#if DEBUG
+        let testConfiguration = UITestLaunchConfiguration.current
+        if let testConfiguration {
+            do {
+                try testConfiguration.prepareInstallationIfNeeded()
+            } catch {
+                fatalError("The UI test installation fixture could not be prepared.")
+            }
+        }
+        let applicationRoot = testConfiguration?.rootURL ?? productionRoot
+        let supervisorScheduler: PorticoScheduling
+        if let scale = testConfiguration?.supervisorSchedulerScale, scale != 1 {
+            supervisorScheduler = UITestScaledScheduler(scale: scale)
+        } else {
+            supervisorScheduler = scheduler
+        }
+        let launcher: HelperLaunching = testConfiguration.map {
+            UITestHelperLauncher(scenario: $0.scenario)
+        } ?? ProcessHelperLauncher()
+        let reachabilityProbe: LocalAppProbing = testConfiguration.map {
+            UITestLocalAppProbe(result: $0.reachabilityResult)
+        } ?? LoopbackTCPProbe()
+        let launchAtLoginService: LaunchAtLoginServicing = testConfiguration.map {
+            UITestLaunchAtLoginService(
+                status: $0.launchAtLoginStatus,
+                registrationFails: $0.registrationFails
+            )
+        } ?? ServiceManagementLaunchAtLoginService()
+        let copyText: (String) -> Void
+        let openURL: (URL) -> Void
+        if testConfiguration == nil {
+            copyText = Self.copyToPasteboard
+            openURL = Self.openWorkspaceURL
+        } else {
+            copyText = { _ in }
+            openURL = { _ in }
+        }
+#else
+        let applicationRoot = productionRoot
+        let supervisorScheduler: PorticoScheduling = scheduler
+        let launcher: HelperLaunching = ProcessHelperLauncher()
+        let reachabilityProbe: LocalAppProbing = LoopbackTCPProbe()
+        let launchAtLoginService: LaunchAtLoginServicing = ServiceManagementLaunchAtLoginService()
+        let copyText: (String) -> Void = Self.copyToPasteboard
+        let openURL: (URL) -> Void = Self.openWorkspaceURL
+#endif
+
         let helperURL = Bundle.main.bundleURL
             .appendingPathComponent("Contents/Helpers/portico-helper", isDirectory: false)
-        let scheduler = MainQueueScheduler()
         let history = DiagnosticHistory()
         let supervisor = HelperSupervisor(
             helperURL: helperURL,
             stateRootURL: applicationRoot.appendingPathComponent("tsnet", isDirectory: true),
-            launcher: ProcessHelperLauncher(),
-            scheduler: scheduler,
+            launcher: launcher,
+            scheduler: supervisorScheduler,
             history: history
         )
-        self.supervisor = supervisor
-        self.portalController = PortalController(
+        let portalController = PortalController(
             store: PortalStore(rootURL: applicationRoot),
             helper: supervisor,
-            reachability: LocalAppReachability(probe: LoopbackTCPProbe(), scheduler: scheduler),
+            reachability: LocalAppReachability(probe: reachabilityProbe, scheduler: scheduler),
             history: history,
-            openURL: { NSWorkspace.shared.open($0) }
+            copyText: copyText,
+            announce: { message in
+                NSAccessibility.post(
+                    element: NSApp as Any,
+                    notification: .announcementRequested,
+                    userInfo: [
+                        .announcement: message,
+                        .priority: NSAccessibilityPriorityLevel.medium.rawValue,
+                    ]
+                )
+            },
+            openURL: openURL
         )
+        let launchAtLoginController = LaunchAtLoginController(
+            service: launchAtLoginService,
+            offerState: { portalController.launchAtLoginOffer },
+            saveOfferState: { portalController.commitLaunchAtLoginOffer($0) }
+        )
+        portalController.onFreshPortalOnline = {
+            launchAtLoginController.considerOfferAfterFreshOnline()
+        }
+        self.supervisor = supervisor
+        self.portalController = portalController
+        self.launchAtLoginController = launchAtLoginController
         super.init()
     }
 
+    private static func copyToPasteboard(_ text: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+    }
+
+    private static func openWorkspaceURL(_ url: URL) {
+        NSWorkspace.shared.open(url)
+    }
+
     func applicationDidFinishLaunching(_ notification: Notification) {
-        supervisor.start()
+        supervisor.start(loggingPreference: portalController.operationalLogging)
     }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
@@ -39,5 +120,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             sender.reply(toApplicationShouldTerminate: true)
         }
         return .terminateLater
+    }
+
+    func applicationDidBecomeActive(_ notification: Notification) {
+        launchAtLoginController.refreshStatus()
     }
 }

--- a/Portico/Diagnostics.swift
+++ b/Portico/Diagnostics.swift
@@ -111,6 +111,8 @@ enum DiagnosticReportRenderer {
         switch event {
         case let .helper(availability):
             switch availability {
+            case .awaitingLoggingChoice: return "Helper awaiting logging choice"
+            case .restarting: return "Helper restarting"
             case .connecting: return "Helper connecting"
             case let .retrying(attempt, delay): return "Helper retry \(attempt) in \(Int(delay))s"
             case .connected: return "Helper connected"
@@ -124,6 +126,8 @@ enum DiagnosticReportRenderer {
 
     private static func describeHelper(_ availability: HelperAvailability) -> String {
         switch availability {
+        case .awaitingLoggingChoice: return "awaiting logging choice"
+        case .restarting: return "restarting"
         case .connecting: return "connecting"
         case let .retrying(attempt, delay): return "retry \(attempt) in \(Int(delay))s"
         case .connected: return "connected"

--- a/Portico/HelperSupervisor.swift
+++ b/Portico/HelperSupervisor.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 enum HelperAvailability: Equatable {
+    case awaitingLoggingChoice
+    case restarting
     case connecting
     case retrying(attempt: Int, delay: TimeInterval)
     case connected
@@ -27,6 +29,7 @@ protocol PortalHelperClient: AnyObject {
     var onEvent: ((PortalHelperEvent) -> Void)? { get set }
 
     func retry()
+    func restart(loggingPreference: OperationalLoggingPreference)
 
     func reconcilePortals(
         _ portals: [PortalConfiguration],
@@ -50,6 +53,7 @@ protocol HelperLaunching {
     func launch(
         at executableURL: URL,
         arguments: [String],
+        loggingPreference: OperationalLoggingPreference,
         onLine: @escaping (Data) -> Void,
         onEOF: @escaping () -> Void,
         onExit: @escaping (Int32) -> Void
@@ -83,6 +87,7 @@ final class HelperSupervisor: ObservableObject, PortalHelperClient {
     private var shutdownTimeoutTask: ScheduledTask?
     private var retryTask: ScheduledTask?
     private var stabilityTask: ScheduledTask?
+    private var restartTimeoutTask: ScheduledTask?
     private var processGeneration = 0
     private var reconciliationGeneration = 0
     private var retryDelayIndex = 0
@@ -90,6 +95,8 @@ final class HelperSupervisor: ObservableObject, PortalHelperClient {
     private var isShuttingDown = false
     private var isShutdownComplete = false
     private var shutdownCompletions: [() -> Void] = []
+    private var loggingPreference: OperationalLoggingPreference = .undecided
+    private var restartingGeneration: Int?
 
     init(
         helperURL: URL,
@@ -111,8 +118,13 @@ final class HelperSupervisor: ObservableObject, PortalHelperClient {
         self.shutdownGraceInterval = shutdownGraceInterval
     }
 
-    func start() {
+    func start(loggingPreference: OperationalLoggingPreference) {
         guard process == nil, retryTask == nil, !isShuttingDown else { return }
+        self.loggingPreference = loggingPreference
+        guard loggingPreference != .undecided else {
+            availability = .awaitingLoggingChoice
+            return
+        }
         launch()
     }
 
@@ -143,6 +155,53 @@ final class HelperSupervisor: ObservableObject, PortalHelperClient {
         }
     }
 
+    func restart(loggingPreference: OperationalLoggingPreference) {
+        guard loggingPreference != .undecided,
+              loggingPreference != self.loggingPreference,
+              !isShuttingDown
+        else { return }
+        self.loggingPreference = loggingPreference
+        retryTask?.cancel()
+        retryTask = nil
+        stabilityTask?.cancel()
+        stabilityTask = nil
+        handshakeTimeoutTask?.cancel()
+        handshakeTimeoutTask = nil
+        restartTimeoutTask?.cancel()
+        restartTimeoutTask = nil
+        reconciliationGeneration += 1
+        failPendingResponses()
+        retryDelayIndex = 0
+        failureHandled = false
+        availability = .restarting
+
+        guard let process else {
+            launch()
+            return
+        }
+        guard process.isRunning else {
+            self.process = nil
+            launch()
+            return
+        }
+
+        let generation = processGeneration
+        restartingGeneration = generation
+        do {
+            try sendWithoutResponse(
+                command: .shutdown,
+                requestID: requestIDProvider(),
+                payload: EmptyPayload()
+            )
+        } catch {
+            process.terminate()
+        }
+        process.closeInput()
+        restartTimeoutTask = scheduler.schedule(after: shutdownGraceInterval) { [weak self] in
+            self?.forceRestart(generation: generation)
+        }
+    }
+
     private func launch() {
         guard process == nil, !isShuttingDown else { return }
         processGeneration += 1
@@ -153,6 +212,7 @@ final class HelperSupervisor: ObservableObject, PortalHelperClient {
             process = try launcher.launch(
                 at: helperURL,
                 arguments: ["--state-root", stateRootURL.path],
+                loggingPreference: loggingPreference,
                 onLine: { [weak self] data in self?.receive(line: data, generation: generation) },
                 onEOF: { [weak self] in self?.handleFailure(generation: generation) },
                 onExit: { [weak self] _ in self?.processExited(generation: generation) }
@@ -325,7 +385,10 @@ final class HelperSupervisor: ObservableObject, PortalHelperClient {
     }
 
     private func receive(line: Data, generation: Int) {
-        guard generation == processGeneration, !failureHandled else { return }
+        guard generation == processGeneration,
+              restartingGeneration == nil,
+              !failureHandled
+        else { return }
         guard !isShuttingDown else { return }
         guard let envelope = try? JSONDecoder().decode(IncomingHelperEnvelope.self, from: line),
               envelope.version == helperProtocolVersion
@@ -406,7 +469,11 @@ final class HelperSupervisor: ObservableObject, PortalHelperClient {
     }
 
     private func handleFailure(generation: Int) {
-        guard generation == processGeneration, !failureHandled, !isShuttingDown else { return }
+        guard generation == processGeneration,
+              restartingGeneration == nil,
+              !failureHandled,
+              !isShuttingDown
+        else { return }
         failureHandled = true
         handshakeTimeoutTask?.cancel()
         handshakeTimeoutTask = nil
@@ -452,6 +519,14 @@ final class HelperSupervisor: ObservableObject, PortalHelperClient {
     }
 
     private func processExited(generation: Int) {
+        if restartingGeneration == generation {
+            process = nil
+            restartTimeoutTask?.cancel()
+            restartTimeoutTask = nil
+            restartingGeneration = nil
+            launch()
+            return
+        }
         guard generation == processGeneration, process != nil else { return }
         process = nil
         if isShuttingDown {
@@ -477,6 +552,13 @@ final class HelperSupervisor: ObservableObject, PortalHelperClient {
         guard isShuttingDown, !isShutdownComplete else { return }
         if process?.isRunning == true { process?.terminate() }
         finishShutdown()
+    }
+
+    private func forceRestart(generation: Int) {
+        guard restartingGeneration == generation else { return }
+        if process?.isRunning == true {
+            process?.terminate()
+        }
     }
 
     nonisolated private static func defaultStateRootURL() -> URL {

--- a/Portico/LaunchAtLogin.swift
+++ b/Portico/LaunchAtLogin.swift
@@ -1,0 +1,151 @@
+import Foundation
+import ServiceManagement
+
+enum LaunchAtLoginStatus: Equatable {
+    case notRegistered
+    case enabled
+    case requiresApproval
+    case notFound
+}
+
+protocol LaunchAtLoginServicing: AnyObject {
+    var status: LaunchAtLoginStatus { get }
+
+    func register() throws
+    func unregister() throws
+    func openSystemSettingsLoginItems()
+}
+
+final class ServiceManagementLaunchAtLoginService: LaunchAtLoginServicing {
+    private let service: SMAppService
+
+    init(service: SMAppService = .mainApp) {
+        self.service = service
+    }
+
+    var status: LaunchAtLoginStatus {
+        switch service.status {
+        case .notRegistered: .notRegistered
+        case .enabled: .enabled
+        case .requiresApproval: .requiresApproval
+        case .notFound: .notFound
+        @unknown default: .notFound
+        }
+    }
+
+    func register() throws {
+        try service.register()
+    }
+
+    func unregister() throws {
+        try service.unregister()
+    }
+
+    func openSystemSettingsLoginItems() {
+        SMAppService.openSystemSettingsLoginItems()
+    }
+}
+
+@MainActor
+final class LaunchAtLoginController: ObservableObject {
+    @Published private(set) var status: LaunchAtLoginStatus
+    @Published private(set) var isOffering = false
+    @Published private(set) var errorMessage: String?
+
+    private let service: LaunchAtLoginServicing
+    private let offerState: () -> LaunchAtLoginOfferState
+    private let saveOfferState: (LaunchAtLoginOfferState) -> Bool
+
+    init(
+        service: LaunchAtLoginServicing,
+        offerState: @escaping () -> LaunchAtLoginOfferState,
+        saveOfferState: @escaping (LaunchAtLoginOfferState) -> Bool
+    ) {
+        self.service = service
+        self.offerState = offerState
+        self.saveOfferState = saveOfferState
+        status = service.status
+    }
+
+    func considerOfferAfterFreshOnline() {
+        guard offerState() == .notOffered else { return }
+        refreshStatus()
+        if status == .enabled {
+            _ = commit(.accepted)
+            return
+        }
+        guard commit(.presented) else { return }
+        isOffering = true
+    }
+
+    func acceptOffer() {
+        guard isOffering, commit(.accepted) else { return }
+        isOffering = false
+        register()
+    }
+
+    func declineOffer() {
+        guard isOffering, commit(.declined) else { return }
+        isOffering = false
+    }
+
+    func retryRegistration() {
+        refreshStatus()
+        guard status == .notRegistered else { return }
+        register()
+    }
+
+    func setEnabled(_ enabled: Bool) {
+        refreshStatus()
+        if enabled {
+            guard status == .notRegistered else { return }
+            if offerState() != .accepted, !commit(.accepted) { return }
+            register()
+        } else {
+            guard status == .enabled || status == .requiresApproval else { return }
+            do {
+                try service.unregister()
+                errorMessage = nil
+            } catch {
+                errorMessage = "Launch at login could not be disabled."
+            }
+            refreshStatus(preservingError: true)
+        }
+    }
+
+    func openLoginItemsSettings() {
+        refreshStatus()
+        guard status == .requiresApproval else { return }
+        service.openSystemSettingsLoginItems()
+    }
+
+    func refreshStatus() {
+        refreshStatus(preservingError: false)
+    }
+
+    private func register() {
+        do {
+            try service.register()
+            errorMessage = nil
+        } catch {
+            errorMessage = "Launch at login could not be enabled."
+        }
+        refreshStatus(preservingError: true)
+    }
+
+    private func commit(_ state: LaunchAtLoginOfferState) -> Bool {
+        guard saveOfferState(state) else {
+            errorMessage = "The launch at login choice could not be saved."
+            return false
+        }
+        errorMessage = nil
+        return true
+    }
+
+    private func refreshStatus(preservingError: Bool) {
+        status = service.status
+        if !preservingError {
+            errorMessage = nil
+        }
+    }
+}

--- a/Portico/PortalActionAvailability.swift
+++ b/Portico/PortalActionAvailability.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+struct PortalActionContext {
+    var loggingPreference: OperationalLoggingPreference
+    var inputsValid: Bool
+    var helperAvailability: HelperAvailability
+    var lifecycle: PortalLifecycle?
+    var desiredState: PortalDesiredState?
+    var tailscaleState: PortalTailscaleState?
+    var hasPortalURL: Bool
+    var isTailscaleFactsStale: Bool
+    var isAuthenticationPending: Bool
+    var removalState: PortalRemovalState?
+    var hasTailnetBinding: Bool
+    var portalCount: Int
+    var isEditedPortValid: Bool
+    var isRefreshingLocalApps: Bool
+
+    init(
+        loggingPreference: OperationalLoggingPreference,
+        inputsValid: Bool,
+        helperAvailability: HelperAvailability,
+        lifecycle: PortalLifecycle? = nil,
+        desiredState: PortalDesiredState? = nil,
+        tailscaleState: PortalTailscaleState? = nil,
+        hasPortalURL: Bool = false,
+        isTailscaleFactsStale: Bool = false,
+        isAuthenticationPending: Bool = false,
+        removalState: PortalRemovalState? = nil,
+        hasTailnetBinding: Bool = false,
+        portalCount: Int = 0,
+        isEditedPortValid: Bool = false,
+        isRefreshingLocalApps: Bool = false
+    ) {
+        self.loggingPreference = loggingPreference
+        self.inputsValid = inputsValid
+        self.helperAvailability = helperAvailability
+        self.lifecycle = lifecycle
+        self.desiredState = desiredState
+        self.tailscaleState = tailscaleState
+        self.hasPortalURL = hasPortalURL
+        self.isTailscaleFactsStale = isTailscaleFactsStale
+        self.isAuthenticationPending = isAuthenticationPending
+        self.removalState = removalState
+        self.hasTailnetBinding = hasTailnetBinding
+        self.portalCount = portalCount
+        self.isEditedPortValid = isEditedPortValid
+        self.isRefreshingLocalApps = isRefreshingLocalApps
+    }
+}
+
+struct PortalActionAvailability: Equatable {
+    let addPortal: Bool
+    let refreshLocalApps: Bool
+    let start: Bool
+    let stop: Bool
+    let editPort: Bool
+    let authenticate: Bool
+    let copyPortalURL: Bool
+    let openPortalURL: Bool
+    let diagnostics: Bool
+    let remove: Bool
+    let retryRemoval: Bool
+    let resetTailnet: Bool
+    let settings: Bool
+
+    init(context: PortalActionContext) {
+        let isActive = context.lifecycle == .active
+        let helperConnected = context.helperAvailability == .connected
+        addPortal = context.loggingPreference != .undecided && context.inputsValid
+        refreshLocalApps = helperConnected && !context.isRefreshingLocalApps
+        start = isActive && context.desiredState == .stopped
+        stop = isActive && context.desiredState == .enabled
+        editPort = isActive && context.isEditedPortValid
+        authenticate = isActive
+            && context.desiredState == .enabled
+            && helperConnected
+            && context.tailscaleState == .authenticating
+            && !context.isTailscaleFactsStale
+            && !context.isAuthenticationPending
+        copyPortalURL = context.hasPortalURL
+        openPortalURL = context.hasPortalURL
+            && !context.isTailscaleFactsStale
+            && context.tailscaleState == .online
+        diagnostics = true
+        remove = isActive
+        retryRemoval = context.lifecycle == .pendingRemoval
+            && context.removalState == .failed
+            && helperConnected
+        resetTailnet = context.hasTailnetBinding && context.portalCount == 0
+        settings = true
+    }
+}

--- a/Portico/PortalConfiguration.swift
+++ b/Portico/PortalConfiguration.swift
@@ -80,23 +80,42 @@ struct InstallationAlert: Codable, Equatable, Identifiable {
     let createdAt: Date
 }
 
+enum OperationalLoggingPreference: String, Codable, Equatable, CaseIterable {
+    case undecided
+    case enabled
+    case disabled
+}
+
+enum LaunchAtLoginOfferState: String, Codable, Equatable {
+    case notOffered
+    case presented
+    case declined
+    case accepted
+}
+
 struct InstallationRecord: Codable, Equatable {
-    static let currentVersion = 2
+    static let currentVersion = 3
 
     let version: Int
     var tailnetBinding: TailnetBinding?
     var portals: [PortalConfiguration]
     var alerts: [InstallationAlert]
+    var operationalLogging: OperationalLoggingPreference
+    var launchAtLoginOffer: LaunchAtLoginOfferState
 
     init(
         tailnetBinding: TailnetBinding? = nil,
         portals: [PortalConfiguration] = [],
-        alerts: [InstallationAlert] = []
+        alerts: [InstallationAlert] = [],
+        operationalLogging: OperationalLoggingPreference = .undecided,
+        launchAtLoginOffer: LaunchAtLoginOfferState = .notOffered
     ) {
         version = Self.currentVersion
         self.tailnetBinding = tailnetBinding
         self.portals = portals
         self.alerts = alerts
+        self.operationalLogging = operationalLogging
+        self.launchAtLoginOffer = launchAtLoginOffer
     }
 }
 

--- a/Portico/PortalController.swift
+++ b/Portico/PortalController.swift
@@ -34,6 +34,11 @@ final class PortalController: ObservableObject {
     @Published private(set) var diagnosticEntries: [DiagnosticEntry] = []
     @Published private(set) var removalStates: [UUID: PortalRemovalState] = [:]
     @Published private(set) var removalNotices: [PortalRemovalNotice] = []
+    @Published private(set) var operationalLogging: OperationalLoggingPreference = .undecided
+    @Published private(set) var operationalLoggingError: String?
+    @Published private(set) var launchAtLoginOffer: LaunchAtLoginOfferState = .notOffered
+
+    var onFreshPortalOnline: (() -> Void)?
 
     var portal: PortalConfiguration? { portals.first }
     var status: PortalStatusPayload? { portal.flatMap { statuses[$0.id] } }
@@ -50,6 +55,8 @@ final class PortalController: ObservableObject {
     private let uuidProvider: () -> UUID
     private let dateProvider: () -> Date
     private let openURL: (URL) -> Void
+    private let copyText: (String) -> Void
+    private let announce: (String) -> Void
     private let reachability: LocalAppReachability?
     private let history: DiagnosticHistory
     private let diagnosticVersions: DiagnosticVersions
@@ -62,6 +69,7 @@ final class PortalController: ObservableObject {
     private var pendingReconciliation: PortalReconciliation?
     private var removalAttemptTokens: [UUID: Int] = [:]
     private var removalsAwaitingReconciliation: [UUID: Int] = [:]
+    private var loggingRestartPending = false
 
     init(
         store: PortalStore,
@@ -71,6 +79,8 @@ final class PortalController: ObservableObject {
         reachability: LocalAppReachability? = nil,
         history: DiagnosticHistory? = nil,
         diagnosticVersions: DiagnosticVersions = .current,
+        copyText: @escaping (String) -> Void = { _ in },
+        announce: @escaping (String) -> Void = { _ in },
         openURL: @escaping (URL) -> Void
     ) {
         self.store = store
@@ -80,6 +90,8 @@ final class PortalController: ObservableObject {
         self.reachability = reachability
         self.history = history ?? DiagnosticHistory(dateProvider: dateProvider)
         self.diagnosticVersions = diagnosticVersions
+        self.copyText = copyText
+        self.announce = announce
         self.openURL = openURL
         self.history.onChange = { [weak self] entries in self?.diagnosticEntries = entries }
         self.reachability?.onChange = { [weak self] states in
@@ -108,6 +120,7 @@ final class PortalController: ObservableObject {
     }
 
     func refreshLocalApps() {
+        guard actionAvailability().refreshLocalApps else { return }
         discoveryGeneration += 1
         let generation = discoveryGeneration
         isRefreshingLocalApps = true
@@ -130,6 +143,48 @@ final class PortalController: ObservableObject {
 
     func retryHelper() {
         helper.retry()
+    }
+
+    func setOperationalLogging(_ preference: OperationalLoggingPreference) {
+        guard preference != .undecided,
+              preference != installation.operationalLogging
+        else { return }
+        var updated = installation
+        updated.operationalLogging = preference
+        do {
+            try store.save(updated)
+        } catch {
+            let errorMessage = "The operational-support logging setting could not be saved."
+            operationalLoggingError = errorMessage
+            message = errorMessage
+            return
+        }
+
+        installation = updated
+        publishInstallation()
+        operationalLoggingError = nil
+        message = nil
+        discoveryGeneration += 1
+        isRefreshingLocalApps = false
+        authenticationPending.removeAll()
+        reconciliationGeneration += 1
+        pendingReconciliation = nil
+        loggingRestartPending = true
+        helper.restart(loggingPreference: preference)
+    }
+
+    func commitLaunchAtLoginOffer(_ state: LaunchAtLoginOfferState) -> Bool {
+        guard state != installation.launchAtLoginOffer else { return true }
+        var updated = installation
+        updated.launchAtLoginOffer = state
+        do {
+            try store.save(updated)
+            installation = updated
+            publishInstallation()
+            return true
+        } catch {
+            return false
+        }
     }
 
     func diagnosticReport() -> String {
@@ -156,6 +211,14 @@ final class PortalController: ObservableObject {
         )
     }
 
+    func copyDiagnosticReport() {
+        copyText(diagnosticReport())
+    }
+
+    func openExternalURL(_ url: URL) {
+        openURL(url)
+    }
+
     func selectLocalApp(_ candidate: LocalAppCandidatePayload) {
         guard localApps.contains(candidate) else { return }
         localAppPort = String(candidate.localAppPort)
@@ -164,13 +227,20 @@ final class PortalController: ObservableObject {
         }
     }
 
-    func addPortal() {
+    @discardableResult
+    func addPortal() -> PortalValidationError? {
+        guard operationalLogging != .undecided else {
+            message = "Choose an operational-support logging setting before adding a Portal."
+            return nil
+        }
         let port: UInt16
         do {
             port = try PortalInputValidator.validate(name: portalName, port: localAppPort)
-        } catch {
+        } catch let error as PortalValidationError {
             message = "Enter a lower-case DNS label and a port from 1 through 65535."
-            return
+            return error
+        } catch {
+            return nil
         }
         let configuration = PortalConfiguration(
             id: uuidProvider(),
@@ -195,6 +265,7 @@ final class PortalController: ObservableObject {
         } catch {
             message = "The Portal could not be saved."
         }
+        return nil
     }
 
     func startPortal(id: UUID) {
@@ -249,7 +320,7 @@ final class PortalController: ObservableObject {
     func retryRemoval(id: UUID) {
         guard installation.portals.contains(where: {
             $0.id == id && $0.lifecycle == .pendingRemoval
-        }), removalStates[id] == .failed else { return }
+        }), actionAvailability(for: installation.portals.first(where: { $0.id == id })).retryRemoval else { return }
         queueRemovalAttempt(id)
     }
 
@@ -283,7 +354,8 @@ final class PortalController: ObservableObject {
     }
 
     func authenticate(id: UUID) {
-        guard portals.contains(where: { $0.id == id && $0.lifecycle == .active }),
+        guard let portal = portals.first(where: { $0.id == id && $0.lifecycle == .active }),
+              actionAvailability(for: portal).authenticate,
               authenticationPending.insert(id).inserted
         else { return }
         helper.authenticatePortal(id: id) { [weak self] result in
@@ -326,6 +398,56 @@ final class PortalController: ObservableObject {
         }
     }
 
+    func actionAvailability(
+        for portal: PortalConfiguration? = nil,
+        editedPort: String? = nil
+    ) -> PortalActionAvailability {
+        let addInputsValid = portal == nil && (try? PortalInputValidator.validate(
+            name: portalName,
+            port: localAppPort
+        )) != nil
+        let editedPortValid: Bool
+        if let portal, let editedPort, editedPort != String(portal.localAppPort),
+           let parsed = try? PortalInputValidator.validate(name: portal.name, port: editedPort) {
+            editedPortValid = parsed > 0
+        } else {
+            editedPortValid = false
+        }
+        let status = portal.flatMap { statuses[$0.id] }
+        return PortalActionAvailability(context: PortalActionContext(
+            loggingPreference: installation.operationalLogging,
+            inputsValid: addInputsValid,
+            helperAvailability: helper.availability,
+            lifecycle: portal?.lifecycle,
+            desiredState: portal?.desiredState,
+            tailscaleState: status?.state,
+            hasPortalURL: status?.portalURL != nil,
+            isTailscaleFactsStale: portal.map { staleStatusIDs.contains($0.id) } ?? false,
+            isAuthenticationPending: portal.map { authenticationPending.contains($0.id) } ?? false,
+            removalState: portal.flatMap { removalStates[$0.id] },
+            hasTailnetBinding: installation.tailnetBinding != nil,
+            portalCount: installation.portals.count,
+            isEditedPortValid: editedPortValid,
+            isRefreshingLocalApps: isRefreshingLocalApps
+        ))
+    }
+
+    func copyPortalURL(id: UUID) {
+        guard let portal = installation.portals.first(where: { $0.id == id }),
+              actionAvailability(for: portal).copyPortalURL,
+              let url = statuses[id]?.portalURL
+        else { return }
+        copyText(url.absoluteString)
+    }
+
+    func openPortalURL(id: UUID) {
+        guard let portal = installation.portals.first(where: { $0.id == id }),
+              actionAvailability(for: portal).openPortalURL,
+              let url = statuses[id]?.portalURL
+        else { return }
+        openURL(url)
+    }
+
     func pendingWarningText(for portal: PortalConfiguration) -> String {
         "Removing \(portal.name) from a different tailnet. Local cleanup is in progress; its remote node may still require manual removal."
     }
@@ -349,6 +471,19 @@ final class PortalController: ObservableObject {
     }
 
     private func helperAvailabilityChanged(_ availability: HelperAvailability) {
+        if availability == .connected {
+            let event: PorticoAnnouncementEvent = loggingRestartPending
+                ? .preferenceRestartCompleted
+                : .helperConnected
+            loggingRestartPending = false
+            announce(PorticoAnnouncement.text(for: event))
+        } else if availability == .failed {
+            let event: PorticoAnnouncementEvent = loggingRestartPending
+                ? .preferenceRestartFailed
+                : .helperTerminalFailure
+            loggingRestartPending = false
+            announce(PorticoAnnouncement.text(for: event))
+        }
         guard availability != .connected else { return }
         staleStatusIDs.formUnion(statuses.keys)
         for portal in installation.portals where portal.lifecycle == .active {
@@ -477,6 +612,7 @@ final class PortalController: ObservableObject {
         guard removalAttemptTokens[id] == token else { return }
         removalStates[id] = .failed
         message = "Portal removal could not be completed. Retry when ready."
+        announce(PorticoAnnouncement.text(for: .removalFailed))
     }
 
     private func finishRemoval(id: UUID, token: Int) {
@@ -505,6 +641,7 @@ final class PortalController: ObservableObject {
             ))
             publishInstallation()
             message = nil
+            announce(PorticoAnnouncement.text(for: .removalSucceeded))
         } catch {
             failRemovalAttempt(id: id, token: token)
             message = "Local cleanup completed, but the Portal record could not be removed. Retry when ready."
@@ -517,10 +654,15 @@ final class PortalController: ObservableObject {
             guard let portal = installation.portals.first(where: {
                 $0.id == id && $0.lifecycle == .active
             }) else { return }
+            let wasFreshOnline = statuses[id]?.state == .online && !staleStatusIDs.contains(id)
             let displayStatus = status.sanitizedForDisplay()
             statuses[id] = displayStatus
             staleStatusIDs.remove(id)
             recordPortalState(portal)
+            if status.state == .online, !wasFreshOnline {
+                announce(PorticoAnnouncement.text(for: .portalOnline))
+                onFreshPortalOnline?()
+            }
             if portal.lifecycle == .active, status.state == .online,
                let tailnetName = status.tailnetName, !tailnetName.isEmpty {
                 receiveOnlineStatus(for: portal, displayStatus: displayStatus, tailnetName: tailnetName)
@@ -634,6 +776,8 @@ final class PortalController: ObservableObject {
     private func publishInstallation() {
         portals = installation.portals
         alerts = installation.alerts
+        operationalLogging = installation.operationalLogging
+        launchAtLoginOffer = installation.launchAtLoginOffer
         tailnetDisplaySuffix = installation.tailnetBinding?.magicDNSSuffix.nonEmpty
         reachability?.update(portals: installation.portals.filter { $0.lifecycle == .active })
     }

--- a/Portico/PortalPresentation.swift
+++ b/Portico/PortalPresentation.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+struct PortalPresentation {
+    static let prerequisiteGuidance = [
+        "Enable MagicDNS for your tailnet.",
+        "Enable HTTPS certificates for your tailnet.",
+        "Approve the Portal device when your tailnet requires device approval.",
+        "Portal names are published to Certificate Transparency logs when certificates are issued.",
+    ]
+
+    let portalName: String
+    let assignedName: String?
+    let desiredState: String
+    let tailscaleState: String
+    let localAppReachability: String
+    let portalURLLabel: String
+    let collisionExplanation: String?
+
+    init(
+        portal: PortalConfiguration,
+        status: PortalStatusPayload?,
+        reachability: LocalAppReachabilityState,
+        isStale: Bool
+    ) {
+        portalName = portal.name
+        assignedName = status?.assignedName
+        desiredState = portal.desiredState.title
+        let state = status?.state.title ?? "Unknown"
+        tailscaleState = isStale ? "\(state) — Last Known" : state
+        localAppReachability = reachability.title
+        portalURLLabel = isStale ? "Portal URL — Last Known" : "Portal URL"
+        if let assignedName = status?.assignedName, assignedName != portal.name {
+            collisionExplanation = "Tailscale assigned “\(assignedName)” because “\(portal.name)” was unavailable. Portal Name remains “\(portal.name)”."
+        } else {
+            collisionExplanation = nil
+        }
+    }
+
+    static func showsPrerequisiteGuidance(portalCount: Int) -> Bool {
+        portalCount == 0
+    }
+}
+
+enum PorticoAnnouncementEvent {
+    case helperConnected
+    case helperTerminalFailure
+    case portalOnline
+    case removalSucceeded
+    case removalFailed
+    case preferenceRestartCompleted
+    case preferenceRestartFailed
+}
+
+enum PorticoAnnouncement {
+    static func text(for event: PorticoAnnouncementEvent) -> String {
+        switch event {
+        case .helperConnected: "Helper connected."
+        case .helperTerminalFailure: "Helper unavailable."
+        case .portalOnline: "Portal online."
+        case .removalSucceeded: "Portal removal completed."
+        case .removalFailed: "Portal removal failed."
+        case .preferenceRestartCompleted: "Logging preference restart completed."
+        case .preferenceRestartFailed: "Logging preference restart failed."
+        }
+    }
+}
+
+extension LocalAppReachabilityState {
+    var title: String {
+        switch self {
+        case .unknown: "Unknown"
+        case .reachable: "Reachable"
+        case .unavailable: "Unavailable"
+        }
+    }
+}
+
+extension PortalTailscaleState {
+    var title: String {
+        switch self {
+        case .authenticating: "Authentication required"
+        case .awaitingApproval: "Awaiting approval"
+        case .connecting: "Connecting"
+        case .online: "Online"
+        case .stopped: "Stopped"
+        case .error: "Error"
+        }
+    }
+}
+
+extension PortalDesiredState {
+    var title: String {
+        switch self {
+        case .enabled: "Enabled"
+        case .stopped: "Stopped"
+        }
+    }
+}

--- a/Portico/PortalStore.swift
+++ b/Portico/PortalStore.swift
@@ -11,9 +11,7 @@ struct PortalStore {
 
     init(
         rootURL: URL,
-        writeData: @escaping (Data, URL) throws -> Void = { data, url in
-            try data.write(to: url, options: .atomic)
-        }
+        writeData: @escaping (Data, URL) throws -> Void = securelyWrite
     ) {
         self.rootURL = rootURL
         self.writeData = writeData
@@ -28,6 +26,10 @@ struct PortalStore {
     }
 
     var installationURL: URL {
+        rootURL.appendingPathComponent("installation-v3.json", isDirectory: false)
+    }
+
+    var versionTwoInstallationURL: URL {
         rootURL.appendingPathComponent("installation-v2.json", isDirectory: false)
     }
 
@@ -51,9 +53,18 @@ struct PortalStore {
             guard installation.version == InstallationRecord.currentVersion else {
                 throw PortalStoreError.unsupportedVersion(installation.version)
             }
-            if FileManager.default.fileExists(atPath: legacyConfigurationURL.path) {
-                try? FileManager.default.removeItem(at: legacyConfigurationURL)
+            removeOlderFiles()
+            return installation
+        }
+        if FileManager.default.fileExists(atPath: versionTwoInstallationURL.path) {
+            let data = try Data(contentsOf: versionTwoInstallationURL)
+            let historical = try JSONDecoder().decode(VersionTwoInstallationRecord.self, from: data)
+            guard historical.version == VersionTwoInstallationRecord.currentVersion else {
+                throw PortalStoreError.unsupportedVersion(historical.version)
             }
+            let installation = historical.migrated
+            try save(installation)
+            removeOlderFiles()
             return installation
         }
         guard FileManager.default.fileExists(atPath: legacyConfigurationURL.path) else {
@@ -64,9 +75,13 @@ struct PortalStore {
         guard envelope.version == LegacyPortalConfigurationEnvelope.currentVersion else {
             throw PortalStoreError.unsupportedVersion(envelope.version)
         }
-        let installation = InstallationRecord(portals: [envelope.portal.migrated])
+        let installation = InstallationRecord(
+            portals: [envelope.portal.migrated],
+            operationalLogging: .enabled,
+            launchAtLoginOffer: .notOffered
+        )
         try save(installation)
-        try FileManager.default.removeItem(at: legacyConfigurationURL)
+        removeOlderFiles()
         return installation
     }
 
@@ -79,7 +94,80 @@ struct PortalStore {
         try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: rootURL.path)
         let data = try JSONEncoder().encode(installation)
         try writeData(data, installationURL)
-        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: installationURL.path)
+    }
+
+    private func removeOlderFiles() {
+        for url in [versionTwoInstallationURL, legacyConfigurationURL]
+        where FileManager.default.fileExists(atPath: url.path) {
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+}
+
+private struct VersionTwoInstallationRecord: Decodable {
+    static let currentVersion = 2
+
+    let version: Int
+    let tailnetBinding: TailnetBinding?
+    let portals: [VersionTwoPortalConfiguration]
+    let alerts: [InstallationAlert]
+
+    var migrated: InstallationRecord {
+        let isPristine = tailnetBinding == nil && portals.isEmpty && alerts.isEmpty
+        return InstallationRecord(
+            tailnetBinding: tailnetBinding,
+            portals: portals.map(\.migrated),
+            alerts: alerts,
+            operationalLogging: isPristine ? .undecided : .enabled,
+            launchAtLoginOffer: .notOffered
+        )
+    }
+}
+
+private struct VersionTwoPortalConfiguration: Decodable {
+    let id: UUID
+    let name: String
+    let localAppPort: UInt16
+    let createdAt: Date
+    let desiredState: PortalDesiredState
+    let lifecycle: PortalLifecycle
+    let removalAssignedName: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case localAppPort
+        case createdAt
+        case desiredState
+        case lifecycle
+        case removalAssignedName
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        localAppPort = try container.decode(UInt16.self, forKey: .localAppPort)
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        desiredState = try container.contains(.desiredState)
+            ? container.decode(PortalDesiredState.self, forKey: .desiredState)
+            : .enabled
+        lifecycle = try container.decode(PortalLifecycle.self, forKey: .lifecycle)
+        removalAssignedName = lifecycle == .pendingRemoval
+            ? try container.decodeIfPresent(String.self, forKey: .removalAssignedName)
+            : nil
+    }
+
+    var migrated: PortalConfiguration {
+        PortalConfiguration(
+            id: id,
+            name: name,
+            localAppPort: localAppPort,
+            createdAt: createdAt,
+            desiredState: desiredState,
+            lifecycle: lifecycle,
+            removalAssignedName: removalAssignedName
+        )
     }
 }
 
@@ -104,5 +192,34 @@ private struct LegacyPortalConfiguration: Decodable {
             createdAt: createdAt,
             lifecycle: .active
         )
+    }
+}
+
+private func securelyWrite(_ data: Data, to destinationURL: URL) throws {
+    let fileManager = FileManager.default
+    let temporaryURL = destinationURL
+        .deletingLastPathComponent()
+        .appendingPathComponent(".\(destinationURL.lastPathComponent).\(UUID().uuidString).tmp")
+    defer { try? fileManager.removeItem(at: temporaryURL) }
+
+    guard fileManager.createFile(
+        atPath: temporaryURL.path,
+        contents: nil,
+        attributes: [.posixPermissions: 0o600]
+    ) else {
+        throw CocoaError(.fileWriteUnknown)
+    }
+    try data.write(to: temporaryURL)
+    try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: temporaryURL.path)
+
+    if fileManager.fileExists(atPath: destinationURL.path) {
+        _ = try fileManager.replaceItemAt(
+            destinationURL,
+            withItemAt: temporaryURL,
+            backupItemName: nil,
+            options: .usingNewMetadataOnly
+        )
+    } else {
+        try fileManager.moveItem(at: temporaryURL, to: destinationURL)
     }
 }

--- a/Portico/PorticoApp.swift
+++ b/Portico/PorticoApp.swift
@@ -7,34 +7,94 @@ struct PorticoApp: App {
 
     var body: some Scene {
         MenuBarExtra("Portico", systemImage: "door.left.hand.open") {
-            PortalView(controller: appDelegate.portalController, supervisor: appDelegate.supervisor)
+            PortalView(
+                controller: appDelegate.portalController,
+                supervisor: appDelegate.supervisor,
+                launchAtLogin: appDelegate.launchAtLoginController
+            )
+            .environment(\.openURL, OpenURLAction { url in
+                appDelegate.portalController.openExternalURL(url)
+                return .handled
+            })
         }
         .menuBarExtraStyle(.window)
+        .commands { PorticoCommands() }
         Window("Portico Diagnostics", id: "diagnostics") {
             DiagnosticsView(controller: appDelegate.portalController)
         }
         .defaultSize(width: 720, height: 520)
+        Settings {
+            SettingsView(
+                controller: appDelegate.portalController,
+                supervisor: appDelegate.supervisor,
+                launchAtLogin: appDelegate.launchAtLoginController
+            )
+        }
+    }
+}
+
+private struct PorticoCommands: Commands {
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some Commands {
+        CommandGroup(after: .appSettings) {
+            Button("Diagnostics") { openWindow(id: "diagnostics") }
+                .keyboardShortcut("d", modifiers: [.command, .shift])
+#if DEBUG
+            if UITestLaunchConfiguration.current?.scenario == .restarting {
+                Button("Complete UI Test Restart") { UITestRestartGate.shared.release() }
+                    .keyboardShortcut("r", modifiers: [.command, .shift])
+            }
+#endif
+        }
     }
 }
 
 private struct PortalView: View {
+    private enum AccessibilityFocusTarget: Hashable {
+        case portalNameField
+        case localAppPortField
+        case portal(UUID)
+        case removalNotice(UUID)
+    }
+
     @Environment(\.openWindow) private var openWindow
     @ObservedObject var controller: PortalController
     @ObservedObject var supervisor: HelperSupervisor
+    @ObservedObject var launchAtLogin: LaunchAtLoginController
     @State private var showingResetConfirmation = false
     @State private var removalCandidate: PortalConfiguration?
+    @State private var removalCompletionFocusID: UUID?
+    @FocusState private var inputFocus: AccessibilityFocusTarget?
+    @AccessibilityFocusState private var accessibilityFocus: AccessibilityFocusTarget?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             Label(supervisor.availability.title, systemImage: supervisor.availability.symbolName)
+                .accessibilityIdentifier("helper-state")
             if supervisor.availability == .failed {
                 Button("Retry Helper") { controller.retryHelper() }
                     .buttonStyle(.borderedProminent)
+                    .accessibilityIdentifier("retry-helper")
             }
             if let suffix = controller.tailnetDisplaySuffix {
                 LabeledContent("Tailnet", value: suffix)
             }
-            Button("Diagnostics") { openWindow(id: "diagnostics") }
+            if launchAtLogin.isOffering {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Open Portico at Login?").font(.headline)
+                    Text("You can change this later in Settings.")
+                    HStack {
+                        Button("Not Now") { launchAtLogin.declineOffer() }
+                            .accessibilityIdentifier("login-offer-decline")
+                        Button("Enable") { launchAtLogin.acceptOffer() }
+                            .buttonStyle(.borderedProminent)
+                            .accessibilityIdentifier("login-offer-enable")
+                    }
+                }
+                .accessibilityElement(children: .contain)
+                .accessibilityIdentifier("launch-at-login-offer")
+            }
             Divider()
             ForEach(controller.pendingPortals, id: \.id) { portal in
                 pendingWarning(portal)
@@ -44,6 +104,7 @@ private struct PortalView: View {
             }
             ForEach(controller.removalNotices) { notice in
                 removalNotice(notice)
+                    .accessibilityFocused($accessibilityFocus, equals: .removalNotice(notice.id))
             }
             ForEach(controller.alerts) { alert in
                 completedWarning(alert)
@@ -54,6 +115,7 @@ private struct PortalView: View {
                     portal: portal,
                     onRemove: { removalCandidate = portal }
                 )
+                .accessibilityFocused($accessibilityFocus, equals: .portal(portal.id))
                 Divider()
             }
             addPortalForm
@@ -68,9 +130,28 @@ private struct PortalView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+            Divider()
+            SettingsLink()
+                .keyboardShortcut(",", modifiers: .command)
+                .accessibilityIdentifier("settings")
+            Button("Diagnostics") { openWindow(id: "diagnostics") }
+                .keyboardShortcut("d", modifiers: [.command, .shift])
+                .accessibilityIdentifier("diagnostics")
         }
         .padding()
         .frame(width: 380)
+        .onDisappear {
+            if launchAtLogin.isOffering {
+                launchAtLogin.declineOffer()
+            }
+        }
+        .onChange(of: controller.removalNotices) { _, notices in
+            guard let id = removalCompletionFocusID,
+                  notices.contains(where: { $0.id == id })
+            else { return }
+            removalCompletionFocusID = nil
+            accessibilityFocus = .removalNotice(id)
+        }
         .confirmationDialog(
             "Reset this installation's tailnet binding? This does not remove any remote Tailscale node.",
             isPresented: $showingResetConfirmation,
@@ -83,11 +164,12 @@ private struct PortalView: View {
         }
         .sheet(isPresented: Binding(
             get: { removalCandidate != nil },
-            set: { if !$0 { removalCandidate = nil } }
+            set: { if !$0 { cancelRemoval() } }
         )) {
             if let portal = removalCandidate {
                 VStack(alignment: .leading, spacing: 12) {
                     Text("Remove Portal?").font(.headline)
+                        .accessibilityIdentifier("remove-confirmation-heading")
                     Text(controller.removalWarningText(for: portal))
                     Link(
                         "How to remove a Tailscale device",
@@ -95,11 +177,16 @@ private struct PortalView: View {
                     )
                     HStack {
                         Spacer()
-                        Button("Cancel") { removalCandidate = nil }
+                        Button("Cancel") { cancelRemoval() }
+                            .keyboardShortcut(.cancelAction)
+                            .accessibilityIdentifier("remove-cancel")
                         Button("Remove Portal", role: .destructive) {
+                            removalCompletionFocusID = portal.id
                             controller.removePortal(id: portal.id)
                             removalCandidate = nil
                         }
+                        .keyboardShortcut(.defaultAction)
+                        .accessibilityIdentifier("remove-confirm")
                     }
                 }
                 .padding()
@@ -111,16 +198,47 @@ private struct PortalView: View {
             NSApp.terminate(nil)
         }
         .keyboardShortcut("q")
+        .accessibilityIdentifier("quit")
     }
 
     private var addPortalForm: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Add Portal").font(.headline)
+                .accessibilityIdentifier("add-form")
+            if PortalPresentation.showsPrerequisiteGuidance(portalCount: controller.portals.count) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Before creating your first Portal").font(.subheadline)
+                    ForEach(PortalPresentation.prerequisiteGuidance, id: \.self) { guidance in
+                        Label(guidance, systemImage: "info.circle")
+                            .font(.caption)
+                    }
+                }
+                .accessibilityElement(children: .contain)
+                .accessibilityIdentifier("add-guidance")
+            }
+            if controller.operationalLogging == .undecided {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Choose operational-support logging before adding a Portal.")
+                        .font(.caption)
+                    HStack {
+                        Button("Allow Operational-support Logging") {
+                            controller.setOperationalLogging(.enabled)
+                        }
+                        .accessibilityIdentifier("logging-enabled")
+                        Button("Disable Operational-support Logging") {
+                            controller.setOperationalLogging(.disabled)
+                        }
+                        .accessibilityIdentifier("logging-disabled")
+                    }
+                }
+                .accessibilityElement(children: .contain)
+                .accessibilityIdentifier("logging-choice")
+            }
             HStack {
                 Text("Detected Local Apps").font(.subheadline)
                 Spacer()
                 Button("Refresh") { controller.refreshLocalApps() }
-                    .disabled(controller.isRefreshingLocalApps)
+                    .disabled(!controller.actionAvailability().refreshLocalApps)
             }
             if controller.isRefreshingLocalApps {
                 ProgressView()
@@ -145,9 +263,50 @@ private struct PortalView: View {
                     .foregroundStyle(.secondary)
             }
             TextField("Portal Name", text: $controller.portalName)
+                .accessibilityIdentifier("portal-name-field")
+                .focused($inputFocus, equals: .portalNameField)
+                .accessibilityFocused($accessibilityFocus, equals: .portalNameField)
+                .onSubmit { validateNameAndAdvance() }
             TextField("Local App Port", text: $controller.localAppPort)
-            Button("Add Portal") { controller.addPortal() }
+                .accessibilityIdentifier("local-app-port-field")
+                .focused($inputFocus, equals: .localAppPortField)
+                .accessibilityFocused($accessibilityFocus, equals: .localAppPortField)
+                .onSubmit { submitPortal() }
+            Button("Add Portal") { submitPortal() }
                 .buttonStyle(.borderedProminent)
+                .disabled(!controller.actionAvailability().addPortal)
+        }
+    }
+
+    private func validateNameAndAdvance() {
+        do {
+            _ = try PortalInputValidator.validate(name: controller.portalName, port: "1")
+            inputFocus = .localAppPortField
+            accessibilityFocus = .localAppPortField
+        } catch {
+            inputFocus = .portalNameField
+            accessibilityFocus = .portalNameField
+        }
+    }
+
+    private func submitPortal() {
+        switch controller.addPortal() {
+        case .invalidName:
+            inputFocus = .portalNameField
+            accessibilityFocus = .portalNameField
+        case .invalidPort:
+            inputFocus = .localAppPortField
+            accessibilityFocus = .localAppPortField
+        case nil:
+            break
+        }
+    }
+
+    private func cancelRemoval() {
+        guard let portal = removalCandidate else { return }
+        removalCandidate = nil
+        DispatchQueue.main.async {
+            accessibilityFocus = .portal(portal.id)
         }
     }
 
@@ -186,6 +345,7 @@ private struct PortalView: View {
             if controller.removalStates[portal.id] == .failed {
                 Button("Retry Removal") { controller.retryRemoval(id: portal.id) }
                     .controlSize(.small)
+                    .disabled(!controller.actionAvailability(for: portal).retryRemoval)
             } else {
                 ProgressView()
                     .controlSize(.small)
@@ -193,6 +353,8 @@ private struct PortalView: View {
             Button("Diagnostics") { openWindow(id: "diagnostics") }
                 .controlSize(.small)
         }
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("removing-portal")
     }
 
     private func removalNotice(_ notice: PortalRemovalNotice) -> some View {
@@ -206,6 +368,8 @@ private struct PortalView: View {
             Button("Dismiss") { controller.dismissRemovalNotice(id: notice.id) }
                 .controlSize(.small)
         }
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("removal-complete")
     }
 }
 
@@ -215,6 +379,7 @@ private struct PortalStatusView: View {
     let portal: PortalConfiguration
     let onRemove: () -> Void
     @State private var localAppPort: String
+    @FocusState private var startStopFocused: Bool
 
     init(controller: PortalController, portal: PortalConfiguration, onRemove: @escaping () -> Void) {
         self.controller = controller
@@ -224,32 +389,47 @@ private struct PortalStatusView: View {
     }
 
     var body: some View {
-        Text(portal.name).font(.headline)
-        LabeledContent("Desired State", value: portal.desiredState.title)
-        HStack {
-            Text("Local App Port")
-            Spacer()
-            TextField("Local App Port", text: $localAppPort)
-                .frame(width: 80)
-                .onSubmit(updatePort)
-            Button("Update") { updatePort() }
-                .controlSize(.small)
-            Button(portal.desiredState == .enabled ? "Stop" : "Start") {
-                if portal.desiredState == .enabled {
-                    controller.stopPortal(id: portal.id)
-                } else {
-                    controller.startPortal(id: portal.id)
-                }
-            }
-            .controlSize(.small)
+        let isStale = controller.staleStatusIDs.contains(portal.id)
+        let status = controller.statuses[portal.id]
+        let presentation = PortalPresentation(
+            portal: portal,
+            status: status,
+            reachability: controller.reachabilityStates[portal.id] ?? .unknown,
+            isStale: isStale
+        )
+        let rowActions = controller.actionAvailability(for: portal)
+        let editedPortActions = controller.actionAvailability(for: portal, editedPort: localAppPort)
+        Text(presentation.portalName).font(.headline)
+            .accessibilityLabel("Portal Name, \(presentation.portalName)")
+            .accessibilityIdentifier("portal-name")
+        if let assignedName = presentation.assignedName {
+            LabeledContent("Assigned Name", value: assignedName)
+                .accessibilityIdentifier("assigned-name")
         }
+        if let explanation = presentation.collisionExplanation {
+            Text(explanation).font(.caption).foregroundStyle(.secondary)
+        }
+        LabeledContent("Desired State", value: presentation.desiredState)
+            .accessibilityIdentifier("desired-state")
+        LabeledContent("Tailscale", value: presentation.tailscaleState)
+            .accessibilityIdentifier("tailscale-state")
+        LabeledContent("Local App", value: presentation.localAppReachability)
+            .accessibilityIdentifier("local-app-state")
         if let status = controller.statuses[portal.id] {
-            LabeledContent("Tailscale", value: status.state.title)
-            if let assignedName = status.assignedName {
-                LabeledContent("Assigned Name", value: assignedName)
-            }
             if let portalURL = status.portalURL {
-                LabeledContent("Portal URL", value: portalURL.absoluteString)
+                LabeledContent(
+                    presentation.portalURLLabel,
+                    value: portalURL.absoluteString
+                )
+                .accessibilityIdentifier("portal-url")
+                HStack {
+                    Button("Copy Portal URL") { controller.copyPortalURL(id: portal.id) }
+                        .disabled(!rowActions.copyPortalURL)
+                        .accessibilityIdentifier("copy-portal-url")
+                    Button("Open Portal URL") { controller.openPortalURL(id: portal.id) }
+                        .disabled(!rowActions.openPortalURL)
+                        .accessibilityIdentifier("open-portal-url")
+                }
             }
             if !status.addresses.isEmpty {
                 LabeledContent("Addresses", value: status.addresses.joined(separator: ", "))
@@ -257,24 +437,45 @@ private struct PortalStatusView: View {
             if status.state == .authenticating {
                 Button("Authenticate") { controller.authenticate(id: portal.id) }
                     .buttonStyle(.borderedProminent)
+                    .disabled(!rowActions.authenticate)
+                    .accessibilityIdentifier("authenticate")
             }
-            if controller.staleStatusIDs.contains(portal.id) {
-                Text("Last known Tailscale facts — stale")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-        } else {
-            Text("Waiting for Portal status…")
-                .foregroundStyle(.secondary)
         }
-        LabeledContent(
-            "Local App",
-            value: (controller.reachabilityStates[portal.id] ?? .unknown).title
-        )
+        HStack {
+            Text("Local App Port")
+            Spacer()
+            TextField("Local App Port", text: $localAppPort)
+                .frame(width: 80)
+                .onSubmit(updatePort)
+                .accessibilityIdentifier("edit-local-app-port")
+            Button("Update") { updatePort() }
+                .controlSize(.small)
+                .disabled(!editedPortActions.editPort)
+                .accessibilityIdentifier("update-local-app-port")
+            Button(portal.desiredState == .enabled ? "Stop" : "Start") {
+                if portal.desiredState == .enabled {
+                    controller.stopPortal(id: portal.id)
+                } else {
+                    controller.startPortal(id: portal.id)
+                }
+                DispatchQueue.main.async {
+                    startStopFocused = true
+                }
+            }
+            .controlSize(.small)
+            .focusable()
+            .focused($startStopFocused)
+            .accessibilityIdentifier("start-stop")
+            .disabled(portal.desiredState == .enabled
+                ? !rowActions.stop
+                : !rowActions.start)
+        }
         Button("Diagnostics") { openWindow(id: "diagnostics") }
             .controlSize(.small)
+            .accessibilityIdentifier("portal-diagnostics")
         Button("Remove Portal", role: .destructive, action: onRemove)
             .controlSize(.small)
+            .accessibilityIdentifier("remove-portal")
     }
 
     private func updatePort() {
@@ -282,18 +483,86 @@ private struct PortalStatusView: View {
     }
 }
 
+private struct SettingsView: View {
+    @ObservedObject var controller: PortalController
+    @ObservedObject var supervisor: HelperSupervisor
+    @ObservedObject var launchAtLogin: LaunchAtLoginController
+    @AccessibilityFocusState private var headingFocused: Bool
+
+    var body: some View {
+        Form {
+            Text("Portico Settings")
+                .font(.title2)
+                .accessibilityAddTraits(.isHeader)
+                .accessibilityFocused($headingFocused)
+                .accessibilityIdentifier("settings-heading")
+            Picker(
+                "Operational-support logging",
+                selection: Binding(
+                    get: { controller.operationalLogging },
+                    set: { controller.setOperationalLogging($0) }
+                )
+            ) {
+                Text("Allow operational-support logging").tag(OperationalLoggingPreference.enabled)
+                Text("Disable operational-support logging").tag(OperationalLoggingPreference.disabled)
+            }
+            .pickerStyle(.radioGroup)
+            .accessibilityIdentifier("logging-preference")
+            Text("Changing this setting safely restarts the helper.")
+                .font(.caption)
+            LabeledContent("Helper", value: supervisor.availability.title)
+                .accessibilityIdentifier("settings-helper-state")
+            if let error = controller.operationalLoggingError {
+                Text(error).foregroundStyle(.secondary)
+                    .accessibilityIdentifier("logging-preference-error")
+            }
+            LabeledContent("Launch at login", value: launchAtLogin.status.title)
+                .accessibilityIdentifier("launch-at-login-status")
+            if launchAtLogin.status == .notRegistered {
+                Button("Enable Launch at Login") { launchAtLogin.setEnabled(true) }
+                    .accessibilityIdentifier("enable-launch-at-login")
+            } else if launchAtLogin.status == .enabled {
+                Button("Disable Launch at Login") { launchAtLogin.setEnabled(false) }
+                    .accessibilityIdentifier("disable-launch-at-login")
+            } else if launchAtLogin.status == .requiresApproval {
+                Button("Open Login Items Settings") { launchAtLogin.openLoginItemsSettings() }
+                    .accessibilityIdentifier("open-login-items-settings")
+            }
+            if controller.launchAtLoginOffer == .accepted,
+               launchAtLogin.status == .notRegistered,
+               launchAtLogin.errorMessage != nil {
+                Button("Retry Launch at Login") { launchAtLogin.retryRegistration() }
+                    .accessibilityIdentifier("retry-launch-at-login")
+            }
+            if let error = launchAtLogin.errorMessage {
+                Text(error).foregroundStyle(.secondary)
+                    .accessibilityIdentifier("launch-at-login-error")
+            }
+        }
+        .padding()
+        .frame(width: 480)
+        .onAppear {
+            launchAtLogin.refreshStatus()
+            headingFocused = true
+        }
+    }
+}
+
 private struct DiagnosticsView: View {
     @ObservedObject var controller: PortalController
+    @AccessibilityFocusState private var headingFocused: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Portico Diagnostics").font(.title2)
+                .accessibilityAddTraits(.isHeader)
+                .accessibilityFocused($headingFocused)
+                .accessibilityIdentifier("diagnostics-heading")
             HStack {
                 Button("Refresh Local App Reachability") { controller.refreshReachability() }
                 Spacer()
                 Button("Copy Report") {
-                    NSPasteboard.general.clearContents()
-                    NSPasteboard.general.setString(controller.diagnosticReport(), forType: .string)
+                    controller.copyDiagnosticReport()
                 }
             }
             ScrollView {
@@ -304,15 +573,17 @@ private struct DiagnosticsView: View {
             }
         }
         .padding()
+        .onAppear { headingFocused = true }
     }
 }
 
-private extension LocalAppReachabilityState {
+private extension LaunchAtLoginStatus {
     var title: String {
         switch self {
-        case .unknown: "Unknown"
-        case .reachable: "Reachable"
-        case .unavailable: "Unavailable"
+        case .notRegistered: "Off"
+        case .enabled: "On"
+        case .requiresApproval: "Approval required"
+        case .notFound: "Unavailable"
         }
     }
 }
@@ -320,6 +591,8 @@ private extension LocalAppReachabilityState {
 private extension HelperAvailability {
     var title: String {
         switch self {
+        case .awaitingLoggingChoice: "Awaiting logging choice"
+        case .restarting: "Restarting"
         case .connecting: "Connecting"
         case let .retrying(attempt, delay): "Retry \(attempt) in \(Int(delay))s"
         case .connected: "Connected"
@@ -330,32 +603,10 @@ private extension HelperAvailability {
 
     var symbolName: String {
         switch self {
-        case .connecting, .retrying: "ellipsis.circle"
+        case .awaitingLoggingChoice, .restarting, .connecting, .retrying: "ellipsis.circle"
         case .connected: "checkmark.circle"
         case .failed: "exclamationmark.triangle"
         case .shuttingDown: "stop.circle"
-        }
-    }
-}
-
-private extension PortalTailscaleState {
-    var title: String {
-        switch self {
-        case .authenticating: "Authentication required"
-        case .awaitingApproval: "Awaiting approval"
-        case .connecting: "Connecting"
-        case .online: "Online"
-        case .stopped: "Stopped"
-        case .error: "Error"
-        }
-    }
-}
-
-private extension PortalDesiredState {
-    var title: String {
-        switch self {
-        case .enabled: "Enabled"
-        case .stopped: "Stopped"
         }
     }
 }

--- a/Portico/ProcessHelperLauncher.swift
+++ b/Portico/ProcessHelperLauncher.swift
@@ -1,9 +1,30 @@
 import Foundation
 
+enum ProcessHelperLauncherError: Error {
+    case loggingChoiceRequired
+}
+
 final class ProcessHelperLauncher: HelperLaunching {
+    static func childEnvironment(
+        for preference: OperationalLoggingPreference,
+        inherited: [String: String]
+    ) throws -> [String: String] {
+        var environment = inherited
+        switch preference {
+        case .undecided:
+            throw ProcessHelperLauncherError.loggingChoiceRequired
+        case .enabled:
+            environment.removeValue(forKey: "TS_NO_LOGS_NO_SUPPORT")
+        case .disabled:
+            environment["TS_NO_LOGS_NO_SUPPORT"] = "true"
+        }
+        return environment
+    }
+
     func launch(
         at executableURL: URL,
         arguments: [String],
+        loggingPreference: OperationalLoggingPreference,
         onLine: @escaping (Data) -> Void,
         onEOF: @escaping () -> Void,
         onExit: @escaping (Int32) -> Void
@@ -16,6 +37,10 @@ final class ProcessHelperLauncher: HelperLaunching {
 
         process.executableURL = executableURL
         process.arguments = arguments
+        process.environment = try Self.childEnvironment(
+            for: loggingPreference,
+            inherited: ProcessInfo.processInfo.environment
+        )
         process.standardInput = input
         process.standardOutput = output
         process.standardError = diagnostics

--- a/Portico/UITestLaunchConfiguration.swift
+++ b/Portico/UITestLaunchConfiguration.swift
@@ -1,0 +1,350 @@
+import Foundation
+
+#if DEBUG
+
+enum UITestScenario: String {
+    case firstRun = "first-run"
+    case online
+    case authenticating
+    case stale
+    case restarting
+    case terminalFailure = "terminal-failure"
+    case removing
+    case removingFailure = "removing-failure"
+    case loginApproval = "login-approval"
+    case loginError = "login-error"
+    case loginOffer = "login-offer"
+}
+
+struct UITestLaunchConfiguration {
+    static let portalID = UUID(uuidString: "11111111-1111-4111-8111-111111111111")!
+
+    let scenario: UITestScenario
+    let rootURL: URL
+
+    static var current: UITestLaunchConfiguration? {
+#if DEBUG
+        let process = ProcessInfo.processInfo
+        guard process.arguments.contains("--ui-testing"),
+              let rawScenario = process.environment["PORTICO_UI_TEST_SCENARIO"],
+              let scenario = UITestScenario(rawValue: rawScenario),
+              let root = process.environment["PORTICO_UI_TEST_ROOT"]
+        else { return nil }
+        let rootURL = URL(fileURLWithPath: root, isDirectory: true).standardizedFileURL
+        guard rootURL.deletingLastPathComponent().path == "/private/tmp",
+              rootURL.lastPathComponent.hasPrefix("PorticoUITests-")
+        else { return nil }
+        return UITestLaunchConfiguration(scenario: scenario, rootURL: rootURL)
+#else
+        return nil
+#endif
+    }
+
+    func prepareInstallationIfNeeded() throws {
+        let store = PortalStore(rootURL: rootURL)
+        guard !FileManager.default.fileExists(atPath: store.installationURL.path) else { return }
+        switch scenario {
+        case .firstRun:
+            break
+        case .loginApproval, .loginError:
+            try store.save(InstallationRecord(operationalLogging: .enabled))
+        case .removing, .removingFailure:
+            try store.save(InstallationRecord(
+                tailnetBinding: Self.tailnetBinding,
+                portals: [Self.portal(lifecycle: .pendingRemoval, removalAssignedName: "portal-one-1")],
+                operationalLogging: .enabled,
+                launchAtLoginOffer: .declined
+            ))
+        case .loginOffer:
+            try store.save(InstallationRecord(
+                tailnetBinding: Self.tailnetBinding,
+                portals: [Self.portal()],
+                operationalLogging: .enabled,
+                launchAtLoginOffer: .notOffered
+            ))
+        case .online, .authenticating, .stale, .restarting, .terminalFailure:
+            try store.save(InstallationRecord(
+                tailnetBinding: Self.tailnetBinding,
+                portals: [Self.portal()],
+                operationalLogging: .enabled,
+                launchAtLoginOffer: .declined
+            ))
+        }
+    }
+
+    var launchAtLoginStatus: LaunchAtLoginStatus {
+        scenario == .loginApproval ? .requiresApproval : .notRegistered
+    }
+
+    var registrationFails: Bool { scenario == .loginError }
+    var reachabilityResult: Bool { scenario != .terminalFailure }
+    var supervisorSchedulerScale: Double {
+        switch scenario {
+        case .terminalFailure: 0.01
+        case .restarting: 5
+        default: 1
+        }
+    }
+
+    private static let tailnetBinding = TailnetBinding(
+        name: "test-tailnet",
+        magicDNSSuffix: "example.ts.net"
+    )
+
+    private static func portal(
+        lifecycle: PortalLifecycle = .active,
+        removalAssignedName: String? = nil
+    ) -> PortalConfiguration {
+        PortalConfiguration(
+            id: portalID,
+            name: "portal-one",
+            localAppPort: 8080,
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+            desiredState: .enabled,
+            lifecycle: lifecycle,
+            removalAssignedName: removalAssignedName
+        )
+    }
+}
+
+private struct UITestHelperLaunchBlocked: Error {}
+private struct UITestServiceError: Error {}
+
+final class UITestRestartGate {
+    static let shared = UITestRestartGate()
+
+    private var completion: (() -> Void)?
+
+    private init() {}
+
+    func hold(_ completion: @escaping () -> Void) {
+        self.completion = completion
+    }
+
+    func release() {
+        let completion = completion
+        self.completion = nil
+        completion?()
+    }
+}
+
+final class UITestHelperLauncher: HelperLaunching {
+    private let scenario: UITestScenario
+    private var launchCount = 0
+
+    init(scenario: UITestScenario) {
+        self.scenario = scenario
+    }
+
+    func launch(
+        at executableURL: URL,
+        arguments: [String],
+        loggingPreference: OperationalLoggingPreference,
+        onLine: @escaping (Data) -> Void,
+        onEOF: @escaping () -> Void,
+        onExit: @escaping (Int32) -> Void
+    ) throws -> HelperProcess {
+        if scenario == .terminalFailure || (scenario == .stale && launchCount > 0) {
+            throw UITestHelperLaunchBlocked()
+        }
+        launchCount += 1
+        return UITestHelperProcess(
+            scenario: scenario,
+            onLine: onLine,
+            onEOF: onEOF,
+            onExit: onExit
+        )
+    }
+}
+
+private final class UITestHelperProcess: HelperProcess {
+    private struct RequestEnvelope: Decodable {
+        let requestId: String
+        let command: HelperCommand
+    }
+
+    private let scenario: UITestScenario
+    private let onLine: (Data) -> Void
+    private let onEOF: () -> Void
+    private let onExit: (Int32) -> Void
+    private var shutdownRequested = false
+    private var staleFailureScheduled = false
+    private(set) var isRunning = true
+
+    init(
+        scenario: UITestScenario,
+        onLine: @escaping (Data) -> Void,
+        onEOF: @escaping () -> Void,
+        onExit: @escaping (Int32) -> Void
+    ) {
+        self.scenario = scenario
+        self.onLine = onLine
+        self.onEOF = onEOF
+        self.onExit = onExit
+    }
+
+    func send(_ data: Data) throws {
+        let envelope = try JSONDecoder().decode(RequestEnvelope.self, from: data)
+        switch envelope.command {
+        case .handshake:
+            respond(HandshakeResult(protocolVersion: helperProtocolVersion), requestID: envelope.requestId)
+        case .shutdown:
+            shutdownRequested = true
+        case .reconcilePortals:
+            let request = try JSONDecoder().decode(HelperRequest<ReconcilePortalsPayload>.self, from: data)
+            respond(
+                ReconcilePortalsResult(entries: request.payload.portals.map {
+                    ReconcilePortalEntry(portalId: $0.portalId, outcome: .converged)
+                }),
+                requestID: envelope.requestId
+            )
+            emitStatuses(for: request.payload.portals)
+        case .authenticatePortal:
+            respond(AuthenticatePortalResult(accepted: true), requestID: envelope.requestId)
+        case .cleanupRejectedPortal:
+            respond(CleanupRejectedPortalResult(accepted: true), requestID: envelope.requestId)
+        case .removePortal:
+            if scenario == .removing { return }
+            if scenario == .removingFailure {
+                respondError(code: "remove_failed", requestID: envelope.requestId)
+            } else {
+                respond(RemovePortalResult(accepted: true), requestID: envelope.requestId)
+            }
+        case .discoverLocalApps:
+            respond(DiscoverLocalAppsResult(candidates: []), requestID: envelope.requestId)
+        }
+    }
+
+    func closeInput() {
+        guard shutdownRequested else { return }
+        if scenario == .restarting {
+            UITestRestartGate.shared.hold { [weak self] in
+                self?.finish(exitCode: 0)
+            }
+        } else {
+            finish(exitCode: 0)
+        }
+    }
+
+    func terminate() {
+        finish(exitCode: -15)
+    }
+
+    private func respond<Result: Codable>(_ result: Result, requestID: String) {
+        let response = HelperResponse(
+            version: helperProtocolVersion,
+            requestId: requestID,
+            result: result,
+            error: nil
+        )
+        deliver(response)
+    }
+
+    private func respondError(code: String, requestID: String) {
+        let response = HelperResponse<RemovePortalResult>(
+            version: helperProtocolVersion,
+            requestId: requestID,
+            result: nil,
+            error: HelperProtocolError(code: code, message: "UI test failure")
+        )
+        deliver(response)
+    }
+
+    private func deliver<Message: Encodable>(_ message: Message, delay: TimeInterval = 0) {
+        guard let data = try? JSONEncoder().encode(message) else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+            guard self?.isRunning == true else { return }
+            self?.onLine(data)
+        }
+    }
+
+    private func emitStatuses(for portals: [ReconcilePortalPayload]) {
+        guard [.online, .authenticating, .stale, .restarting, .loginOffer].contains(scenario) else { return }
+        for portal in portals {
+            let state: PortalTailscaleState = scenario == .authenticating ? .authenticating : .online
+            deliver(HelperEvent(
+                version: helperProtocolVersion,
+                event: .portalStatus,
+                portalId: portal.portalId,
+                payload: PortalStatusPayload(
+                    state: state,
+                    stableNodeId: "node-1",
+                    assignedName: "portal-one-1",
+                    portalURL: URL(string: "https://portal-one-1.example.ts.net"),
+                    addresses: ["100.64.0.10"],
+                    tailnetName: "test-tailnet",
+                    magicDNSSuffix: "example.ts.net"
+                )
+            ), delay: 0.01)
+        }
+        guard scenario == .stale, !staleFailureScheduled else { return }
+        staleFailureScheduled = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.02) { [weak self] in
+            guard self?.isRunning == true else { return }
+            self?.onEOF()
+        }
+    }
+
+    private func finish(exitCode: Int32) {
+        guard isRunning else { return }
+        isRunning = false
+        onExit(exitCode)
+    }
+}
+
+final class UITestLaunchAtLoginService: LaunchAtLoginServicing {
+    private(set) var status: LaunchAtLoginStatus
+    private let registrationFails: Bool
+
+    init(status: LaunchAtLoginStatus, registrationFails: Bool) {
+        self.status = status
+        self.registrationFails = registrationFails
+    }
+
+    func register() throws {
+        if registrationFails { throw UITestServiceError() }
+        status = .enabled
+    }
+
+    func unregister() throws { status = .notRegistered }
+    func openSystemSettingsLoginItems() {}
+}
+
+final class UITestLocalAppProbe: LocalAppProbing {
+    private let result: Bool
+
+    init(result: Bool) {
+        self.result = result
+    }
+
+    func probe(port: UInt16, timeout: TimeInterval, completion: @escaping (Bool) -> Void) {
+        DispatchQueue.main.async { [result] in completion(result) }
+    }
+}
+
+@MainActor
+final class UITestScaledScheduler: PorticoScheduling {
+    private let scale: Double
+
+    init(scale: Double) {
+        self.scale = scale
+    }
+
+    @discardableResult
+    func schedule(after delay: TimeInterval, _ action: @escaping () -> Void) -> ScheduledTask {
+        let workItem = DispatchWorkItem(block: action)
+        DispatchQueue.main.asyncAfter(deadline: .now() + max(0.01, delay * scale), execute: workItem)
+        return UITestScheduledTask(workItem: workItem)
+    }
+}
+
+private final class UITestScheduledTask: ScheduledTask {
+    private let workItem: DispatchWorkItem
+
+    init(workItem: DispatchWorkItem) {
+        self.workItem = workItem
+    }
+
+    func cancel() { workItem.cancel() }
+}
+#endif

--- a/PorticoTests/HelperShutdownTests.swift
+++ b/PorticoTests/HelperShutdownTests.swift
@@ -14,7 +14,7 @@ final class HelperShutdownTests: XCTestCase {
             handshakeTimeout: 1,
             shutdownGraceInterval: 1
         )
-        supervisor.start()
+        supervisor.start(loggingPreference: .enabled)
         launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
         var completionCount = 0
 
@@ -46,7 +46,7 @@ final class HelperShutdownTests: XCTestCase {
             handshakeTimeout: 1,
             shutdownGraceInterval: 0.01
         )
-        supervisor.start()
+        supervisor.start(loggingPreference: .enabled)
         launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
         var completionCount = 0
 
@@ -64,7 +64,7 @@ final class HelperShutdownTests: XCTestCase {
             launcher: launcher,
             requestIDProvider: { "request-1" }
         )
-        supervisor.start()
+        supervisor.start(loggingPreference: .enabled)
         launcher.exit(status: 1)
         var completionCount = 0
 
@@ -83,7 +83,7 @@ final class HelperShutdownTests: XCTestCase {
             requestIDProvider: { requestIDs.removeFirst() },
             shutdownGraceInterval: 1
         )
-        supervisor.start()
+        supervisor.start(loggingPreference: .enabled)
         launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
         var completionCount = 0
 

--- a/PorticoTests/HelperSupervisorTests.swift
+++ b/PorticoTests/HelperSupervisorTests.swift
@@ -4,6 +4,103 @@ import XCTest
 
 @MainActor
 final class HelperSupervisorTests: XCTestCase {
+    func testUndecidedLoggingWaitsWithoutLaunchingChild() {
+        let launcher = FakeHelperLauncher()
+        let supervisor = HelperSupervisor(
+            helperURL: URL(fileURLWithPath: "/unused/portico-helper"),
+            launcher: launcher
+        )
+
+        supervisor.start(loggingPreference: .undecided)
+
+        XCTAssertEqual(supervisor.availability, .awaitingLoggingChoice)
+        XCTAssertTrue(launcher.processes.isEmpty)
+    }
+
+    func testControlledRestartWaitsForOldOwnershipBeforeLaunchingWithNewPreference() throws {
+        let launcher = FakeHelperLauncher()
+        let scheduler = FakePorticoScheduler()
+        var requestIDs = ["handshake-1", "shutdown-1", "handshake-2"]
+        let supervisor = HelperSupervisor(
+            helperURL: URL(fileURLWithPath: "/unused/portico-helper"),
+            launcher: launcher,
+            requestIDProvider: { requestIDs.removeFirst() },
+            scheduler: scheduler,
+            handshakeTimeout: 60
+        )
+        supervisor.start(loggingPreference: .enabled)
+        launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
+
+        supervisor.restart(loggingPreference: .disabled)
+
+        XCTAssertEqual(supervisor.availability, .restarting)
+        XCTAssertEqual(launcher.processes.count, 1)
+        XCTAssertTrue(launcher.process.inputClosed)
+        let shutdown = try JSONDecoder().decode(
+            HelperRequest<EmptyPayload>.self,
+            from: XCTUnwrap(launcher.process.sent.last)
+        )
+        XCTAssertEqual(shutdown.command, .shutdown)
+
+        launcher.exit(status: 0)
+
+        XCTAssertEqual(launcher.processes.count, 2)
+        XCTAssertEqual(launcher.loggingPreferences, [.enabled, .disabled])
+        XCTAssertEqual(launcher.processes.filter(\.isRunning).count, 1)
+        launcher.receive(line: #"{"version":3,"requestId":"handshake-2","result":{"protocolVersion":3}}"#)
+        XCTAssertEqual(supervisor.availability, .connected)
+    }
+
+    func testControlledRestartForcesOldChildButStillWaitsForExitOwnership() {
+        let launcher = FakeHelperLauncher()
+        let scheduler = FakePorticoScheduler()
+        var requestIDs = ["handshake-1", "shutdown-1", "handshake-2"]
+        let supervisor = HelperSupervisor(
+            helperURL: URL(fileURLWithPath: "/unused/portico-helper"),
+            launcher: launcher,
+            requestIDProvider: { requestIDs.removeFirst() },
+            scheduler: scheduler,
+            handshakeTimeout: 60,
+            shutdownGraceInterval: 1
+        )
+        supervisor.start(loggingPreference: .enabled)
+        launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
+
+        supervisor.restart(loggingPreference: .disabled)
+        scheduler.run(delay: 1)
+
+        XCTAssertTrue(launcher.process.terminated)
+        XCTAssertEqual(launcher.processes.count, 1)
+
+        launcher.exit(status: 0)
+        XCTAssertEqual(launcher.processes.count, 2)
+    }
+
+    func testControlledRestartRejectsOldEventsAndStartsFreshRecoveryBudget() {
+        let launcher = FakeHelperLauncher()
+        let scheduler = FakePorticoScheduler()
+        var requestIDs = ["handshake-1", "shutdown-1", "handshake-2"]
+        let supervisor = HelperSupervisor(
+            helperURL: URL(fileURLWithPath: "/unused/portico-helper"),
+            launcher: launcher,
+            requestIDProvider: { requestIDs.removeFirst() },
+            scheduler: scheduler,
+            handshakeTimeout: 60
+        )
+        var events: [PortalHelperEvent] = []
+        supervisor.onEvent = { events.append($0) }
+        supervisor.start(loggingPreference: .enabled)
+        launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
+
+        supervisor.restart(loggingPreference: .disabled)
+        launcher.receive(line: #"{"version":3,"event":"portalStatus","portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","payload":{"state":"online","addresses":[]}}"#)
+        XCTAssertTrue(events.isEmpty)
+        launcher.exit(status: 0)
+        launcher.exit(status: 1)
+
+        XCTAssertEqual(supervisor.availability, .retrying(attempt: 1, delay: 1))
+    }
+
     func testRetriesUnexpectedExitWithOneChildAndFixedSharedBudget() {
         let launcher = FakeHelperLauncher()
         let scheduler = FakePorticoScheduler()
@@ -15,7 +112,7 @@ final class HelperSupervisorTests: XCTestCase {
             handshakeTimeout: 60
         )
 
-        supervisor.start()
+        supervisor.start(loggingPreference: .enabled)
         for expectedDelay in [1.0, 2.0, 4.0, 8.0, 16.0] {
             launcher.exit(status: 1)
 
@@ -57,7 +154,7 @@ final class HelperSupervisorTests: XCTestCase {
             handshakeTimeout: 60
         )
 
-        supervisor.start()
+        supervisor.start(loggingPreference: .enabled)
         launcher.exit(status: 1)
         scheduler.runNext()
         launcher.receive(line: #"{"version":3,"requestId":"handshake-2","result":{"protocolVersion":3}}"#)
@@ -87,7 +184,7 @@ final class HelperSupervisorTests: XCTestCase {
             handshakeTimeout: 1
         )
 
-        supervisor.start()
+        supervisor.start(loggingPreference: .enabled)
 
         XCTAssertEqual(supervisor.availability, .connecting)
         let requestData = try XCTUnwrap(launcher.process.sent.first)
@@ -112,7 +209,7 @@ final class HelperSupervisorTests: XCTestCase {
             handshakeTimeout: 0.01
         )
 
-        supervisor.start()
+        supervisor.start(loggingPreference: .enabled)
         try await Task.sleep(nanoseconds: 50_000_000)
         launcher.exit(status: 1)
 
@@ -138,7 +235,7 @@ final class HelperSupervisorTests: XCTestCase {
                 requestIDProvider: { "request-1" },
                 handshakeTimeout: 1
             )
-            supervisor.start()
+            supervisor.start(loggingPreference: .enabled)
 
             trigger(launcher)
             if !alreadyExited {
@@ -164,7 +261,7 @@ final class HelperSupervisorTests: XCTestCase {
         )
         var events: [PortalHelperEvent] = []
         supervisor.onEvent = { events.append($0) }
-        supervisor.start()
+        supervisor.start(loggingPreference: .enabled)
         XCTAssertEqual(launcher.arguments, ["--state-root", "/trusted/tsnet"])
         launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
         let laterPortal = PortalConfiguration(
@@ -227,7 +324,7 @@ final class HelperSupervisorTests: XCTestCase {
             requestIDProvider: { requestIDs.removeFirst() },
             handshakeTimeout: 1
         )
-        supervisor.start()
+        supervisor.start(loggingPreference: .enabled)
         launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
         var result: Result<ReconcilePortalsResult, Error>?
 
@@ -248,7 +345,7 @@ final class HelperSupervisorTests: XCTestCase {
             requestIDProvider: { requestIDs.removeFirst() },
             handshakeTimeout: 1
         )
-        supervisor.start()
+        supervisor.start(loggingPreference: .enabled)
         launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
         var result: Result<[LocalAppCandidatePayload], Error>?
 
@@ -274,7 +371,7 @@ final class HelperSupervisorTests: XCTestCase {
             requestIDProvider: { requestIDs.removeFirst() },
             handshakeTimeout: 1
         )
-        supervisor.start()
+        supervisor.start(loggingPreference: .enabled)
         launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
         let portalID = UUID(uuidString: "9f55ca93-d7b3-4eab-a871-310ea576005a")!
         var result: Result<Void, Error>?
@@ -299,7 +396,7 @@ final class HelperSupervisorTests: XCTestCase {
             requestIDProvider: { requestIDs.removeFirst() },
             handshakeTimeout: 1
         )
-        supervisor.start()
+        supervisor.start(loggingPreference: .enabled)
         launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
         let portalID = UUID(uuidString: "9f55ca93-d7b3-4eab-a871-310ea576005a")!
         var result: Result<Void, Error>?
@@ -334,7 +431,7 @@ final class HelperSupervisorTests: XCTestCase {
             requestIDProvider: { requestIDs.removeFirst() },
             handshakeTimeout: 1
         )
-        supervisor.start()
+        supervisor.start(loggingPreference: .enabled)
         launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
         var result: Result<[LocalAppCandidatePayload], Error>?
 
@@ -355,10 +452,12 @@ final class FakeHelperLauncher: HelperLaunching {
     private var onEOF: (() -> Void)?
     private var onExit: ((Int32) -> Void)?
     private(set) var arguments: [String] = []
+    private(set) var loggingPreferences: [OperationalLoggingPreference] = []
 
     func launch(
         at executableURL: URL,
         arguments: [String],
+        loggingPreference: OperationalLoggingPreference,
         onLine: @escaping (Data) -> Void,
         onEOF: @escaping () -> Void,
         onExit: @escaping (Int32) -> Void
@@ -366,6 +465,7 @@ final class FakeHelperLauncher: HelperLaunching {
         let process = FakeHelperProcess()
         processes.append(process)
         self.arguments = arguments
+        loggingPreferences.append(loggingPreference)
         self.onLine = onLine
         self.onEOF = onEOF
         self.onExit = onExit

--- a/PorticoTests/LaunchAtLoginTests.swift
+++ b/PorticoTests/LaunchAtLoginTests.swift
@@ -1,0 +1,178 @@
+import XCTest
+@testable import Portico
+
+@MainActor
+final class LaunchAtLoginTests: XCTestCase {
+    func testFirstFreshOnlineOfferPersistsPresentedBeforePresentation() {
+        let service = FakeLaunchAtLoginService(status: .notRegistered)
+        let store = FakeLaunchAtLoginOfferStore()
+        let controller = makeController(service: service, store: store)
+
+        controller.considerOfferAfterFreshOnline()
+
+        XCTAssertEqual(store.state, .presented)
+        XCTAssertEqual(store.saved, [.presented])
+        XCTAssertTrue(controller.isOffering)
+        controller.considerOfferAfterFreshOnline()
+        XCTAssertEqual(store.saved, [.presented])
+    }
+
+    func testAlreadyEnabledAcceptsWithoutPrompt() {
+        let service = FakeLaunchAtLoginService(status: .enabled)
+        let store = FakeLaunchAtLoginOfferStore()
+        let controller = makeController(service: service, store: store)
+
+        controller.considerOfferAfterFreshOnline()
+
+        XCTAssertEqual(store.state, .accepted)
+        XCTAssertFalse(controller.isOffering)
+        XCTAssertEqual(service.registerCount, 0)
+    }
+
+    func testPersistenceFailurePreventsPresentationAndRegistration() {
+        let service = FakeLaunchAtLoginService(status: .notRegistered)
+        let store = FakeLaunchAtLoginOfferStore(shouldSave: false)
+        let controller = makeController(service: service, store: store)
+
+        controller.considerOfferAfterFreshOnline()
+        controller.acceptOffer()
+
+        XCTAssertFalse(controller.isOffering)
+        XCTAssertEqual(service.registerCount, 0)
+        XCTAssertEqual(controller.errorMessage, "The launch at login choice could not be saved.")
+    }
+
+    func testPresentedStateDoesNotRepeatAfterRelaunchAndDeclineIsDurable() {
+        let service = FakeLaunchAtLoginService(status: .notRegistered)
+        let presentedStore = FakeLaunchAtLoginOfferStore(state: .presented)
+        let relaunched = makeController(service: service, store: presentedStore)
+
+        relaunched.considerOfferAfterFreshOnline()
+        XCTAssertFalse(relaunched.isOffering)
+
+        let offeredStore = FakeLaunchAtLoginOfferStore()
+        let offered = makeController(service: service, store: offeredStore)
+        offered.considerOfferAfterFreshOnline()
+        offered.declineOffer()
+        XCTAssertEqual(offeredStore.state, .declined)
+        XCTAssertFalse(offered.isOffering)
+    }
+
+    func testAcceptancePersistsBeforeRegistrationAndFailureHasExplicitRetry() {
+        struct ExpectedFailure: Error {}
+        let service = FakeLaunchAtLoginService(status: .notRegistered)
+        service.registerError = ExpectedFailure()
+        let store = FakeLaunchAtLoginOfferStore()
+        var events: [String] = []
+        store.onSave = { events.append("saved-\($0.rawValue)") }
+        service.onRegister = { events.append("register") }
+        let controller = makeController(service: service, store: store)
+        controller.considerOfferAfterFreshOnline()
+
+        controller.acceptOffer()
+
+        XCTAssertEqual(events.suffix(2), ["saved-accepted", "register"])
+        XCTAssertEqual(store.state, .accepted)
+        XCTAssertEqual(controller.errorMessage, "Launch at login could not be enabled.")
+        service.registerError = nil
+        controller.retryRegistration()
+        XCTAssertEqual(service.registerCount, 2)
+    }
+
+    func testApprovalAndUnavailableStatesExposeOnlyTheirFixedActions() {
+        let service = FakeLaunchAtLoginService(status: .requiresApproval)
+        let store = FakeLaunchAtLoginOfferStore(state: .accepted)
+        let controller = makeController(service: service, store: store)
+
+        controller.refreshStatus()
+        controller.openLoginItemsSettings()
+
+        XCTAssertEqual(controller.status, .requiresApproval)
+        XCTAssertEqual(service.openSettingsCount, 1)
+
+        service.status = .notFound
+        controller.refreshStatus()
+        controller.retryRegistration()
+        XCTAssertEqual(controller.status, .notFound)
+        XCTAssertEqual(service.registerCount, 0)
+    }
+
+    func testDisableFailureKeepsLiveStatusAndExternalRefreshDoesNotMutateOfferHistory() {
+        struct ExpectedFailure: Error {}
+        let service = FakeLaunchAtLoginService(status: .enabled)
+        service.unregisterError = ExpectedFailure()
+        let store = FakeLaunchAtLoginOfferStore(state: .accepted)
+        let controller = makeController(service: service, store: store)
+
+        controller.setEnabled(false)
+
+        XCTAssertEqual(controller.status, .enabled)
+        XCTAssertEqual(controller.errorMessage, "Launch at login could not be disabled.")
+        service.status = .notRegistered
+        controller.refreshStatus()
+        XCTAssertEqual(controller.status, .notRegistered)
+        XCTAssertTrue(store.saved.isEmpty)
+    }
+
+    private func makeController(
+        service: FakeLaunchAtLoginService,
+        store: FakeLaunchAtLoginOfferStore
+    ) -> LaunchAtLoginController {
+        LaunchAtLoginController(
+            service: service,
+            offerState: { store.state },
+            saveOfferState: { store.save($0) }
+        )
+    }
+}
+
+private final class FakeLaunchAtLoginOfferStore {
+    var state: LaunchAtLoginOfferState
+    var shouldSave: Bool
+    var saved: [LaunchAtLoginOfferState] = []
+    var onSave: ((LaunchAtLoginOfferState) -> Void)?
+
+    init(state: LaunchAtLoginOfferState = .notOffered, shouldSave: Bool = true) {
+        self.state = state
+        self.shouldSave = shouldSave
+    }
+
+    func save(_ state: LaunchAtLoginOfferState) -> Bool {
+        guard shouldSave else { return false }
+        self.state = state
+        saved.append(state)
+        onSave?(state)
+        return true
+    }
+}
+
+private final class FakeLaunchAtLoginService: LaunchAtLoginServicing {
+    var status: LaunchAtLoginStatus
+    var registerError: Error?
+    var unregisterError: Error?
+    var onRegister: (() -> Void)?
+    private(set) var registerCount = 0
+    private(set) var unregisterCount = 0
+    private(set) var openSettingsCount = 0
+
+    init(status: LaunchAtLoginStatus) {
+        self.status = status
+    }
+
+    func register() throws {
+        registerCount += 1
+        onRegister?()
+        if let registerError { throw registerError }
+        status = .enabled
+    }
+
+    func unregister() throws {
+        unregisterCount += 1
+        if let unregisterError { throw unregisterError }
+        status = .notRegistered
+    }
+
+    func openSystemSettingsLoginItems() {
+        openSettingsCount += 1
+    }
+}

--- a/PorticoTests/PortalActionAvailabilityTests.swift
+++ b/PorticoTests/PortalActionAvailabilityTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+@testable import Portico
+
+final class PortalActionAvailabilityTests: XCTestCase {
+    func testAuthoritativeActionMatrix() {
+        let activeEnabled = PortalActionContext(
+            loggingPreference: .enabled,
+            inputsValid: true,
+            helperAvailability: .connected,
+            lifecycle: .active,
+            desiredState: .enabled,
+            tailscaleState: .online,
+            hasPortalURL: true,
+            hasTailnetBinding: true,
+            portalCount: 1,
+            isEditedPortValid: true
+        )
+        let available = PortalActionAvailability(context: activeEnabled)
+        XCTAssertTrue(available.addPortal)
+        XCTAssertTrue(available.refreshLocalApps)
+        XCTAssertTrue(available.stop)
+        XCTAssertTrue(available.editPort)
+        XCTAssertTrue(available.copyPortalURL)
+        XCTAssertTrue(available.openPortalURL)
+        XCTAssertTrue(available.diagnostics)
+        XCTAssertTrue(available.remove)
+        XCTAssertTrue(available.settings)
+        XCTAssertFalse(available.start)
+        XCTAssertFalse(available.authenticate)
+        XCTAssertFalse(available.retryRemoval)
+        XCTAssertFalse(available.resetTailnet)
+
+        var stoppedOffline = activeEnabled
+        stoppedOffline.helperAvailability = .failed
+        stoppedOffline.desiredState = .stopped
+        stoppedOffline.isTailscaleFactsStale = true
+        let offline = PortalActionAvailability(context: stoppedOffline)
+        XCTAssertTrue(offline.addPortal)
+        XCTAssertTrue(offline.start)
+        XCTAssertTrue(offline.editPort)
+        XCTAssertTrue(offline.copyPortalURL)
+        XCTAssertTrue(offline.remove)
+        XCTAssertFalse(offline.refreshLocalApps)
+        XCTAssertFalse(offline.openPortalURL)
+        XCTAssertFalse(offline.authenticate)
+
+        var authenticating = activeEnabled
+        authenticating.tailscaleState = .authenticating
+        authenticating.hasPortalURL = false
+        XCTAssertTrue(PortalActionAvailability(context: authenticating).authenticate)
+        authenticating.isAuthenticationPending = true
+        XCTAssertFalse(PortalActionAvailability(context: authenticating).authenticate)
+        authenticating.isAuthenticationPending = false
+        authenticating.isTailscaleFactsStale = true
+        XCTAssertFalse(PortalActionAvailability(context: authenticating).authenticate)
+
+        var removing = activeEnabled
+        removing.lifecycle = .pendingRemoval
+        removing.removalState = .failed
+        let removal = PortalActionAvailability(context: removing)
+        XCTAssertTrue(removal.retryRemoval)
+        XCTAssertTrue(removal.diagnostics)
+        XCTAssertFalse(removal.remove)
+        XCTAssertFalse(removal.start)
+
+        let reset = PortalActionAvailability(context: PortalActionContext(
+            loggingPreference: .undecided,
+            inputsValid: true,
+            helperAvailability: .awaitingLoggingChoice,
+            hasTailnetBinding: true,
+            portalCount: 0
+        ))
+        XCTAssertFalse(reset.addPortal)
+        XCTAssertTrue(reset.resetTailnet)
+        XCTAssertTrue(reset.settings)
+        XCTAssertTrue(reset.diagnostics)
+    }
+}

--- a/PorticoTests/PortalConfigurationTests.swift
+++ b/PorticoTests/PortalConfigurationTests.swift
@@ -2,6 +2,14 @@ import XCTest
 @testable import Portico
 
 final class PortalConfigurationTests: XCTestCase {
+    func testVersionThreeInstallationDefaultsRequireLoggingChoiceAndHaveNotOfferedLogin() {
+        let installation = InstallationRecord()
+
+        XCTAssertEqual(installation.version, 3)
+        XCTAssertEqual(installation.operationalLogging, .undecided)
+        XCTAssertEqual(installation.launchAtLoginOffer, .notOffered)
+    }
+
     func testAcceptsDNSLabelAndPortBoundaries() throws {
         for name in ["a", "portal-1", String(repeating: "a", count: 63)] {
             XCTAssertNoThrow(try PortalInputValidator.validate(name: name, port: "1"))

--- a/PorticoTests/PortalControllerTests.swift
+++ b/PorticoTests/PortalControllerTests.swift
@@ -6,9 +6,109 @@ import XCTest
 final class PortalControllerTests: XCTestCase {
     private let portalID = UUID(uuidString: "9f55ca93-d7b3-4eab-a871-310ea576005a")!
 
+    func testUndecidedLoggingPreventsFirstPortalCreation() {
+        let controller = PortalController(
+            store: PortalStore(rootURL: temporaryRoot()),
+            helper: FakePortalHelperClient(),
+            openURL: { _ in }
+        )
+        controller.portalName = "hermes"
+        controller.localAppPort = "8787"
+
+        controller.addPortal()
+
+        XCTAssertTrue(controller.portals.isEmpty)
+        XCTAssertEqual(controller.message, "Choose an operational-support logging setting before adding a Portal.")
+    }
+
+    func testLoggingPreferenceCommitsBeforeControlledRestartAndSameValueIsNoOp() throws {
+        let store = PortalStore(rootURL: temporaryRoot())
+        try store.save(InstallationRecord(operationalLogging: .enabled))
+        let client = FakePortalHelperClient()
+        client.onRestart = { preference in
+            XCTAssertEqual(try? store.loadInstallation().operationalLogging, preference)
+        }
+        let controller = PortalController(store: store, helper: client, openURL: { _ in })
+
+        controller.setOperationalLogging(.enabled)
+        controller.setOperationalLogging(.disabled)
+
+        XCTAssertEqual(controller.operationalLogging, .disabled)
+        XCTAssertEqual(client.restartedWith, [.disabled])
+    }
+
+    func testLoggingPersistenceFailureLeavesPreferenceAndProcessUntouched() throws {
+        struct ExpectedFailure: Error {}
+        let root = temporaryRoot()
+        let initialStore = PortalStore(rootURL: root)
+        try initialStore.save(InstallationRecord(operationalLogging: .enabled))
+        let failingStore = PortalStore(rootURL: root, writeData: { _, _ in throw ExpectedFailure() })
+        let client = FakePortalHelperClient()
+        let controller = PortalController(store: failingStore, helper: client, openURL: { _ in })
+
+        controller.setOperationalLogging(.disabled)
+
+        XCTAssertEqual(controller.operationalLogging, .enabled)
+        XCTAssertTrue(client.restartedWith.isEmpty)
+        XCTAssertEqual(controller.message, "The operational-support logging setting could not be saved.")
+        XCTAssertEqual(
+            controller.operationalLoggingError,
+            "The operational-support logging setting could not be saved."
+        )
+    }
+
+    func testLoggingRestartRejectsOldAuthenticationURL() throws {
+        let store = PortalStore(rootURL: temporaryRoot())
+        let portal = PortalConfiguration(id: portalID, name: "hermes", localAppPort: 8787, createdAt: Date())
+        try store.save(InstallationRecord(portals: [portal], operationalLogging: .enabled))
+        let client = FakePortalHelperClient()
+        var opened: [URL] = []
+        let controller = PortalController(store: store, helper: client, openURL: { opened.append($0) })
+        controller.authenticate(id: portalID)
+
+        controller.setOperationalLogging(.disabled)
+        client.send(.authenticationURL(portalID, URL(string: "https://login.example/secret")!))
+
+        XCTAssertTrue(opened.isEmpty)
+    }
+
+    func testCurrentPortalURLCanCopyAndOpenButStaleURLCanOnlyCopy() throws {
+        let store = PortalStore(rootURL: temporaryRoot())
+        let portal = PortalConfiguration(id: portalID, name: "hermes", localAppPort: 8787, createdAt: Date())
+        try store.save(InstallationRecord(portals: [portal], operationalLogging: .enabled))
+        let client = FakePortalHelperClient()
+        var copied: [String] = []
+        var opened: [URL] = []
+        let controller = PortalController(
+            store: store,
+            helper: client,
+            copyText: { copied.append($0) },
+            openURL: { opened.append($0) }
+        )
+        let url = URL(string: "https://hermes.example.ts.net/")!
+        client.send(.status(portalID, PortalStatusPayload(
+            state: .online,
+            stableNodeId: nil,
+            assignedName: "hermes",
+            portalURL: url,
+            addresses: [],
+            magicDNSSuffix: "example.ts.net"
+        )))
+
+        controller.copyPortalURL(id: portalID)
+        controller.openPortalURL(id: portalID)
+        client.disconnect(as: .retrying(attempt: 1, delay: 1))
+        controller.copyPortalURL(id: portalID)
+        controller.openPortalURL(id: portalID)
+
+        XCTAssertEqual(copied, [url.absoluteString, url.absoluteString])
+        XCTAssertEqual(opened, [url])
+    }
+
     func testAddValidatesBeforeCreatingOnePortalUUID() throws {
         let client = FakePortalHelperClient()
         let store = PortalStore(rootURL: temporaryRoot())
+        try store.save(InstallationRecord(operationalLogging: .enabled))
         var UUIDCreationCount = 0
         let controller = PortalController(
             store: store,
@@ -20,14 +120,19 @@ final class PortalControllerTests: XCTestCase {
 
         controller.portalName = "Invalid Name"
         controller.localAppPort = "8787"
-        controller.addPortal()
+        XCTAssertEqual(controller.addPortal(), .invalidName)
         XCTAssertNil(controller.portal)
         XCTAssertEqual(UUIDCreationCount, 0)
         XCTAssertTrue(client.started.isEmpty)
 
         controller.portalName = "hermes"
+        controller.localAppPort = "0"
+        XCTAssertEqual(controller.addPortal(), .invalidPort)
+        XCTAssertNil(controller.portal)
+        XCTAssertEqual(UUIDCreationCount, 0)
+
         controller.localAppPort = "8787"
-        controller.addPortal()
+        XCTAssertNil(controller.addPortal())
         let portal = try XCTUnwrap(controller.portal)
         XCTAssertEqual(portal.id, portalID)
         XCTAssertEqual(UUIDCreationCount, 1)
@@ -108,6 +213,7 @@ final class PortalControllerTests: XCTestCase {
     func testAddPersistsFinalEditableFieldsAndIgnoresStaleDiscovery() throws {
         let client = FakePortalHelperClient()
         let store = PortalStore(rootURL: temporaryRoot())
+        try store.save(InstallationRecord(operationalLogging: .enabled))
         let controller = PortalController(
             store: store,
             helper: client,
@@ -142,7 +248,7 @@ final class PortalControllerTests: XCTestCase {
     func testStartsSavedPortalAfterHandshakeWithSameDefinition() throws {
         let store = PortalStore(rootURL: temporaryRoot())
         let saved = PortalConfiguration(id: portalID, name: "hermes", localAppPort: 8787, createdAt: Date(timeIntervalSince1970: 1_786_000_000))
-        try store.save(saved)
+        try store.save(InstallationRecord(portals: [saved], operationalLogging: .enabled))
         let client = FakePortalHelperClient(availability: .connecting)
         let controller = PortalController(store: store, helper: client, openURL: { _ in })
 
@@ -576,6 +682,13 @@ final class PortalControllerTests: XCTestCase {
         var opened: [URL] = []
         let controller = PortalController(store: store, helper: client, openURL: { opened.append($0) })
         let transient = URL(string: "https://login.tailscale.com/a/transient")!
+        client.send(.status(portalID, PortalStatusPayload(
+            state: .authenticating,
+            stableNodeId: nil,
+            assignedName: nil,
+            portalURL: nil,
+            addresses: []
+        )))
 
         client.send(.authenticationURL(portalID, transient))
         XCTAssertTrue(opened.isEmpty)
@@ -596,7 +709,7 @@ final class PortalControllerTests: XCTestCase {
         let secondID = UUID(uuidString: "5ea74329-3144-4ba2-925f-138d14d61fcc")!
         let first = PortalConfiguration(id: firstID, name: "hermes", localAppPort: 8787, createdAt: Date())
         let store = PortalStore(rootURL: temporaryRoot())
-        try store.save(InstallationRecord(portals: [first]))
+        try store.save(InstallationRecord(portals: [first], operationalLogging: .enabled))
         let client = FakePortalHelperClient()
         let controller = PortalController(
             store: store,
@@ -877,7 +990,7 @@ final class PortalControllerTests: XCTestCase {
             handshakeTimeout: 60
         )
         let controller = PortalController(store: store, helper: supervisor, openURL: { _ in })
-        supervisor.start()
+        supervisor.start(loggingPreference: .enabled)
         launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
         controller.stopPortal(id: portalID)
 
@@ -1004,6 +1117,8 @@ final class FakePortalHelperClient: PortalHelperClient {
     var onCleanup: ((UUID) -> Void)?
     var onReconcile: (([PortalConfiguration]) -> Void)?
     private(set) var retryCount = 0
+    private(set) var restartedWith: [OperationalLoggingPreference] = []
+    var onRestart: ((OperationalLoggingPreference) -> Void)?
 
     init(availability: HelperAvailability = .connected) {
         self.availability = availability
@@ -1025,6 +1140,11 @@ final class FakePortalHelperClient: PortalHelperClient {
     }
 
     func retry() { retryCount += 1 }
+
+    func restart(loggingPreference: OperationalLoggingPreference) {
+        restartedWith.append(loggingPreference)
+        onRestart?(loggingPreference)
+    }
 
     func authenticatePortal(id: UUID, completion: @escaping (Result<Void, Error>) -> Void) {
         authenticated.append(id)

--- a/PorticoTests/PortalPresentationTests.swift
+++ b/PorticoTests/PortalPresentationTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import Portico
+
+final class PortalPresentationTests: XCTestCase {
+    func testFirstRunGuidance() {
+        XCTAssertEqual(
+            PortalPresentation.prerequisiteGuidance,
+            [
+                "Enable MagicDNS for your tailnet.",
+                "Enable HTTPS certificates for your tailnet.",
+                "Approve the Portal device when your tailnet requires device approval.",
+                "Portal names are published to Certificate Transparency logs when certificates are issued.",
+            ]
+        )
+        XCTAssertTrue(PortalPresentation.showsPrerequisiteGuidance(portalCount: 0))
+        XCTAssertFalse(PortalPresentation.showsPrerequisiteGuidance(portalCount: 1))
+    }
+
+    func testPortalIdentityStatesCollisionAndLastKnownURLRemainSeparate() {
+        let portal = PortalConfiguration(
+            id: UUID(uuidString: "9F55CA93-D7B3-4EAB-A871-310EA576005A")!,
+            name: "hermes",
+            localAppPort: 8787,
+            createdAt: Date(),
+            desiredState: .enabled
+        )
+        let status = PortalStatusPayload(
+            state: .online,
+            stableNodeId: nil,
+            assignedName: "hermes-1",
+            portalURL: URL(string: "https://hermes-1.example.ts.net/"),
+            addresses: [],
+            magicDNSSuffix: "example.ts.net"
+        )
+
+        let presentation = PortalPresentation(
+            portal: portal,
+            status: status,
+            reachability: .unavailable,
+            isStale: true
+        )
+
+        XCTAssertEqual(presentation.portalName, "hermes")
+        XCTAssertEqual(presentation.assignedName, "hermes-1")
+        XCTAssertEqual(presentation.desiredState, "Enabled")
+        XCTAssertEqual(presentation.tailscaleState, "Online — Last Known")
+        XCTAssertEqual(presentation.localAppReachability, "Unavailable")
+        XCTAssertEqual(presentation.portalURLLabel, "Portal URL — Last Known")
+        XCTAssertEqual(
+            presentation.collisionExplanation,
+            "Tailscale assigned “hermes-1” because “hermes” was unavailable. Portal Name remains “hermes”."
+        )
+    }
+
+    func testAnnouncementsAreFixedAndContainNoRuntimeFacts() {
+        XCTAssertEqual(PorticoAnnouncement.text(for: .helperConnected), "Helper connected.")
+        XCTAssertEqual(PorticoAnnouncement.text(for: .helperTerminalFailure), "Helper unavailable.")
+        XCTAssertEqual(PorticoAnnouncement.text(for: .portalOnline), "Portal online.")
+        XCTAssertEqual(PorticoAnnouncement.text(for: .removalSucceeded), "Portal removal completed.")
+        XCTAssertEqual(PorticoAnnouncement.text(for: .removalFailed), "Portal removal failed.")
+        XCTAssertEqual(PorticoAnnouncement.text(for: .preferenceRestartCompleted), "Logging preference restart completed.")
+        XCTAssertEqual(PorticoAnnouncement.text(for: .preferenceRestartFailed), "Logging preference restart failed.")
+    }
+}

--- a/PorticoTests/PortalStoreTests.swift
+++ b/PorticoTests/PortalStoreTests.swift
@@ -3,11 +3,126 @@ import XCTest
 @testable import Portico
 
 final class PortalStoreTests: XCTestCase {
+    func testNewInstallationUsesVersionThreeDefaults() throws {
+        let store = PortalStore(rootURL: temporaryRoot())
+
+        XCTAssertEqual(
+            try store.loadInstallation(),
+            InstallationRecord(
+                operationalLogging: .undecided,
+                launchAtLoginOffer: .notOffered
+            )
+        )
+        XCTAssertEqual(store.installationURL.lastPathComponent, "installation-v3.json")
+    }
+
+    func testVersionOneMigrationEnablesLoggingAndStartsLoginOfferUnspent() throws {
+        let root = temporaryRoot()
+        let store = PortalStore(rootURL: root)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try historicalVersionOneData().write(to: store.legacyConfigurationURL)
+
+        let installation = try store.loadInstallation()
+
+        XCTAssertEqual(installation.operationalLogging, .enabled)
+        XCTAssertEqual(installation.launchAtLoginOffer, .notOffered)
+        XCTAssertEqual(installation.portals.count, 1)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.legacyConfigurationURL.path))
+    }
+
+    func testPristineVersionTwoMigrationRequiresLoggingChoice() throws {
+        let store = PortalStore(rootURL: temporaryRoot())
+        try FileManager.default.createDirectory(at: store.rootURL, withIntermediateDirectories: true)
+        try Data(#"{"version":2,"portals":[],"alerts":[]}"#.utf8).write(to: store.versionTwoInstallationURL)
+
+        let installation = try store.loadInstallation()
+
+        XCTAssertEqual(installation.operationalLogging, .undecided)
+        XCTAssertEqual(installation.launchAtLoginOffer, .notOffered)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.versionTwoInstallationURL.path))
+    }
+
+    func testNonPristineVersionTwoMigrationsPreserveExistingLoggingBehavior() throws {
+        let records = [
+            #"{"version":2,"portals":[{"id":"9F55CA93-D7B3-4EAB-A871-310EA576005A","name":"hermes","localAppPort":8787,"createdAt":807692800,"lifecycle":"active"}],"alerts":[]}"#,
+            #"{"version":2,"tailnetBinding":{"name":"opaque-tailnet-id","magicDNSSuffix":"one.ts.net"},"portals":[],"alerts":[]}"#,
+            #"{"version":2,"portals":[],"alerts":[{"id":"1F93E456-69EC-445A-8374-D7FC5558D0C7","kind":"crossTailnetRejection","portalName":"hermes","createdAt":807692800}]}"#,
+        ]
+
+        for record in records {
+            let store = PortalStore(rootURL: temporaryRoot())
+            try FileManager.default.createDirectory(at: store.rootURL, withIntermediateDirectories: true)
+            try Data(record.utf8).write(to: store.versionTwoInstallationURL)
+
+            let installation = try store.loadInstallation()
+
+            XCTAssertEqual(installation.operationalLogging, .enabled, record)
+            XCTAssertEqual(installation.launchAtLoginOffer, .notOffered, record)
+        }
+    }
+
+    func testValidVersionThreeWinsAfterInterruptedOlderCleanup() throws {
+        let store = PortalStore(rootURL: temporaryRoot())
+        let authoritative = InstallationRecord(
+            tailnetBinding: TailnetBinding(name: "opaque-tailnet-id", magicDNSSuffix: "example.ts.net"),
+            operationalLogging: .disabled,
+            launchAtLoginOffer: .accepted
+        )
+        try store.save(authoritative)
+        try FileManager.default.createDirectory(at: store.rootURL, withIntermediateDirectories: true)
+        try Data(#"{"version":2,"portals":[],"alerts":[]}"#.utf8).write(to: store.versionTwoInstallationURL)
+        try historicalVersionOneData(name: "stale").write(to: store.legacyConfigurationURL)
+
+        XCTAssertEqual(try store.loadInstallation(), authoritative)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.versionTwoInstallationURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.legacyConfigurationURL.path))
+    }
+
+    func testCorruptVersionThreeFailsClosedWithoutFallingBack() throws {
+        let store = PortalStore(rootURL: temporaryRoot())
+        try FileManager.default.createDirectory(at: store.rootURL, withIntermediateDirectories: true)
+        let corrupt = Data("not-json".utf8)
+        try corrupt.write(to: store.installationURL)
+        try Data(#"{"version":2,"portals":[],"alerts":[]}"#.utf8).write(to: store.versionTwoInstallationURL)
+
+        XCTAssertThrowsError(try store.loadInstallation())
+        XCTAssertEqual(try Data(contentsOf: store.installationURL), corrupt)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: store.versionTwoInstallationURL.path))
+    }
+
+    func testUnsupportedVersionThreeFailsClosedWithoutFallingBack() throws {
+        let store = PortalStore(rootURL: temporaryRoot())
+        try FileManager.default.createDirectory(at: store.rootURL, withIntermediateDirectories: true)
+        let unsupported = Data(
+            #"{"version":4,"operationalLogging":"disabled","launchAtLoginOffer":"accepted","portals":[],"alerts":[]}"#.utf8
+        )
+        try unsupported.write(to: store.installationURL)
+        try Data(#"{"version":2,"portals":[],"alerts":[]}"#.utf8).write(to: store.versionTwoInstallationURL)
+
+        XCTAssertThrowsError(try store.loadInstallation())
+        XCTAssertEqual(try Data(contentsOf: store.installationURL), unsupported)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: store.versionTwoInstallationURL.path))
+    }
+
+    func testFailedVersionTwoMigrationPreservesOlderAuthority() throws {
+        struct ExpectedFailure: Error {}
+        let root = temporaryRoot()
+        let versionTwoURL = root.appendingPathComponent("installation-v2.json")
+        let source = Data(#"{"version":2,"portals":[],"alerts":[]}"#.utf8)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try source.write(to: versionTwoURL)
+        let store = PortalStore(rootURL: root, writeData: { _, _ in throw ExpectedFailure() })
+
+        XCTAssertThrowsError(try store.loadInstallation())
+        XCTAssertEqual(try Data(contentsOf: versionTwoURL), source)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.installationURL.path))
+    }
+
     func testMigratesValidVersionOnePortalIntoUnboundVersionTwoInstallation() throws {
         let root = temporaryRoot()
         let store = PortalStore(rootURL: root)
         let legacyURL = root.appendingPathComponent("portal-v1.json", isDirectory: false)
-        let installationURL = root.appendingPathComponent("installation-v2.json", isDirectory: false)
+        let installationURL = store.installationURL
         let portal = PortalConfiguration(
             id: UUID(uuidString: "9f55ca93-d7b3-4eab-a871-310ea576005a")!,
             name: "hermes",
@@ -23,7 +138,10 @@ final class PortalStoreTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: legacyURL.path))
         XCTAssertEqual(try permissions(of: root), 0o700)
         XCTAssertEqual(try permissions(of: installationURL), 0o600)
-        XCTAssertEqual(try store.loadInstallation(), InstallationRecord(portals: [portal]))
+        XCTAssertEqual(
+            try store.loadInstallation(),
+            InstallationRecord(portals: [portal], operationalLogging: .enabled)
+        )
     }
 
     func testFailedVersionTwoWritePreservesVersionOneSource() throws {
@@ -80,36 +198,45 @@ final class PortalStoreTests: XCTestCase {
         XCTAssertEqual(try permissions(of: store.installationURL), 0o600)
     }
 
-    func testHistoricalVersionTwoDefaultsToEnabledAndNextSavePersistsDesiredState() throws {
-        struct ExpectedFailure: Error {}
+    func testSavingReplacesAnExistingFileWithSecurePermissions() throws {
+        let store = PortalStore(rootURL: temporaryRoot())
+        try FileManager.default.createDirectory(at: store.rootURL, withIntermediateDirectories: true)
+        try Data("stale".utf8).write(to: store.installationURL)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o644],
+            ofItemAtPath: store.installationURL.path
+        )
 
+        try store.save(InstallationRecord(operationalLogging: .disabled))
+
+        XCTAssertEqual(try permissions(of: store.installationURL), 0o600)
+        XCTAssertEqual(
+            try store.loadInstallation(),
+            InstallationRecord(operationalLogging: .disabled)
+        )
+    }
+
+    func testHistoricalVersionTwoDefaultsToEnabledAndNextSavePersistsDesiredState() throws {
         let root = temporaryRoot()
-        let installationURL = root.appendingPathComponent("installation-v2.json", isDirectory: false)
+        let versionTwoURL = root.appendingPathComponent("installation-v2.json", isDirectory: false)
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         let historical = Data(
             #"{"version":2,"portals":[{"id":"9F55CA93-D7B3-4EAB-A871-310EA576005A","name":"hermes","localAppPort":8787,"createdAt":807692800,"lifecycle":"active"},{"id":"5EA74329-3144-4BA2-925F-138D14D61FCC","name":"atlas","localAppPort":8788,"createdAt":807692801,"lifecycle":"active"}],"alerts":[]}"#.utf8
         )
-        try historical.write(to: installationURL)
-        var shouldFail = true
-        let store = PortalStore(rootURL: root, writeData: { data, url in
-            guard !shouldFail else { throw ExpectedFailure() }
-            try data.write(to: url, options: .atomic)
-        })
+        try historical.write(to: versionTwoURL)
+        let store = PortalStore(rootURL: root)
 
         var installation = try store.loadInstallation()
 
         XCTAssertEqual(installation.portals.map(\.desiredState), [.enabled, .enabled])
         installation.portals[1].desiredState = .stopped
-        XCTAssertThrowsError(try store.save(installation))
-        XCTAssertEqual(try Data(contentsOf: installationURL), historical)
-
-        shouldFail = false
         try store.save(installation)
 
-        let saved = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(contentsOf: installationURL)) as? [String: Any])
-        XCTAssertEqual(saved["version"] as? Int, 2)
+        let saved = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(contentsOf: store.installationURL)) as? [String: Any])
+        XCTAssertEqual(saved["version"] as? Int, 3)
         let portals = try XCTUnwrap(saved["portals"] as? [[String: Any]])
         XCTAssertEqual(portals.map { $0["desiredState"] as? String }, ["enabled", "stopped"])
+        XCTAssertEqual(saved["operationalLogging"] as? String, "enabled")
         XCTAssertEqual(try store.loadInstallation(), installation)
     }
 
@@ -119,11 +246,11 @@ final class PortalStoreTests: XCTestCase {
         let historical = Data(
             #"{"version":2,"portals":[{"id":"9F55CA93-D7B3-4EAB-A871-310EA576005A","name":"hermes","localAppPort":8787,"createdAt":807692800,"desiredState":"enabled","lifecycle":"active"}],"alerts":[]}"#.utf8
         )
-        try historical.write(to: store.installationURL)
+        try historical.write(to: store.versionTwoInstallationURL)
 
         var installation = try store.loadInstallation()
 
-        XCTAssertEqual(installation.version, 2)
+        XCTAssertEqual(installation.version, 3)
         XCTAssertNil(installation.portals[0].removalAssignedName)
 
         installation.portals[0].lifecycle = .pendingRemoval
@@ -131,7 +258,7 @@ final class PortalStoreTests: XCTestCase {
         try store.save(installation)
 
         XCTAssertEqual(try store.loadInstallation(), installation)
-        XCTAssertEqual(try store.loadInstallation().version, 2)
+        XCTAssertEqual(try store.loadInstallation().version, 3)
     }
 
     func testExplicitNullDesiredStateIsCorruptRatherThanDefaulting() throws {
@@ -140,10 +267,10 @@ final class PortalStoreTests: XCTestCase {
         let corrupt = Data(
             #"{"version":2,"portals":[{"id":"9F55CA93-D7B3-4EAB-A871-310EA576005A","name":"hermes","localAppPort":8787,"createdAt":807692800,"desiredState":null,"lifecycle":"active"}],"alerts":[]}"#.utf8
         )
-        try corrupt.write(to: store.installationURL)
+        try corrupt.write(to: store.versionTwoInstallationURL)
 
         XCTAssertThrowsError(try store.loadInstallation())
-        XCTAssertEqual(try Data(contentsOf: store.installationURL), corrupt)
+        XCTAssertEqual(try Data(contentsOf: store.versionTwoInstallationURL), corrupt)
     }
 
     func testSavedPortalReloadsWithSameImmutableDefinition() throws {

--- a/PorticoTests/ProcessHelperLauncherTests.swift
+++ b/PorticoTests/ProcessHelperLauncherTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import XCTest
+@testable import Portico
+
+final class ProcessHelperLauncherTests: XCTestCase {
+    func testEnabledLoggingRemovesInheritedOptOutWithoutChangingOtherVariables() throws {
+        let environment = try ProcessHelperLauncher.childEnvironment(
+            for: .enabled,
+            inherited: ["PATH": "/usr/bin", "TS_NO_LOGS_NO_SUPPORT": "true"]
+        )
+
+        XCTAssertEqual(environment, ["PATH": "/usr/bin"])
+    }
+
+    func testDisabledLoggingSetsExactOptOutValue() throws {
+        let environment = try ProcessHelperLauncher.childEnvironment(
+            for: .disabled,
+            inherited: ["PATH": "/usr/bin", "TS_NO_LOGS_NO_SUPPORT": "false"]
+        )
+
+        XCTAssertEqual(environment, ["PATH": "/usr/bin", "TS_NO_LOGS_NO_SUPPORT": "true"])
+    }
+
+    func testUndecidedLoggingCannotConstructHelperEnvironment() {
+        XCTAssertThrowsError(
+            try ProcessHelperLauncher.childEnvironment(for: .undecided, inherited: [:])
+        )
+    }
+}

--- a/PorticoUITests/PorticoUITests.swift
+++ b/PorticoUITests/PorticoUITests.swift
@@ -68,7 +68,6 @@ final class PorticoUITests: XCTestCase {
 
     func testLoggingRestartAndTerminalFailureStates() {
         var app = launch(scenario: "restarting")
-        openMenuBarExtra(app)
         app.typeKey(",", modifierFlags: .command)
         let disabledLogging = app.radioButtons["Disable operational-support logging"]
         XCTAssertTrue(disabledLogging.waitForExistence(timeout: 3), app.debugDescription)

--- a/PorticoUITests/PorticoUITests.swift
+++ b/PorticoUITests/PorticoUITests.swift
@@ -1,0 +1,182 @@
+import XCTest
+
+final class PorticoUITests: XCTestCase {
+    func testFirstRunGuidanceAndLoggingGate() {
+        let app = launch(scenario: "first-run")
+        openMenuBarExtra(app)
+
+        XCTAssertTrue(
+            app.descendants(matching: .any)["add-guidance"].waitForExistence(timeout: 3),
+            app.debugDescription
+        )
+        XCTAssertEqual(app.staticTexts["helper-state"].value as? String, "Awaiting logging choice")
+        XCTAssertFalse(app.buttons["Add Portal"].isEnabled)
+        XCTAssertTrue(app.buttons["logging-enabled"].exists)
+        XCTAssertTrue(app.buttons["logging-disabled"].exists)
+    }
+
+    func testOnlinePortalActionsAndNativeWindows() {
+        let app = launch(scenario: "online")
+        openMenuBarExtra(app)
+
+        XCTAssertTrue(app.descendants(matching: .any)["portal-name"].waitForExistence(timeout: 3))
+        XCTAssertTrue(app.descendants(matching: .any)["assigned-name"].exists)
+        XCTAssertTrue(app.descendants(matching: .any)["desired-state"].exists)
+        XCTAssertTrue(app.descendants(matching: .any)["tailscale-state"].exists)
+        XCTAssertTrue(app.descendants(matching: .any)["local-app-state"].exists)
+        XCTAssertTrue(app.buttons["copy-portal-url"].isEnabled)
+        XCTAssertTrue(app.buttons["open-portal-url"].isEnabled)
+        let startStop = app.buttons["start-stop"]
+        XCTAssertTrue(startStop.isEnabled)
+        XCTAssertFalse(app.buttons["authenticate"].exists)
+
+        startStop.click()
+        XCTAssertTrue(waitForValue("Stopped", element: app.staticTexts["desired-state"], timeout: 3))
+        let focusedStartStop = app.buttons.matching(
+            NSPredicate(format: "identifier == %@ AND hasKeyboardFocus == true", "start-stop")
+        ).firstMatch
+        XCTAssertTrue(focusedStartStop.waitForExistence(timeout: 3), app.debugDescription)
+
+        app.typeKey(",", modifierFlags: .command)
+        XCTAssertTrue(app.staticTexts["settings-heading"].waitForExistence(timeout: 3))
+        app.typeKey("w", modifierFlags: .command)
+        app.typeKey("d", modifierFlags: [.command, .shift])
+        XCTAssertTrue(app.staticTexts["diagnostics-heading"].waitForExistence(timeout: 3))
+        XCTAssertFalse(app.staticTexts["settings-heading"].exists)
+        app.typeKey("q", modifierFlags: .command)
+        XCTAssertTrue(app.wait(for: .notRunning, timeout: 5))
+    }
+
+    func testStaleAndAuthenticatingActions() {
+        var app = launch(scenario: "stale")
+        openMenuBarExtra(app)
+
+        let lastKnown = app.staticTexts.matching(
+            NSPredicate(format: "label CONTAINS %@ OR value CONTAINS %@", "Last Known", "Last Known")
+        ).firstMatch
+        XCTAssertTrue(lastKnown.waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.buttons["copy-portal-url"].isEnabled)
+        XCTAssertFalse(app.buttons["open-portal-url"].isEnabled)
+
+        app = launch(scenario: "authenticating")
+        openMenuBarExtra(app)
+        XCTAssertTrue(app.buttons["authenticate"].waitForExistence(timeout: 3))
+        XCTAssertTrue(app.buttons["authenticate"].isEnabled)
+        XCTAssertTrue(app.buttons["copy-portal-url"].isEnabled)
+        XCTAssertFalse(app.buttons["open-portal-url"].isEnabled)
+    }
+
+    func testLoggingRestartAndTerminalFailureStates() {
+        var app = launch(scenario: "restarting")
+        openMenuBarExtra(app)
+        app.typeKey(",", modifierFlags: .command)
+        let disabledLogging = app.radioButtons["Disable operational-support logging"]
+        XCTAssertTrue(disabledLogging.waitForExistence(timeout: 3), app.debugDescription)
+        disabledLogging.click()
+        XCTAssertTrue(waitForValue("Restarting", element: app.staticTexts["settings-helper-state"], timeout: 2))
+        app.typeKey("r", modifierFlags: [.command, .shift])
+        app.typeKey("w", modifierFlags: .command)
+        openMenuBarExtra(app)
+        XCTAssertTrue(waitForValue("Restarting", element: app.staticTexts["helper-state"], timeout: 2))
+        XCTAssertTrue(waitForValue("Connected", element: app.staticTexts["helper-state"], timeout: 5))
+
+        app = launch(scenario: "terminal-failure")
+        openMenuBarExtra(app)
+        XCTAssertTrue(waitForValue("Helper unavailable", element: app.staticTexts["helper-state"], timeout: 3))
+        XCTAssertTrue(app.buttons["retry-helper"].isEnabled)
+        XCTAssertTrue(app.buttons["start-stop"].isEnabled)
+    }
+
+    func testRemovalConfirmationCancelCompletionAndFailure() {
+        var app = launch(scenario: "online")
+        openMenuBarExtra(app)
+        app.buttons["remove-portal"].click()
+        XCTAssertTrue(app.staticTexts["remove-confirmation-heading"].waitForExistence(timeout: 3))
+        app.typeKey(.escape, modifierFlags: [])
+        XCTAssertFalse(app.staticTexts["remove-confirmation-heading"].waitForExistence(timeout: 1))
+        XCTAssertTrue(app.descendants(matching: .any)["portal-name"].exists)
+
+        app.buttons["remove-portal"].click()
+        XCTAssertTrue(app.buttons["remove-confirm"].waitForExistence(timeout: 3))
+        app.typeKey(.return, modifierFlags: [])
+        let removalComplete = app.descendants(matching: .any)["removal-complete"]
+        if !removalComplete.waitForExistence(timeout: 1) {
+            openMenuBarExtra(app)
+        }
+        XCTAssertTrue(removalComplete.waitForExistence(timeout: 5), app.debugDescription)
+
+        app = launch(scenario: "removing")
+        openMenuBarExtra(app)
+        XCTAssertTrue(app.descendants(matching: .any)["removing-portal"].waitForExistence(timeout: 3))
+        XCTAssertFalse(app.buttons["Retry Removal"].exists)
+
+        app = launch(scenario: "removing-failure")
+        openMenuBarExtra(app)
+        let retryRemoval = app.buttons["Retry Removal"]
+        if !retryRemoval.waitForExistence(timeout: 1) {
+            openMenuBarExtra(app)
+        }
+        XCTAssertTrue(retryRemoval.waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(retryRemoval.isEnabled)
+    }
+
+    func testLaunchAtLoginApprovalAndRegistrationError() {
+        var app = launch(scenario: "login-approval")
+        app.typeKey(",", modifierFlags: .command)
+        XCTAssertTrue(app.staticTexts["settings-heading"].waitForExistence(timeout: 3))
+        XCTAssertTrue(app.buttons["open-login-items-settings"].isEnabled)
+
+        app = launch(scenario: "login-error")
+        app.typeKey(",", modifierFlags: .command)
+        XCTAssertTrue(app.buttons["enable-launch-at-login"].waitForExistence(timeout: 3))
+        app.buttons["enable-launch-at-login"].click()
+        XCTAssertTrue(app.staticTexts["launch-at-login-error"].waitForExistence(timeout: 3))
+        XCTAssertTrue(app.buttons["retry-launch-at-login"].isEnabled)
+    }
+
+    func testLaunchAtLoginOfferDoesNotRepeatAfterRelaunch() {
+        let root = makeRoot()
+        var app = launch(scenario: "login-offer", root: root)
+        openMenuBarExtra(app)
+        XCTAssertTrue(app.descendants(matching: .any)["launch-at-login-offer"].waitForExistence(timeout: 5))
+
+        app.statusItems.firstMatch.click()
+        openMenuBarExtra(app)
+        XCTAssertFalse(app.descendants(matching: .any)["launch-at-login-offer"].waitForExistence(timeout: 2))
+
+        app.terminate()
+        XCTAssertTrue(app.wait(for: .notRunning, timeout: 5))
+        app = launch(scenario: "login-offer", root: root)
+        openMenuBarExtra(app)
+        XCTAssertFalse(app.descendants(matching: .any)["launch-at-login-offer"].waitForExistence(timeout: 2))
+    }
+
+    private func launch(scenario: String, root: String? = nil) -> XCUIApplication {
+        let app = XCUIApplication()
+        app.terminate()
+        XCTAssertTrue(app.wait(for: .notRunning, timeout: 5))
+        app.launchArguments = ["--ui-testing"]
+        app.launchEnvironment = [
+            "PORTICO_UI_TEST_SCENARIO": scenario,
+            "PORTICO_UI_TEST_ROOT": root ?? makeRoot(),
+        ]
+        app.launch()
+        return app
+    }
+
+    private func makeRoot() -> String {
+        "/private/tmp/PorticoUITests-\(UUID().uuidString)"
+    }
+
+    private func waitForValue(_ value: String, element: XCUIElement, timeout: TimeInterval) -> Bool {
+        let predicate = NSPredicate(format: "value == %@", value)
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: element)
+        return XCTWaiter.wait(for: [expectation], timeout: timeout) == .completed
+    }
+
+    private func openMenuBarExtra(_ app: XCUIApplication) {
+        let item = app.statusItems.firstMatch
+        XCTAssertTrue(item.waitForExistence(timeout: 5))
+        item.click()
+    }
+}

--- a/docs/portico-mvp-spec.md
+++ b/docs/portico-mvp-spec.md
@@ -54,6 +54,15 @@ Portico offers one non-blocking choice to enable it and does not repeat the
 prompt after the user declines. Enabled Portals reconnect whenever Portico is
 running; a Stopped Portal remains stopped across relaunches.
 
+The live `SMAppService.mainApp.status` value is the sole truth for whether
+launch at login is enabled, disabled, awaiting approval, or unavailable.
+Portico persists only whether the one-time offer has not been offered, was
+presented, was declined, or was accepted. It records the presented or accepted
+intent before showing the offer or asking ServiceManagement to register. A
+registration failure leaves the accepted intent intact and exposes an explicit
+Retry action in Settings. Signed-app registration is verified under #11 rather
+than from the unsigned development or UI-test app.
+
 ### Add Portal
 
 Before enrollment, Portico briefly explains that the tailnet might require:
@@ -98,8 +107,9 @@ Name blank. Suggested names are normalized conservatively to a DNS-style
 label and remain editable until enrollment starts.
 
 When tsnet requires authentication, Portico displays an **Authenticate**
-button. It opens the transient URL only after the user clicks; the URL can be
-copied from diagnostics but is never persisted or logged.
+button. It opens the transient URL only after the user clicks. Authentication
+URLs are never persisted, logged, copied into diagnostics, or reused after the
+helper generation that supplied them becomes stale.
 
 The first Portal to become online binds this Portico installation to one
 tailnet. Later Portals must report the same `CurrentTailnet.Name`. A Portal
@@ -132,6 +142,43 @@ tsnet identity after one explicit warning. The warning shows the Assigned
 Name, states that the remote tailnet node remains, and links to Tailscale's
 [manual device-removal instructions](https://tailscale.com/docs/features/access-control/device-management/how-to/remove).
 
+The UI derives every action from one authoritative availability projection:
+
+| Action | Available when | Unavailable or stale behavior |
+| --- | --- | --- |
+| Add Portal | Logging is decided and the name and port validate | Saves locally without requiring a helper connection |
+| Refresh Local Apps | Helper is connected and no refresh is active | Disabled while awaiting choice, restarting, retrying, or failed |
+| Start / Stop | Active Portal whose desired state permits the transition | Commits locally while the helper is unavailable |
+| Edit Local App Port | Active Portal and a changed, valid port | Commits locally while the helper is unavailable |
+| Authenticate | Active and Enabled, helper connected, current non-stale state authenticating, no request pending | Never uses stale state or a stale authentication URL |
+| Copy Portal URL | A sanitized current or session-stale URL exists | Session-stale URLs are labelled **Last Known** and remain copyable |
+| Open Portal URL | Current non-stale URL and current Tailscale state online | Never opens a stale URL; Local App unreachability does not disable it |
+| Diagnostics | Globally always; per Portal while its record exists | Independent of helper availability |
+| Remove | Active Portal | Commits destructive intent locally; cleanup waits for connection |
+| Retry Removal | Removing, cleanup failed, and helper connected | Otherwise waits for helper recovery |
+| Reset Tailnet | A binding exists and no Portal record remains | Preserves logging and launch-at-login offer state |
+| Settings | Always | Remains usable if ServiceManagement is unavailable |
+
+### Keyboard and accessibility
+
+The popover uses visible text and standard focusable controls; helper, Portal,
+and action status never relies on color or an icon alone. Traversal follows the
+visual source order: helper and global state, Portal rows in creation order,
+the Add Portal guidance and form, Reset Tailnet when eligible, then Settings,
+Diagnostics, and Quit. Within a row, identity and the three independent states
+precede URL actions, authentication, port edit, Start or Stop, Diagnostics,
+and Remove.
+
+`Command-,` opens Settings, `Command-Shift-D` opens Diagnostics, and
+`Command-Q` quits. Space or Return activates the focused control and Escape
+cancels destructive confirmation without mutation. Settings and Diagnostics
+initially focus their headings; removal restores focus to the Portal row or
+completion notice, and Add validation errors return focus to the invalid
+field. Portico posts one fixed polite VoiceOver announcement for helper
+connection or terminal failure, a Portal becoming online, removal success or
+failure, and logging-restart success or failure. It never announces retry
+ticks, raw errors, paths, URLs, or credentials.
+
 ## Runtime model
 
 ### State
@@ -149,14 +196,29 @@ TCP connection. It is not an application health check and never sends HTTP.
 
 ### Persistence
 
-Swift owns an atomically written, versioned configuration containing:
+Swift owns an atomically written version-3 configuration at
+`installation-v3.json` containing:
 
 - Portal UUID;
 - immutable Portal Name;
 - Local App port;
 - desired state;
-- creation time; and
-- safe cached last-known Assigned Name, Portal URL, tailnet, and IPs.
+- creation time;
+- the installation-global operational-support logging preference; and
+- the one-time launch-at-login offer state.
+
+Assigned Name, Portal URL, tailnet, IPs, and authentication URL are helper
+facts, not persisted Portal configuration. Safe Portal facts may remain marked
+**Last Known** only within the current app session after helper loss. After a
+relaunch, actions wait for newly received current facts.
+
+A genuinely new installation starts with logging undecided and does not launch
+the helper. Existing v1 installations, and v2 installations containing any
+Portal, tailnet binding, or alert, migrate to logging enabled so their previous
+behavior is preserved; a pristine empty v2 installation migrates to undecided.
+Every migration starts with the launch-at-login offer not offered. A valid v3
+record takes precedence, while an invalid v3 fails closed instead of falling
+back. Migration atomically saves v3 before removing the older record.
 
 The installation tailnet binding stores `CurrentTailnet.Name` and caches its
 MagicDNS suffix for display. The helper owns no separate product database.
@@ -320,6 +382,21 @@ If the helper exits unexpectedly, Swift restarts it with bounded exponential
 backoff and restores Enabled Portals. After the retry budget is exhausted,
 Portico shows a global failure with a manual Retry action.
 
+Changing the committed operational-support logging choice is a controlled,
+commit-first restart. Swift saves and publishes the new value, marks helper
+facts stale, gracefully shuts down the old helper with the existing one-second
+limit, and starts the replacement only after old-process ownership clears.
+The replacement receives a fresh recovery budget and the newest coalesced
+Portal snapshot. Old-process responses, events, and authentication URLs are
+generation-fenced. Local Add, Start, Stop, port edit, and Remove intent may
+still commit while the helper is unavailable; helper-dependent Authenticate,
+listener refresh, and removal Retry remain unavailable until reconnection.
+
+For logging enabled, Swift removes any inherited
+`TS_NO_LOGS_NO_SUPPORT` from the child environment. For logging disabled, it
+sets that variable to exactly `true` before the helper starts. This preference
+does not alter the helper command line or protocol version.
+
 ### tsnet lifecycle
 
 Each server has a unique state directory and immutable requested hostname.
@@ -440,13 +517,24 @@ commands, secret-bearing arguments, and invalid name suggestions.
 
 ### Native UI
 
-- listener suggestion and manual-port Add Portal flows;
-- prerequisite explanation and explicit Authenticate action;
-- name-collision presentation;
-- Start, Stop, port edit, Copy, Open, and diagnostics;
-- cross-tailnet rejection;
-- removal warning content; and
-- Tailscale logging choice and launch-at-login suggestion.
+- first-run prerequisite guidance, logging gate, and Add availability;
+- separately labelled Portal identity, Assigned Name, desired state,
+  Tailscale state, and Local App reachability;
+- current versus session-stale URL actions and explicit Authenticate action;
+- Start, Stop, port edit, Copy, Open, Diagnostics, and Remove availability;
+- controlled logging restart, retry, and terminal helper failure;
+- removal confirmation, Escape cancellation, completion, in-progress, and
+  retryable-failure states;
+- one-time launch-at-login offer persistence plus approval and registration
+  error states;
+- separate native Settings and Diagnostics windows; and
+- `Command-,`, `Command-Shift-D`, `Command-Q`, Return, and Escape behavior.
+
+The XCUITest target selects a test-only launch configuration before dependency
+construction. It uses a retained temporary installation root, an in-process
+fake helper, a fake ServiceManagement adapter, and intercepted URL/open and
+copy actions. It never starts the real helper, writes Application Support,
+registers a login item, or opens an external URL.
 
 ### Packaging
 
@@ -455,11 +543,34 @@ commands, secret-bearing arguments, and invalid name suggestions.
 - the helper is present at the expected bundle path; and
 - a packaged app starts and shuts down without leaving a helper process.
 
+### Manual macOS 14 accessibility acceptance
+
+Automated UI tests do not replace a macOS 14 check with Full Keyboard Access,
+VoiceOver, and Accessibility Inspector. Before release, verify all of the
+following on that configuration:
+
+1. First-run traversal reads prerequisite guidance, logging choice, and Add
+   controls in visual order, with Add unavailable until logging is chosen.
+2. Portal Name, collision Assigned Name, desired state, Tailscale state, and
+   Local App reachability are read as separate facts.
+3. A current URL exposes Copy and Open, while a **Last Known** URL is labelled
+   stale, remains copyable, and cannot be opened or authenticated.
+4. `Command-,` and `Command-Shift-D` open separate native windows whose
+   headings receive initial accessibility focus.
+5. A logging change retains useful focus and produces exactly one restart
+   completion or failure announcement.
+6. Removal confirmation supports Return and Escape, cancellation preserves the
+   Portal, and focus returns to the row or completion notice.
+7. The launch-at-login offer is non-blocking and does not repeat after a
+   dismissed, declined, presented-before-crash, or accepted choice.
+8. Accessibility labels and values expose no authentication URL, credential,
+   raw error, sensitive path, or secret-bearing process argument.
+
 ## Deferred live acceptance
 
 The first implementation does not mutate a real tailnet or request public
 certificates automatically. Before calling the spike proven or publishing a
-release, run this explicit manual acceptance scenario:
+release, issue #12 owns this explicit manual acceptance scenario:
 
 1. Start an HTTP test server on `127.0.0.1:8787`.
 2. Add a Portal named `hermes`.
@@ -482,7 +593,8 @@ The first supported artifact is a macOS 14+ universal app distributed outside
 the Mac App Store. Build arm64 and x86_64 helper binaries, combine them,
 embed and sign the helper before signing the outer app, enable the hardened
 runtime, verify both signatures, notarize the final ZIP or DMG, and staple the
-ticket where supported.
+ticket where supported. Issue #11 owns this signed-app work, including the
+production `SMAppService.mainApp` registration smoke check.
 
 A Homebrew cask can consume the same notarized versioned artifact. Mac App
 Store sandbox feasibility is a separate investigation; it must not change the

--- a/project.yml
+++ b/project.yml
@@ -23,7 +23,9 @@ targets:
     settings:
       base:
         ARCHS: arm64
-        CODE_SIGNING_ALLOWED: "NO"
+        CODE_SIGNING_ALLOWED: "YES"
+        CODE_SIGN_IDENTITY: "-"
+        CODE_SIGN_STYLE: Manual
         CODE_SIGNING_REQUIRED: "NO"
         ENABLE_USER_SCRIPT_SANDBOXING: "NO"
         GENERATE_INFOPLIST_FILE: "YES"
@@ -36,6 +38,7 @@ targets:
       configs:
         Debug:
           ENABLE_TESTABILITY: "YES"
+          PRODUCT_BUNDLE_IDENTIFIER: dev.chrisbanes.Portico.Debug
           SWIFT_OPTIMIZATION_LEVEL: "-Onone"
     postBuildScripts:
       - name: Build and Embed Helper
@@ -72,6 +75,28 @@ targets:
         SWIFT_VERSION: "5.0"
         TEST_HOST: "$(BUILT_PRODUCTS_DIR)/Portico.app/Contents/MacOS/Portico"
 
+  PorticoUITests:
+    type: bundle.ui-testing
+    platform: macOS
+    deploymentTarget: "14.0"
+    sources:
+      - path: PorticoUITests
+    dependencies:
+      - target: Portico
+    settings:
+      base:
+        ARCHS: arm64
+        CODE_SIGNING_ALLOWED: "YES"
+        CODE_SIGN_IDENTITY: "-"
+        CODE_SIGN_STYLE: Manual
+        GENERATE_INFOPLIST_FILE: "YES"
+        MACOSX_DEPLOYMENT_TARGET: "14.0"
+        ONLY_ACTIVE_ARCH: "YES"
+        PRODUCT_BUNDLE_IDENTIFIER: dev.chrisbanes.PorticoUITests
+        PRODUCT_NAME: "$(TARGET_NAME)"
+        SWIFT_VERSION: "5.0"
+        TEST_TARGET_NAME: Portico
+
 schemes:
   Portico:
     build:
@@ -82,3 +107,4 @@ schemes:
       config: Debug
       targets:
         - PorticoTests
+        - PorticoUITests


### PR DESCRIPTION
## Summary

- persist the version-3 logging and launch-at-login contract with explicit historical migration boundaries and secure atomic storage
- gate helper startup on logging consent, add generation-safe controlled restart, and inject live ServiceManagement behind a testable adapter
- centralize Portal action availability and build the native Settings, Diagnostics, prerequisite, Portal-row, focus, and announcement experience
- add a hermetic macOS UI-test target with retained relaunch fixtures and reconcile the MVP specification

## Validation

- `./Scripts/verify-xcode-project-generation.sh`
- full Portico scheme: 110 passed, 0 failed, 0 skipped on macOS 26.5.2
- Release configuration build
- `go build ./cmd/portico-helper`
- `go test ./...`
- `go test -race ./internal/portal ./internal/protocol`
- final correctness review, review-and-simplify, and review-only ponytail review: no remaining findings

## Manual follow-up

- the documented macOS 14 Full Keyboard Access, VoiceOver, and Accessibility Inspector checklist remains a manual acceptance run; automated coverage asserts real Start/Stop keyboard focus plus Return, Escape, and application shortcuts, while synthetic Space activation was not reliable with Full Keyboard Access disabled on the available macOS 26.5.2 host
- signed `SMAppService` registration remains #11 work and real-tailnet release validation remains #12 work

Fixes #10