### PR TITLE
Represent Local Apps with Portal destinations

### DIFF
--- a/Portico/HelperSupervisor.swift
+++ b/Portico/HelperSupervisor.swift
@@ -255,7 +255,7 @@ final class HelperSupervisor: ObservableObject, PortalHelperClient {
                     ReconcilePortalPayload(
                         portalId: $0.id,
                         portalName: $0.name,
-                        localAppPort: $0.localAppPort,
+                        localAppPort: $0.destination.localAppPort,
                         desiredState: $0.desiredState
                     )
                 }

--- a/Portico/PortalConfiguration.swift
+++ b/Portico/PortalConfiguration.swift
@@ -1,13 +1,53 @@
 import Foundation
 
+struct PortalDestination: Equatable {
+    let localAppPort: UInt16
+
+    init?(localAppPort: UInt16) {
+        guard localAppPort > 0 else { return nil }
+        self.localAppPort = localAppPort
+    }
+}
+
 struct PortalConfiguration: Codable, Equatable {
     let id: UUID
     let name: String
-    var localAppPort: UInt16
+    var destination: PortalDestination
     let createdAt: Date
     var desiredState: PortalDesiredState = .enabled
     var lifecycle: PortalLifecycle = .active
     var removalAssignedName: String?
+
+    init(
+        id: UUID,
+        name: String,
+        localAppPort: UInt16,
+        createdAt: Date,
+        desiredState: PortalDesiredState = .enabled,
+        lifecycle: PortalLifecycle = .active,
+        removalAssignedName: String? = nil
+    ) {
+        guard let destination = PortalDestination(localAppPort: localAppPort) else {
+            preconditionFailure("Portal destinations require a port from 1 through 65535.")
+        }
+        self.id = id
+        self.name = name
+        self.destination = destination
+        self.createdAt = createdAt
+        self.desiredState = desiredState
+        self.lifecycle = lifecycle
+        self.removalAssignedName = removalAssignedName
+    }
+
+    var localAppPort: UInt16 {
+        get { destination.localAppPort }
+        set {
+            guard let destination = PortalDestination(localAppPort: newValue) else {
+                preconditionFailure("Portal destinations require a port from 1 through 65535.")
+            }
+            self.destination = destination
+        }
+    }
 }
 
 enum PortalDesiredState: String, Codable, Equatable {
@@ -30,7 +70,15 @@ extension PortalConfiguration {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         id = try container.decode(UUID.self, forKey: .id)
         name = try container.decode(String.self, forKey: .name)
-        localAppPort = try container.decode(UInt16.self, forKey: .localAppPort)
+        let localAppPort = try container.decode(UInt16.self, forKey: .localAppPort)
+        guard let destination = PortalDestination(localAppPort: localAppPort) else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .localAppPort,
+                in: container,
+                debugDescription: "Portal destinations require a port from 1 through 65535."
+            )
+        }
+        self.destination = destination
         createdAt = try container.decode(Date.self, forKey: .createdAt)
         desiredState = try container.contains(.desiredState)
             ? container.decode(PortalDesiredState.self, forKey: .desiredState)
@@ -45,7 +93,7 @@ extension PortalConfiguration {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(id, forKey: .id)
         try container.encode(name, forKey: .name)
-        try container.encode(localAppPort, forKey: .localAppPort)
+        try container.encode(destination.localAppPort, forKey: .localAppPort)
         try container.encode(createdAt, forKey: .createdAt)
         try container.encode(desiredState, forKey: .desiredState)
         try container.encode(lifecycle, forKey: .lifecycle)

--- a/Portico/PortalController.swift
+++ b/Portico/PortalController.swift
@@ -342,9 +342,11 @@ final class PortalController: ObservableObject {
             message = "Enter a port from 1 through 65535."
             return
         }
-        guard installation.portals[index].localAppPort != localAppPort else { return }
+        guard installation.portals[index].destination.localAppPort != localAppPort,
+              let destination = PortalDestination(localAppPort: localAppPort)
+        else { return }
         var updated = installation
-        updated.portals[index].localAppPort = localAppPort
+        updated.portals[index].destination = destination
         _ = savePortalOperation(updated)
     }
 

--- a/PorticoTests/PortalConfigurationTests.swift
+++ b/PorticoTests/PortalConfigurationTests.swift
@@ -2,6 +2,12 @@ import XCTest
 @testable import Portico
 
 final class PortalConfigurationTests: XCTestCase {
+    func testLocalAppPortalDestinationAcceptsOnlyValidPorts() throws {
+        XCTAssertEqual(try XCTUnwrap(PortalDestination(localAppPort: 1)).localAppPort, 1)
+        XCTAssertEqual(try XCTUnwrap(PortalDestination(localAppPort: 65535)).localAppPort, 65535)
+        XCTAssertNil(PortalDestination(localAppPort: 0))
+    }
+
     func testVersionThreeInstallationDefaultsRequireLoggingChoiceAndHaveNotOfferedLogin() {
         let installation = InstallationRecord()
 

--- a/PorticoTests/PortalStoreTests.swift
+++ b/PorticoTests/PortalStoreTests.swift
@@ -291,6 +291,36 @@ final class PortalStoreTests: XCTestCase {
         XCTAssertThrowsError(try store.save(portal))
     }
 
+    func testVersionThreePersistenceUsesTheLocalAppPortAdapter() throws {
+        let store = PortalStore(rootURL: temporaryRoot())
+        let portal = PortalConfiguration(
+            id: UUID(uuidString: "9f55ca93-d7b3-4eab-a871-310ea576005a")!,
+            name: "hermes",
+            localAppPort: 8787,
+            createdAt: Date(timeIntervalSince1970: 1_786_000_000)
+        )
+
+        try store.save(InstallationRecord(portals: [portal]))
+
+        let saved = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(contentsOf: store.installationURL)) as? [String: Any]
+        )
+        let savedPortal = try XCTUnwrap((saved["portals"] as? [[String: Any]])?.first)
+        XCTAssertEqual(savedPortal["localAppPort"] as? Int, 8787)
+        XCTAssertNil(savedPortal["destination"])
+        XCTAssertEqual(try store.loadInstallation().portals.first?.destination, portal.destination)
+    }
+
+    func testVersionThreeRejectsAnInvalidLocalAppPort() throws {
+        let store = PortalStore(rootURL: temporaryRoot())
+        try FileManager.default.createDirectory(at: store.rootURL, withIntermediateDirectories: true)
+        try Data(
+            #"{"version":3,"portals":[{"id":"9F55CA93-D7B3-4EAB-A871-310EA576005A","name":"hermes","localAppPort":0,"createdAt":807692800,"lifecycle":"active"}],"alerts":[],"operationalLogging":"enabled","launchAtLoginOffer":"notOffered"}"#.utf8
+        ).write(to: store.installationURL)
+
+        XCTAssertThrowsError(try store.loadInstallation())
+    }
+
     func testSavingFirstPortalPreservesInstallationBindingAndAlerts() throws {
         let store = PortalStore(rootURL: temporaryRoot())
         let alert = InstallationAlert(


### PR DESCRIPTION
Fixes #31

## Rationale

Make a validated internal `PortalDestination` the stored Portal configuration while preserving the installation v3 and helper protocol v3 `localAppPort` adapters.

## Validation

- Swift unit tests: 106 passed across all Portico unit-test classes
- `go test ./...`
- `go build ./cmd/portico-helper`
- Correctness/standards, simplify, and over-engineering reviews: no actionable findings

## Residual risk

No live-tailnet behavior was exercised; existing fake-helper, filesystem-store, protocol, runtime, and proxy seams remain unchanged.