### PR TITLE
Add Remote App destinations

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -28,6 +28,13 @@ _Avoid_: Generated URL, requested URL
 An HTTP service on the same Mac that a Portal makes available to its tailnet.
 _Avoid_: Backend, upstream, target
 
+**Portal Destination**:
+The one configured Local App or Remote App to which a Portal forwards requests.
+
+**Remote App**:
+An HTTP or HTTPS service reached through the Mac network that a Portal makes
+available to its tailnet. A Remote App is configured by scheme, host, and port.
+
 **Enabled Portal**:
 A Portal whose desired state is to remain connected whenever Portico is
 running.

--- a/Portico/HelperProtocol.swift
+++ b/Portico/HelperProtocol.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-let helperProtocolVersion = 3
+let helperProtocolVersion = 4
 
 enum HelperCommand: String, Codable {
     case handshake
@@ -39,8 +39,9 @@ struct ShutdownResult: Codable, Equatable {
 struct ReconcilePortalPayload: Codable, Equatable {
     let portalId: UUID
     let portalName: String
-    let localAppPort: UInt16
+    let destination: PortalDestination
     let desiredState: PortalDesiredState
+
 }
 
 struct ReconcilePortalsPayload: Codable, Equatable {

--- a/Portico/HelperSupervisor.swift
+++ b/Portico/HelperSupervisor.swift
@@ -255,7 +255,7 @@ final class HelperSupervisor: ObservableObject, PortalHelperClient {
                     ReconcilePortalPayload(
                         portalId: $0.id,
                         portalName: $0.name,
-                        localAppPort: $0.destination.localAppPort,
+                        destination: $0.destination,
                         desiredState: $0.desiredState
                     )
                 }

--- a/Portico/LocalAppReachability.swift
+++ b/Portico/LocalAppReachability.swift
@@ -75,9 +75,11 @@ final class LocalAppReachability: ObservableObject {
     }
 
     func update(portals: [PortalConfiguration]) {
-        let updated = Dictionary(uniqueKeysWithValues: portals
-            .filter { $0.lifecycle == .active }
-            .map { ($0.id, $0.localAppPort) })
+        let pairs: [(UUID, UInt16)] = portals.compactMap { portal in
+            guard portal.lifecycle == .active, let port = portal.localAppPort else { return nil }
+            return (portal.id, port)
+        }
+        let updated = Dictionary(uniqueKeysWithValues: pairs)
         let previous = portalPorts
         guard updated != previous else { return }
         portalPorts = updated

--- a/Portico/PortalConfiguration.swift
+++ b/Portico/PortalConfiguration.swift
@@ -1,12 +1,149 @@
+import Darwin
 import Foundation
 
-struct PortalDestination: Equatable {
-    let localAppPort: UInt16
+enum RemoteAppScheme: String, Codable, Equatable {
+    case http
+    case https
+}
+
+enum PortalDestination: Codable, Equatable {
+    case localApp(port: UInt16)
+    case remoteApp(scheme: RemoteAppScheme, host: String, port: UInt16)
 
     init?(localAppPort: UInt16) {
         guard localAppPort > 0 else { return nil }
-        self.localAppPort = localAppPort
+        self = .localApp(port: localAppPort)
     }
+
+    init?(remoteAppScheme: RemoteAppScheme, host: String, port: UInt16) {
+        guard port > 0, let host = Self.canonicalRemoteHost(host), !Self.isLoopbackHost(host) else {
+            return nil
+        }
+        self = .remoteApp(scheme: remoteAppScheme, host: host, port: port)
+    }
+
+    var localAppPort: UInt16? {
+        guard case let .localApp(port) = self else { return nil }
+        return port
+    }
+
+    var isLocalApp: Bool {
+        localAppPort != nil
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case kind
+        case port
+        case scheme
+        case host
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let allKeys = try decoder.container(keyedBy: DynamicCodingKey.self)
+        let keys = Set(allKeys.allKeys.map(\.stringValue))
+        let kind = try container.decode(String.self, forKey: .kind)
+        switch kind {
+        case "localApp":
+            guard keys == ["kind", "port"],
+                  let destination = Self(localAppPort: try container.decode(UInt16.self, forKey: .port))
+            else { throw DecodingError.dataCorruptedError(forKey: .kind, in: container, debugDescription: "Invalid Local App destination.") }
+            self = destination
+        case "remoteApp":
+            guard keys == ["kind", "scheme", "host", "port"],
+                  let destination = Self(
+                    remoteAppScheme: try container.decode(RemoteAppScheme.self, forKey: .scheme),
+                    host: try container.decode(String.self, forKey: .host),
+                    port: try container.decode(UInt16.self, forKey: .port)
+                  )
+            else { throw DecodingError.dataCorruptedError(forKey: .kind, in: container, debugDescription: "Invalid Remote App destination.") }
+            self = destination
+        default:
+            throw DecodingError.dataCorruptedError(forKey: .kind, in: container, debugDescription: "Unknown Portal destination kind.")
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .localApp(port):
+            try container.encode("localApp", forKey: .kind)
+            try container.encode(port, forKey: .port)
+        case let .remoteApp(scheme, host, port):
+            try container.encode("remoteApp", forKey: .kind)
+            try container.encode(scheme, forKey: .scheme)
+            try container.encode(host, forKey: .host)
+            try container.encode(port, forKey: .port)
+        }
+    }
+
+    private static func canonicalRemoteHost(_ raw: String) -> String? {
+        guard !raw.isEmpty, raw == raw.trimmingCharacters(in: .whitespacesAndNewlines), raw.unicodeScalars.allSatisfy(\.isASCII) else {
+            return nil
+        }
+        if raw.contains(":"), !raw.contains("["), !raw.contains("%") {
+            return canonicalIPv6(raw)
+        }
+        if raw.contains("[") || raw.contains("]") || raw.contains("%") {
+            return nil
+        }
+        if let ipv4 = canonicalIPv4(raw) {
+            return ipv4
+        }
+        guard !raw.hasSuffix("."), raw.utf8.count <= 253 else { return nil }
+        let host = raw.lowercased()
+        let labels = host.split(separator: ".", omittingEmptySubsequences: false)
+        guard !labels.isEmpty, labels.allSatisfy({ isValidDNSLabel($0.utf8) }) else { return nil }
+        return host
+    }
+
+    private static func canonicalIPv4(_ raw: String) -> String? {
+        var address = in_addr()
+        guard inet_pton(AF_INET, raw, &address) == 1 else { return nil }
+        var rendered = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
+        guard inet_ntop(AF_INET, &address, &rendered, socklen_t(INET_ADDRSTRLEN)) != nil else { return nil }
+        let canonical = String(cString: rendered)
+        return canonical == raw ? canonical : nil
+    }
+
+    private static func canonicalIPv6(_ raw: String) -> String? {
+        var address = in6_addr()
+        guard inet_pton(AF_INET6, raw, &address) == 1 else { return nil }
+        var rendered = [CChar](repeating: 0, count: Int(INET6_ADDRSTRLEN))
+        guard inet_ntop(AF_INET6, &address, &rendered, socklen_t(INET6_ADDRSTRLEN)) != nil else { return nil }
+        let canonical = String(cString: rendered).lowercased()
+        return canonical == raw ? canonical : nil
+    }
+
+    private static func isLoopbackHost(_ host: String) -> Bool {
+        if host == "localhost" || host == "::1" || host == "0.0.0.0" || host == "::" { return true }
+        if host.hasPrefix("::ffff:") {
+            return isLoopbackHost(String(host.dropFirst("::ffff:".count)))
+        }
+        if let first = host.split(separator: ".").first, Int(first) == 127 { return true }
+        return false
+    }
+
+}
+
+private struct DynamicCodingKey: CodingKey {
+    let stringValue: String
+    init?(stringValue: String) { self.stringValue = stringValue }
+    let intValue: Int? = nil
+    init?(intValue: Int) { return nil }
+}
+
+private func isValidDNSLabel<Bytes: BidirectionalCollection>(_ bytes: Bytes) -> Bool where Bytes.Element == UInt8 {
+    guard (1...63).contains(bytes.count),
+          let first = bytes.first,
+          let last = bytes.last,
+          isLowercaseAlphanumeric(first), isLowercaseAlphanumeric(last)
+    else { return false }
+    return bytes.allSatisfy { isLowercaseAlphanumeric($0) || $0 == 45 }
+}
+
+private func isLowercaseAlphanumeric(_ byte: UInt8) -> Bool {
+    (48...57).contains(byte) || (97...122).contains(byte)
 }
 
 struct PortalConfiguration: Codable, Equatable {
@@ -30,6 +167,26 @@ struct PortalConfiguration: Codable, Equatable {
         guard let destination = PortalDestination(localAppPort: localAppPort) else {
             preconditionFailure("Portal destinations require a port from 1 through 65535.")
         }
+        self.init(
+            id: id,
+            name: name,
+            destination: destination,
+            createdAt: createdAt,
+            desiredState: desiredState,
+            lifecycle: lifecycle,
+            removalAssignedName: removalAssignedName
+        )
+    }
+
+    init(
+        id: UUID,
+        name: String,
+        destination: PortalDestination,
+        createdAt: Date,
+        desiredState: PortalDesiredState = .enabled,
+        lifecycle: PortalLifecycle = .active,
+        removalAssignedName: String? = nil
+    ) {
         self.id = id
         self.name = name
         self.destination = destination
@@ -39,10 +196,10 @@ struct PortalConfiguration: Codable, Equatable {
         self.removalAssignedName = removalAssignedName
     }
 
-    var localAppPort: UInt16 {
+    var localAppPort: UInt16? {
         get { destination.localAppPort }
         set {
-            guard let destination = PortalDestination(localAppPort: newValue) else {
+            guard let newValue, let destination = PortalDestination(localAppPort: newValue) else {
                 preconditionFailure("Portal destinations require a port from 1 through 65535.")
             }
             self.destination = destination
@@ -59,7 +216,7 @@ extension PortalConfiguration {
     private enum CodingKeys: String, CodingKey {
         case id
         case name
-        case localAppPort
+        case destination
         case createdAt
         case desiredState
         case lifecycle
@@ -70,15 +227,7 @@ extension PortalConfiguration {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         id = try container.decode(UUID.self, forKey: .id)
         name = try container.decode(String.self, forKey: .name)
-        let localAppPort = try container.decode(UInt16.self, forKey: .localAppPort)
-        guard let destination = PortalDestination(localAppPort: localAppPort) else {
-            throw DecodingError.dataCorruptedError(
-                forKey: .localAppPort,
-                in: container,
-                debugDescription: "Portal destinations require a port from 1 through 65535."
-            )
-        }
-        self.destination = destination
+        destination = try container.decode(PortalDestination.self, forKey: .destination)
         createdAt = try container.decode(Date.self, forKey: .createdAt)
         desiredState = try container.contains(.desiredState)
             ? container.decode(PortalDesiredState.self, forKey: .desiredState)
@@ -93,7 +242,7 @@ extension PortalConfiguration {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(id, forKey: .id)
         try container.encode(name, forKey: .name)
-        try container.encode(destination.localAppPort, forKey: .localAppPort)
+        try container.encode(destination, forKey: .destination)
         try container.encode(createdAt, forKey: .createdAt)
         try container.encode(desiredState, forKey: .desiredState)
         try container.encode(lifecycle, forKey: .lifecycle)
@@ -142,7 +291,7 @@ enum LaunchAtLoginOfferState: String, Codable, Equatable {
 }
 
 struct InstallationRecord: Codable, Equatable {
-    static let currentVersion = 3
+    static let currentVersion = 4
 
     let version: Int
     var tailnetBinding: TailnetBinding?
@@ -171,11 +320,12 @@ struct InstallationRecord: Codable, Equatable {
 enum PortalValidationError: Error, Equatable {
     case invalidName
     case invalidPort
+    case invalidRemoteHost
 }
 
 enum PortalInputValidator {
     static func validate(name: String, port: String) throws -> UInt16 {
-        guard isValidDNSLabel(name) else {
+        guard isValidDNSLabel(name.utf8) else {
             throw PortalValidationError.invalidName
         }
         guard !port.isEmpty,
@@ -188,22 +338,4 @@ enum PortalInputValidator {
         return value
     }
 
-    private static func isValidDNSLabel(_ value: String) -> Bool {
-        guard (1...63).contains(value.utf8.count),
-              value.unicodeScalars.allSatisfy({ $0.isASCII })
-        else {
-            return false
-        }
-        let bytes = Array(value.utf8)
-        guard isLowercaseAlphanumeric(bytes[0]),
-              isLowercaseAlphanumeric(bytes[bytes.count - 1])
-        else {
-            return false
-        }
-        return bytes.allSatisfy { isLowercaseAlphanumeric($0) || $0 == 45 }
-    }
-
-    private static func isLowercaseAlphanumeric(_ byte: UInt8) -> Bool {
-        (48...57).contains(byte) || (97...122).contains(byte)
-    }
 }

--- a/Portico/PortalController.swift
+++ b/Portico/PortalController.swift
@@ -7,6 +7,13 @@ enum PortalRemovalState: Equatable {
     case failed
 }
 
+enum PortalCreationKind: String, CaseIterable, Identifiable {
+    case localApp
+    case remoteApp
+
+    var id: Self { self }
+}
+
 struct PortalRemovalNotice: Equatable, Identifiable {
     let id: UUID
     let portalName: String
@@ -21,6 +28,10 @@ final class PortalController: ObservableObject {
 
     @Published var portalName = ""
     @Published var localAppPort = ""
+    @Published var creationKind: PortalCreationKind = .localApp
+    @Published var remoteAppScheme: RemoteAppScheme = .https
+    @Published var remoteAppHost = ""
+    @Published var remoteAppPort = ""
     @Published private(set) var portals: [PortalConfiguration] = []
     @Published private(set) var statuses: [UUID: PortalStatusPayload] = [:]
     @Published private(set) var alerts: [InstallationAlert] = []
@@ -220,7 +231,7 @@ final class PortalController: ObservableObject {
     }
 
     func selectLocalApp(_ candidate: LocalAppCandidatePayload) {
-        guard localApps.contains(candidate) else { return }
+        guard creationKind == .localApp, localApps.contains(candidate) else { return }
         localAppPort = String(candidate.localAppPort)
         if portalName.isEmpty, let suggestion = candidate.suggestedPortalName {
             portalName = suggestion
@@ -233,11 +244,11 @@ final class PortalController: ObservableObject {
             message = "Choose an operational-support logging setting before adding a Portal."
             return nil
         }
-        let port: UInt16
+        let destination: PortalDestination
         do {
-            port = try PortalInputValidator.validate(name: portalName, port: localAppPort)
+            destination = try newPortalDestination()
         } catch let error as PortalValidationError {
-            message = "Enter a lower-case DNS label and a port from 1 through 65535."
+            message = "Enter a lower-case DNS label and valid destination details."
             return error
         } catch {
             return nil
@@ -245,7 +256,7 @@ final class PortalController: ObservableObject {
         let configuration = PortalConfiguration(
             id: uuidProvider(),
             name: portalName,
-            localAppPort: port,
+            destination: destination,
             createdAt: dateProvider()
         )
         var updated = installation
@@ -257,6 +268,8 @@ final class PortalController: ObservableObject {
             message = nil
             portalName = ""
             localAppPort = ""
+            remoteAppHost = ""
+            remoteAppPort = ""
             discoveryGeneration += 1
             localApps = []
             isRefreshingLocalApps = false
@@ -342,7 +355,8 @@ final class PortalController: ObservableObject {
             message = "Enter a port from 1 through 65535."
             return
         }
-        guard installation.portals[index].destination.localAppPort != localAppPort,
+        guard installation.portals[index].destination.localAppPort != nil,
+              installation.portals[index].destination.localAppPort != localAppPort,
               let destination = PortalDestination(localAppPort: localAppPort)
         else { return }
         var updated = installation
@@ -404,12 +418,9 @@ final class PortalController: ObservableObject {
         for portal: PortalConfiguration? = nil,
         editedPort: String? = nil
     ) -> PortalActionAvailability {
-        let addInputsValid = portal == nil && (try? PortalInputValidator.validate(
-            name: portalName,
-            port: localAppPort
-        )) != nil
+        let addInputsValid = portal == nil && (try? newPortalDestination()) != nil
         let editedPortValid: Bool
-        if let portal, let editedPort, editedPort != String(portal.localAppPort),
+        if let portal, let localPort = portal.localAppPort, let editedPort, editedPort != String(localPort),
            let parsed = try? PortalInputValidator.validate(name: portal.name, port: editedPort) {
             editedPortValid = parsed > 0
         } else {
@@ -432,6 +443,23 @@ final class PortalController: ObservableObject {
             isEditedPortValid: editedPortValid,
             isRefreshingLocalApps: isRefreshingLocalApps
         ))
+    }
+
+    private func newPortalDestination() throws -> PortalDestination {
+        switch creationKind {
+        case .localApp:
+            let port = try PortalInputValidator.validate(name: portalName, port: localAppPort)
+            guard let destination = PortalDestination(localAppPort: port) else { throw PortalValidationError.invalidPort }
+            return destination
+        case .remoteApp:
+            let port = try PortalInputValidator.validate(name: portalName, port: remoteAppPort)
+            guard let destination = PortalDestination(
+                remoteAppScheme: remoteAppScheme,
+                host: remoteAppHost,
+                port: port
+            ) else { throw PortalValidationError.invalidRemoteHost }
+            return destination
+        }
     }
 
     func copyPortalURL(id: UUID) {

--- a/Portico/PortalStore.swift
+++ b/Portico/PortalStore.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum PortalStoreError: Error {
     case alreadyExists
+    case invalidHistoricalDestination
     case unsupportedVersion(Int)
 }
 
@@ -26,6 +27,10 @@ struct PortalStore {
     }
 
     var installationURL: URL {
+        rootURL.appendingPathComponent("installation-v4.json", isDirectory: false)
+    }
+
+    var versionThreeInstallationURL: URL {
         rootURL.appendingPathComponent("installation-v3.json", isDirectory: false)
     }
 
@@ -56,13 +61,24 @@ struct PortalStore {
             removeOlderFiles()
             return installation
         }
+        if FileManager.default.fileExists(atPath: versionThreeInstallationURL.path) {
+            let data = try Data(contentsOf: versionThreeInstallationURL)
+            let historical = try JSONDecoder().decode(VersionThreeInstallationRecord.self, from: data)
+            guard historical.version == VersionThreeInstallationRecord.currentVersion else {
+                throw PortalStoreError.unsupportedVersion(historical.version)
+            }
+            let installation = try historical.migrate()
+            try save(installation)
+            removeOlderFiles()
+            return installation
+        }
         if FileManager.default.fileExists(atPath: versionTwoInstallationURL.path) {
             let data = try Data(contentsOf: versionTwoInstallationURL)
             let historical = try JSONDecoder().decode(VersionTwoInstallationRecord.self, from: data)
             guard historical.version == VersionTwoInstallationRecord.currentVersion else {
                 throw PortalStoreError.unsupportedVersion(historical.version)
             }
-            let installation = historical.migrated
+            let installation = try historical.migrate()
             try save(installation)
             removeOlderFiles()
             return installation
@@ -76,7 +92,7 @@ struct PortalStore {
             throw PortalStoreError.unsupportedVersion(envelope.version)
         }
         let installation = InstallationRecord(
-            portals: [envelope.portal.migrated],
+            portals: [try envelope.portal.migrate()],
             operationalLogging: .enabled,
             launchAtLoginOffer: .notOffered
         )
@@ -97,34 +113,35 @@ struct PortalStore {
     }
 
     private func removeOlderFiles() {
-        for url in [versionTwoInstallationURL, legacyConfigurationURL]
+        for url in [versionThreeInstallationURL, versionTwoInstallationURL, legacyConfigurationURL]
         where FileManager.default.fileExists(atPath: url.path) {
             try? FileManager.default.removeItem(at: url)
         }
     }
 }
 
-private struct VersionTwoInstallationRecord: Decodable {
-    static let currentVersion = 2
+private struct VersionThreeInstallationRecord: Decodable {
+    static let currentVersion = 3
 
     let version: Int
     let tailnetBinding: TailnetBinding?
-    let portals: [VersionTwoPortalConfiguration]
+    let portals: [HistoricalLocalAppPortalConfiguration]
     let alerts: [InstallationAlert]
+    let operationalLogging: OperationalLoggingPreference
+    let launchAtLoginOffer: LaunchAtLoginOfferState
 
-    var migrated: InstallationRecord {
-        let isPristine = tailnetBinding == nil && portals.isEmpty && alerts.isEmpty
-        return InstallationRecord(
+    func migrate() throws -> InstallationRecord {
+        InstallationRecord(
             tailnetBinding: tailnetBinding,
-            portals: portals.map(\.migrated),
+            portals: try portals.map { try $0.migrate() },
             alerts: alerts,
-            operationalLogging: isPristine ? .undecided : .enabled,
-            launchAtLoginOffer: .notOffered
+            operationalLogging: operationalLogging,
+            launchAtLoginOffer: launchAtLoginOffer
         )
     }
 }
 
-private struct VersionTwoPortalConfiguration: Decodable {
+private struct HistoricalLocalAppPortalConfiguration: Decodable {
     let id: UUID
     let name: String
     let localAppPort: UInt16
@@ -158,15 +175,38 @@ private struct VersionTwoPortalConfiguration: Decodable {
             : nil
     }
 
-    var migrated: PortalConfiguration {
-        PortalConfiguration(
+    func migrate() throws -> PortalConfiguration {
+        guard let destination = PortalDestination(localAppPort: localAppPort) else {
+            throw PortalStoreError.invalidHistoricalDestination
+        }
+        return PortalConfiguration(
             id: id,
             name: name,
-            localAppPort: localAppPort,
+            destination: destination,
             createdAt: createdAt,
             desiredState: desiredState,
             lifecycle: lifecycle,
             removalAssignedName: removalAssignedName
+        )
+    }
+}
+
+private struct VersionTwoInstallationRecord: Decodable {
+    static let currentVersion = 2
+
+    let version: Int
+    let tailnetBinding: TailnetBinding?
+    let portals: [HistoricalLocalAppPortalConfiguration]
+    let alerts: [InstallationAlert]
+
+    func migrate() throws -> InstallationRecord {
+        let isPristine = tailnetBinding == nil && portals.isEmpty && alerts.isEmpty
+        return InstallationRecord(
+            tailnetBinding: tailnetBinding,
+            portals: try portals.map { try $0.migrate() },
+            alerts: alerts,
+            operationalLogging: isPristine ? .undecided : .enabled,
+            launchAtLoginOffer: .notOffered
         )
     }
 }
@@ -184,11 +224,14 @@ private struct LegacyPortalConfiguration: Decodable {
     let localAppPort: UInt16
     let createdAt: Date
 
-    var migrated: PortalConfiguration {
-        PortalConfiguration(
+    func migrate() throws -> PortalConfiguration {
+        guard let destination = PortalDestination(localAppPort: localAppPort) else {
+            throw PortalStoreError.invalidHistoricalDestination
+        }
+        return PortalConfiguration(
             id: id,
             name: name,
-            localAppPort: localAppPort,
+            destination: destination,
             createdAt: createdAt,
             lifecycle: .active
         )

--- a/Portico/PorticoApp.swift
+++ b/Portico/PorticoApp.swift
@@ -54,6 +54,8 @@ private struct PortalView: View {
     private enum AccessibilityFocusTarget: Hashable {
         case portalNameField
         case localAppPortField
+        case remoteAppHostField
+        case remoteAppPortField
         case portal(UUID)
         case removalNotice(UUID)
     }
@@ -267,11 +269,34 @@ private struct PortalView: View {
                 .focused($inputFocus, equals: .portalNameField)
                 .accessibilityFocused($accessibilityFocus, equals: .portalNameField)
                 .onSubmit { validateNameAndAdvance() }
-            TextField("Local App Port", text: $controller.localAppPort)
-                .accessibilityIdentifier("local-app-port-field")
-                .focused($inputFocus, equals: .localAppPortField)
-                .accessibilityFocused($accessibilityFocus, equals: .localAppPortField)
-                .onSubmit { submitPortal() }
+            Picker("Destination", selection: $controller.creationKind) {
+                Text("Local App").tag(PortalCreationKind.localApp)
+                Text("Remote App").tag(PortalCreationKind.remoteApp)
+            }
+            .pickerStyle(.segmented)
+            .accessibilityIdentifier("destination-kind")
+            if controller.creationKind == .localApp {
+                TextField("Local App Port", text: $controller.localAppPort)
+                    .accessibilityIdentifier("local-app-port-field")
+                    .focused($inputFocus, equals: .localAppPortField)
+                    .accessibilityFocused($accessibilityFocus, equals: .localAppPortField)
+                    .onSubmit { submitPortal() }
+            } else {
+                Picker("Scheme", selection: $controller.remoteAppScheme) {
+                    Text("HTTP").tag(RemoteAppScheme.http)
+                    Text("HTTPS").tag(RemoteAppScheme.https)
+                }
+                .accessibilityIdentifier("remote-app-scheme")
+                TextField("Remote App Host", text: $controller.remoteAppHost)
+                    .accessibilityIdentifier("remote-app-host-field")
+                    .focused($inputFocus, equals: .remoteAppHostField)
+                    .accessibilityFocused($accessibilityFocus, equals: .remoteAppHostField)
+                TextField("Remote App Port", text: $controller.remoteAppPort)
+                    .accessibilityIdentifier("remote-app-port-field")
+                    .focused($inputFocus, equals: .remoteAppPortField)
+                    .accessibilityFocused($accessibilityFocus, equals: .remoteAppPortField)
+                    .onSubmit { submitPortal() }
+            }
             Button("Add Portal") { submitPortal() }
                 .buttonStyle(.borderedProminent)
                 .disabled(!controller.actionAvailability().addPortal)
@@ -281,8 +306,11 @@ private struct PortalView: View {
     private func validateNameAndAdvance() {
         do {
             _ = try PortalInputValidator.validate(name: controller.portalName, port: "1")
-            inputFocus = .localAppPortField
-            accessibilityFocus = .localAppPortField
+            let target: AccessibilityFocusTarget = controller.creationKind == .localApp
+                ? .localAppPortField
+                : .remoteAppHostField
+            inputFocus = target
+            accessibilityFocus = target
         } catch {
             inputFocus = .portalNameField
             accessibilityFocus = .portalNameField
@@ -295,8 +323,14 @@ private struct PortalView: View {
             inputFocus = .portalNameField
             accessibilityFocus = .portalNameField
         case .invalidPort:
-            inputFocus = .localAppPortField
-            accessibilityFocus = .localAppPortField
+            let target: AccessibilityFocusTarget = controller.creationKind == .localApp
+                ? .localAppPortField
+                : .remoteAppPortField
+            inputFocus = target
+            accessibilityFocus = target
+        case .invalidRemoteHost:
+            inputFocus = .remoteAppHostField
+            accessibilityFocus = .remoteAppHostField
         case nil:
             break
         }
@@ -385,7 +419,7 @@ private struct PortalStatusView: View {
         self.controller = controller
         self.portal = portal
         self.onRemove = onRemove
-        _localAppPort = State(initialValue: String(portal.localAppPort))
+        _localAppPort = State(initialValue: portal.localAppPort.map(String.init) ?? "")
     }
 
     var body: some View {
@@ -413,8 +447,10 @@ private struct PortalStatusView: View {
             .accessibilityIdentifier("desired-state")
         LabeledContent("Tailscale", value: presentation.tailscaleState)
             .accessibilityIdentifier("tailscale-state")
-        LabeledContent("Local App", value: presentation.localAppReachability)
-            .accessibilityIdentifier("local-app-state")
+        if portal.localAppPort != nil {
+            LabeledContent("Local App", value: presentation.localAppReachability)
+                .accessibilityIdentifier("local-app-state")
+        }
         if let status = controller.statuses[portal.id] {
             if let portalURL = status.portalURL {
                 LabeledContent(
@@ -442,16 +478,21 @@ private struct PortalStatusView: View {
             }
         }
         HStack {
-            Text("Local App Port")
-            Spacer()
-            TextField("Local App Port", text: $localAppPort)
-                .frame(width: 80)
-                .onSubmit(updatePort)
-                .accessibilityIdentifier("edit-local-app-port")
-            Button("Update") { updatePort() }
-                .controlSize(.small)
-                .disabled(!editedPortActions.editPort)
-                .accessibilityIdentifier("update-local-app-port")
+            if portal.localAppPort != nil {
+                Text("Local App Port")
+                Spacer()
+                TextField("Local App Port", text: $localAppPort)
+                    .frame(width: 80)
+                    .onSubmit(updatePort)
+                    .accessibilityIdentifier("edit-local-app-port")
+                Button("Update") { updatePort() }
+                    .controlSize(.small)
+                    .disabled(!editedPortActions.editPort)
+                    .accessibilityIdentifier("update-local-app-port")
+            } else {
+                Text("Remote App")
+                Spacer()
+            }
             Button(portal.desiredState == .enabled ? "Stop" : "Start") {
                 if portal.desiredState == .enabled {
                     controller.stopPortal(id: portal.id)

--- a/PorticoTests/HelperProtocolTests.swift
+++ b/PorticoTests/HelperProtocolTests.swift
@@ -2,9 +2,9 @@ import XCTest
 @testable import Portico
 
 final class HelperProtocolTests: XCTestCase {
-    func testVersionThreeReconciliationFixturesRoundTrip() throws {
-        let requestFixture = #"{"version":3,"requestId":"reconcile-1","command":"reconcilePortals","payload":{"portals":[{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","portalName":"hermes","localAppPort":8787,"desiredState":"enabled"},{"portalId":"5EA74329-3144-4BA2-925F-138D14D61FCC","portalName":"atlas","localAppPort":8788,"desiredState":"stopped"}]}}"#
-        let responseFixture = #"{"version":3,"requestId":"reconcile-1","result":{"entries":[{"portalId":"5EA74329-3144-4BA2-925F-138D14D61FCC","outcome":"converged"},{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","outcome":"startFailed"}]}}"#
+    func testVersionFourReconciliationFixturesRoundTrip() throws {
+        let requestFixture = #"{"version":4,"requestId":"reconcile-1","command":"reconcilePortals","payload":{"portals":[{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","portalName":"hermes","destination":{"kind":"localApp","port":8787},"desiredState":"enabled"},{"portalId":"5EA74329-3144-4BA2-925F-138D14D61FCC","portalName":"atlas","destination":{"kind":"remoteApp","scheme":"https","host":"app.example.com","port":443},"desiredState":"stopped"}]}}"#
+        let responseFixture = #"{"version":4,"requestId":"reconcile-1","result":{"entries":[{"portalId":"5EA74329-3144-4BA2-925F-138D14D61FCC","outcome":"converged"},{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","outcome":"startFailed"}]}}"#
 
         try assertRoundTrip(requestFixture, as: HelperRequest<ReconcilePortalsPayload>.self)
         let response = try JSONDecoder().decode(
@@ -28,43 +28,43 @@ final class HelperProtocolTests: XCTestCase {
         try assertRoundTrip(responseFixture, as: HelperResponse<ReconcilePortalsResult>.self)
     }
 
-    func testDecodesVersionThreeHandshakeResponse() throws {
-        let fixture = Data(#"{"version":3,"requestId":"request-1","result":{"protocolVersion":3}}"#.utf8)
+    func testDecodesVersionFourHandshakeResponse() throws {
+        let fixture = Data(#"{"version":4,"requestId":"request-1","result":{"protocolVersion":4}}"#.utf8)
 
         let response = try JSONDecoder().decode(HelperResponse<HandshakeResult>.self, from: fixture)
 
-        XCTAssertEqual(response.version, 3)
+        XCTAssertEqual(response.version, 4)
         XCTAssertEqual(response.requestId, "request-1")
-        XCTAssertEqual(response.result?.protocolVersion, 3)
+        XCTAssertEqual(response.result?.protocolVersion, 4)
         XCTAssertNil(response.error)
     }
 
     func testDecodesStructuredProtocolError() throws {
-        let fixture = Data(#"{"version":3,"requestId":"request-2","error":{"code":"unknownCommand","message":"unsupported command"}}"#.utf8)
+        let fixture = Data(#"{"version":4,"requestId":"request-2","error":{"code":"unknownCommand","message":"unsupported command"}}"#.utf8)
 
         let response = try JSONDecoder().decode(HelperResponse<HandshakeResult>.self, from: fixture)
 
-        XCTAssertEqual(response.version, 3)
+        XCTAssertEqual(response.version, 4)
         XCTAssertEqual(response.requestId, "request-2")
         XCTAssertNil(response.result)
         XCTAssertEqual(response.error, HelperProtocolError(code: "unknownCommand", message: "unsupported command"))
     }
 
-    func testVersionThreePortalFixturesRoundTrip() throws {
+    func testVersionFourPortalFixturesRoundTrip() throws {
         let portalID = UUID(uuidString: "9f55ca93-d7b3-4eab-a871-310ea576005a")!
         try assertRoundTrip(
-            #"{"version":3,"requestId":"auth-1","command":"authenticatePortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A"}}"#,
+            #"{"version":4,"requestId":"auth-1","command":"authenticatePortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A"}}"#,
             as: HelperRequest<AuthenticatePortalPayload>.self
         )
         try assertRoundTrip(
-            #"{"version":3,"requestId":"cleanup-1","command":"cleanupRejectedPortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A"}}"#,
+            #"{"version":4,"requestId":"cleanup-1","command":"cleanupRejectedPortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A"}}"#,
             as: HelperRequest<CleanupRejectedPortalPayload>.self
         )
         try assertRoundTrip(
-            #"{"version":3,"requestId":"remove-1","command":"removePortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A"}}"#,
+            #"{"version":4,"requestId":"remove-1","command":"removePortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A"}}"#,
             as: HelperRequest<RemovePortalPayload>.self
         )
-        let statusFixture = #"{"version":3,"event":"portalStatus","portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","payload":{"state":"online","stableNodeId":"node-1","assignedName":"hermes-1","portalURL":"https:\/\/hermes-1.example.ts.net\/","addresses":["100.64.0.1","fd7a:115c:a1e0::1"],"tailnetName":"opaque-identity-do-not-display","magicDNSSuffix":"example.ts.net"}}"#
+        let statusFixture = #"{"version":4,"event":"portalStatus","portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","payload":{"state":"online","stableNodeId":"node-1","assignedName":"hermes-1","portalURL":"https:\/\/hermes-1.example.ts.net\/","addresses":["100.64.0.1","fd7a:115c:a1e0::1"],"tailnetName":"opaque-identity-do-not-display","magicDNSSuffix":"example.ts.net"}}"#
         let status = try JSONDecoder().decode(HelperEvent<PortalStatusPayload>.self, from: Data(statusFixture.utf8))
         XCTAssertEqual(status.portalId, portalID)
         XCTAssertEqual(status.payload.state, .online)
@@ -73,12 +73,12 @@ final class HelperProtocolTests: XCTestCase {
         XCTAssertEqual(status.payload.magicDNSSuffix, "example.ts.net")
         try assertRoundTrip(statusFixture, as: HelperEvent<PortalStatusPayload>.self)
 
-        let authenticationFixture = #"{"version":3,"event":"authenticationURL","portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","payload":{"url":"https:\/\/login.tailscale.com\/a\/secret"}}"#
+        let authenticationFixture = #"{"version":4,"event":"authenticationURL","portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","payload":{"url":"https:\/\/login.tailscale.com\/a\/secret"}}"#
         try assertRoundTrip(authenticationFixture, as: HelperEvent<AuthenticationURLPayload>.self)
     }
 
-    func testDecodesVersionThreeDiscoverLocalAppsResult() throws {
-        let fixture = Data(#"{"version":3,"requestId":"discover-1","result":{"candidates":[{"localAppPort":3000,"processLabel":"node","suggestedPortalName":"hermes"},{"localAppPort":8787,"processLabel":"python3"}]}}"#.utf8)
+    func testDecodesVersionFourDiscoverLocalAppsResult() throws {
+        let fixture = Data(#"{"version":4,"requestId":"discover-1","result":{"candidates":[{"localAppPort":3000,"processLabel":"node","suggestedPortalName":"hermes"},{"localAppPort":8787,"processLabel":"python3"}]}}"#.utf8)
 
         let response = try JSONDecoder().decode(HelperResponse<DiscoverLocalAppsResult>.self, from: fixture)
 

--- a/PorticoTests/HelperShutdownTests.swift
+++ b/PorticoTests/HelperShutdownTests.swift
@@ -15,7 +15,7 @@ final class HelperShutdownTests: XCTestCase {
             shutdownGraceInterval: 1
         )
         supervisor.start(loggingPreference: .enabled)
-        launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
+        launcher.receive(line: #"{"version":4,"requestId":"handshake-1","result":{"protocolVersion":4}}"#)
         var completionCount = 0
 
         supervisor.shutdown { completionCount += 1 }
@@ -28,7 +28,7 @@ final class HelperShutdownTests: XCTestCase {
         XCTAssertEqual(request.requestId, "shutdown-1")
         XCTAssertEqual(request.command, .shutdown)
 
-        launcher.receive(line: #"{"version":3,"requestId":"shutdown-1","result":{"accepted":true}}"#)
+        launcher.receive(line: #"{"version":4,"requestId":"shutdown-1","result":{"accepted":true}}"#)
         XCTAssertEqual(completionCount, 0)
         launcher.exit(status: 0)
 
@@ -47,7 +47,7 @@ final class HelperShutdownTests: XCTestCase {
             shutdownGraceInterval: 0.01
         )
         supervisor.start(loggingPreference: .enabled)
-        launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
+        launcher.receive(line: #"{"version":4,"requestId":"handshake-1","result":{"protocolVersion":4}}"#)
         var completionCount = 0
 
         supervisor.shutdown { completionCount += 1 }
@@ -84,7 +84,7 @@ final class HelperShutdownTests: XCTestCase {
             shutdownGraceInterval: 1
         )
         supervisor.start(loggingPreference: .enabled)
-        launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
+        launcher.receive(line: #"{"version":4,"requestId":"handshake-1","result":{"protocolVersion":4}}"#)
         var completionCount = 0
 
         supervisor.shutdown { completionCount += 1 }

--- a/PorticoTests/HelperSupervisorTests.swift
+++ b/PorticoTests/HelperSupervisorTests.swift
@@ -29,7 +29,7 @@ final class HelperSupervisorTests: XCTestCase {
             handshakeTimeout: 60
         )
         supervisor.start(loggingPreference: .enabled)
-        launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
+        launcher.receive(line: #"{"version":4,"requestId":"handshake-1","result":{"protocolVersion":4}}"#)
 
         supervisor.restart(loggingPreference: .disabled)
 
@@ -47,7 +47,7 @@ final class HelperSupervisorTests: XCTestCase {
         XCTAssertEqual(launcher.processes.count, 2)
         XCTAssertEqual(launcher.loggingPreferences, [.enabled, .disabled])
         XCTAssertEqual(launcher.processes.filter(\.isRunning).count, 1)
-        launcher.receive(line: #"{"version":3,"requestId":"handshake-2","result":{"protocolVersion":3}}"#)
+        launcher.receive(line: #"{"version":4,"requestId":"handshake-2","result":{"protocolVersion":4}}"#)
         XCTAssertEqual(supervisor.availability, .connected)
     }
 
@@ -64,7 +64,7 @@ final class HelperSupervisorTests: XCTestCase {
             shutdownGraceInterval: 1
         )
         supervisor.start(loggingPreference: .enabled)
-        launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
+        launcher.receive(line: #"{"version":4,"requestId":"handshake-1","result":{"protocolVersion":4}}"#)
 
         supervisor.restart(loggingPreference: .disabled)
         scheduler.run(delay: 1)
@@ -90,10 +90,10 @@ final class HelperSupervisorTests: XCTestCase {
         var events: [PortalHelperEvent] = []
         supervisor.onEvent = { events.append($0) }
         supervisor.start(loggingPreference: .enabled)
-        launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
+        launcher.receive(line: #"{"version":4,"requestId":"handshake-1","result":{"protocolVersion":4}}"#)
 
         supervisor.restart(loggingPreference: .disabled)
-        launcher.receive(line: #"{"version":3,"event":"portalStatus","portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","payload":{"state":"online","addresses":[]}}"#)
+        launcher.receive(line: #"{"version":4,"event":"portalStatus","portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","payload":{"state":"online","addresses":[]}}"#)
         XCTAssertTrue(events.isEmpty)
         launcher.exit(status: 0)
         launcher.exit(status: 1)
@@ -157,18 +157,18 @@ final class HelperSupervisorTests: XCTestCase {
         supervisor.start(loggingPreference: .enabled)
         launcher.exit(status: 1)
         scheduler.runNext()
-        launcher.receive(line: #"{"version":3,"requestId":"handshake-2","result":{"protocolVersion":3}}"#)
+        launcher.receive(line: #"{"version":4,"requestId":"handshake-2","result":{"protocolVersion":4}}"#)
         supervisor.reconcilePortals([]) { _ in }
-        launcher.receive(line: #"{"version":3,"requestId":"reconcile-2","result":{"entries":[]}}"#)
+        launcher.receive(line: #"{"version":4,"requestId":"reconcile-2","result":{"entries":[]}}"#)
 
         XCTAssertTrue(scheduler.pendingDelays.contains(300))
         launcher.exit(status: 1)
         XCTAssertEqual(supervisor.availability, .retrying(attempt: 2, delay: 2))
 
         scheduler.run(delay: 2)
-        launcher.receive(line: #"{"version":3,"requestId":"handshake-3","result":{"protocolVersion":3}}"#)
+        launcher.receive(line: #"{"version":4,"requestId":"handshake-3","result":{"protocolVersion":4}}"#)
         supervisor.reconcilePortals([]) { _ in }
-        launcher.receive(line: #"{"version":3,"requestId":"reconcile-3","result":{"entries":[]}}"#)
+        launcher.receive(line: #"{"version":4,"requestId":"reconcile-3","result":{"entries":[]}}"#)
         scheduler.run(delay: 300)
         launcher.exit(status: 1)
 
@@ -189,14 +189,14 @@ final class HelperSupervisorTests: XCTestCase {
         XCTAssertEqual(supervisor.availability, .connecting)
         let requestData = try XCTUnwrap(launcher.process.sent.first)
         let request = try JSONDecoder().decode(HelperRequest<EmptyPayload>.self, from: requestData)
-        XCTAssertEqual(request.version, 3)
+        XCTAssertEqual(request.version, 4)
         XCTAssertEqual(request.requestId, "request-1")
         XCTAssertEqual(request.command, .handshake)
 
-        launcher.receive(line: #"{"version":3,"requestId":"other","result":{"protocolVersion":3}}"#)
+        launcher.receive(line: #"{"version":4,"requestId":"other","result":{"protocolVersion":4}}"#)
         XCTAssertEqual(supervisor.availability, .connecting)
 
-        launcher.receive(line: #"{"version":3,"requestId":"request-1","result":{"protocolVersion":3}}"#)
+        launcher.receive(line: #"{"version":4,"requestId":"request-1","result":{"protocolVersion":4}}"#)
         XCTAssertEqual(supervisor.availability, .connected)
     }
 
@@ -221,8 +221,8 @@ final class HelperSupervisorTests: XCTestCase {
     func testHandshakeFailuresEnterSharedRecoveryBudgetAfterChildExit() {
         let failures: [(String, Bool, (FakeHelperLauncher) -> Void)] = [
             ("malformed line", false, { $0.receive(line: "{") }),
-            ("correlated error", false, { $0.receive(line: #"{"version":3,"requestId":"request-1","error":{"code":"unsupportedVersion","message":"unsupported protocol version"}}"#) }),
-            ("unsupported response version", false, { $0.receive(line: #"{"version":1,"requestId":"request-1","result":{"protocolVersion":1}}"#) }),
+            ("correlated error", false, { $0.receive(line: #"{"version":4,"requestId":"request-1","error":{"code":"unsupportedVersion","message":"unsupported protocol version"}}"#) }),
+            ("unsupported response version", false, { $0.receive(line: #"{"version":5,"requestId":"request-1","result":{"protocolVersion":5}}"#) }),
             ("EOF", false, { $0.receiveEOF() }),
             ("nonzero exit", true, { $0.exit(status: 1) }),
         ]
@@ -263,7 +263,7 @@ final class HelperSupervisorTests: XCTestCase {
         supervisor.onEvent = { events.append($0) }
         supervisor.start(loggingPreference: .enabled)
         XCTAssertEqual(launcher.arguments, ["--state-root", "/trusted/tsnet"])
-        launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
+        launcher.receive(line: #"{"version":4,"requestId":"handshake-1","result":{"protocolVersion":4}}"#)
         let laterPortal = PortalConfiguration(
             id: UUID(uuidString: "9f55ca93-d7b3-4eab-a871-310ea576005a")!,
             name: "hermes",
@@ -291,21 +291,21 @@ final class HelperSupervisorTests: XCTestCase {
                 ReconcilePortalPayload(
                     portalId: earlierPortal.id,
                     portalName: "atlas",
-                    localAppPort: 8788,
+                    destination: .localApp(port: 8788),
                     desiredState: .stopped
                 ),
                 ReconcilePortalPayload(
                     portalId: laterPortal.id,
                     portalName: "hermes",
-                    localAppPort: 8787,
+                    destination: .localApp(port: 8787),
                     desiredState: .enabled
                 ),
             ]
         )
-        launcher.receive(line: #"{"version":3,"event":"portalStatus","portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","payload":{"state":"connecting","addresses":[]}}"#)
+        launcher.receive(line: #"{"version":4,"event":"portalStatus","portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","payload":{"state":"connecting","addresses":[]}}"#)
         XCTAssertEqual(events, [.status(laterPortal.id, PortalStatusPayload(state: .connecting, stableNodeId: nil, assignedName: nil, portalURL: nil, addresses: []))])
         XCTAssertNil(result)
-        launcher.receive(line: #"{"version":3,"requestId":"reconcile-1","result":{"entries":[{"portalId":"5EA74329-3144-4BA2-925F-138D14D61FCC","outcome":"converged"},{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","outcome":"startFailed"}]}}"#)
+        launcher.receive(line: #"{"version":4,"requestId":"reconcile-1","result":{"entries":[{"portalId":"5EA74329-3144-4BA2-925F-138D14D61FCC","outcome":"converged"},{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","outcome":"startFailed"}]}}"#)
         XCTAssertEqual(
             try result?.get().entries,
             [
@@ -325,7 +325,7 @@ final class HelperSupervisorTests: XCTestCase {
             handshakeTimeout: 1
         )
         supervisor.start(loggingPreference: .enabled)
-        launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
+        launcher.receive(line: #"{"version":4,"requestId":"handshake-1","result":{"protocolVersion":4}}"#)
         var result: Result<ReconcilePortalsResult, Error>?
 
         supervisor.reconcilePortals([]) { result = $0 }
@@ -346,7 +346,7 @@ final class HelperSupervisorTests: XCTestCase {
             handshakeTimeout: 1
         )
         supervisor.start(loggingPreference: .enabled)
-        launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
+        launcher.receive(line: #"{"version":4,"requestId":"handshake-1","result":{"protocolVersion":4}}"#)
         var result: Result<[LocalAppCandidatePayload], Error>?
 
         supervisor.discoverLocalApps { result = $0 }
@@ -355,7 +355,7 @@ final class HelperSupervisorTests: XCTestCase {
         let request = try JSONDecoder().decode(HelperRequest<EmptyPayload>.self, from: requestData)
         XCTAssertEqual(request.command, .discoverLocalApps)
         XCTAssertEqual(request.requestId, "discover-1")
-        launcher.receive(line: #"{"version":3,"requestId":"discover-1","result":{"candidates":[{"localAppPort":3000,"processLabel":"node","suggestedPortalName":"hermes"}]}}"#)
+        launcher.receive(line: #"{"version":4,"requestId":"discover-1","result":{"candidates":[{"localAppPort":3000,"processLabel":"node","suggestedPortalName":"hermes"}]}}"#)
         XCTAssertEqual(
             try result?.get(),
             [LocalAppCandidatePayload(localAppPort: 3000, processLabel: "node", suggestedPortalName: "hermes")]
@@ -372,7 +372,7 @@ final class HelperSupervisorTests: XCTestCase {
             handshakeTimeout: 1
         )
         supervisor.start(loggingPreference: .enabled)
-        launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
+        launcher.receive(line: #"{"version":4,"requestId":"handshake-1","result":{"protocolVersion":4}}"#)
         let portalID = UUID(uuidString: "9f55ca93-d7b3-4eab-a871-310ea576005a")!
         var result: Result<Void, Error>?
 
@@ -383,7 +383,7 @@ final class HelperSupervisorTests: XCTestCase {
         XCTAssertEqual(request.command, .cleanupRejectedPortal)
         XCTAssertEqual(request.payload.portalId, portalID)
         XCTAssertNil(result)
-        launcher.receive(line: #"{"version":3,"requestId":"cleanup-1","result":{"accepted":true}}"#)
+        launcher.receive(line: #"{"version":4,"requestId":"cleanup-1","result":{"accepted":true}}"#)
         XCTAssertNoThrow(try result?.get())
     }
 
@@ -397,7 +397,7 @@ final class HelperSupervisorTests: XCTestCase {
             handshakeTimeout: 1
         )
         supervisor.start(loggingPreference: .enabled)
-        launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
+        launcher.receive(line: #"{"version":4,"requestId":"handshake-1","result":{"protocolVersion":4}}"#)
         let portalID = UUID(uuidString: "9f55ca93-d7b3-4eab-a871-310ea576005a")!
         var result: Result<Void, Error>?
 
@@ -408,7 +408,7 @@ final class HelperSupervisorTests: XCTestCase {
         XCTAssertEqual(request.command, .removePortal)
         XCTAssertEqual(request.payload, RemovePortalPayload(portalId: portalID))
         XCTAssertEqual(try JSONSerialization.jsonObject(with: requestData) as? NSDictionary, [
-            "version": 3,
+            "version": 4,
             "requestId": "remove-1",
             "command": "removePortal",
             "payload": ["portalId": portalID.uuidString],
@@ -432,11 +432,11 @@ final class HelperSupervisorTests: XCTestCase {
             handshakeTimeout: 1
         )
         supervisor.start(loggingPreference: .enabled)
-        launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
+        launcher.receive(line: #"{"version":4,"requestId":"handshake-1","result":{"protocolVersion":4}}"#)
         var result: Result<[LocalAppCandidatePayload], Error>?
 
         supervisor.discoverLocalApps { result = $0 }
-        launcher.receive(line: #"{"version":3,"requestId":"discover-1","error":{"code":"discoveryFailure","message":"local app discovery failed"}}"#)
+        launcher.receive(line: #"{"version":4,"requestId":"discover-1","error":{"code":"discoveryFailure","message":"local app discovery failed"}}"#)
 
         guard case let .failure(HelperClientError.helper(error)) = result else {
             return XCTFail("expected fixed helper discovery failure")

--- a/PorticoTests/LocalAppReachabilityTests.swift
+++ b/PorticoTests/LocalAppReachabilityTests.swift
@@ -61,6 +61,22 @@ final class LocalAppReachabilityTests: XCTestCase {
         XCTAssertEqual(monitor.states[stopped.id], .unavailable)
     }
 
+    func testRemoteAppsAreExcludedFromLocalAppReachability() {
+        let probe = FakeLocalAppProbe()
+        let monitor = LocalAppReachability(probe: probe, scheduler: FakePorticoScheduler())
+        let remote = PortalConfiguration(
+            id: UUID(uuidString: "11111111-1111-1111-1111-111111111111")!,
+            name: "remote",
+            destination: PortalDestination(remoteAppScheme: .https, host: "app.example.com", port: 443)!,
+            createdAt: Date()
+        )
+
+        monitor.update(portals: [remote])
+
+        XCTAssertTrue(probe.requests.isEmpty)
+        XCTAssertTrue(monitor.states.isEmpty)
+    }
+
     private func portal(
         id: String,
         port: UInt16,

--- a/PorticoTests/PortalConfigurationTests.swift
+++ b/PorticoTests/PortalConfigurationTests.swift
@@ -2,16 +2,37 @@ import XCTest
 @testable import Portico
 
 final class PortalConfigurationTests: XCTestCase {
+    func testRemoteAppDestinationCanonicalizesAndRejectsLoopback() throws {
+        XCTAssertEqual(
+            try XCTUnwrap(PortalDestination(remoteAppScheme: .https, host: "App.Example.COM", port: 443)),
+            .remoteApp(scheme: .https, host: "app.example.com", port: 443)
+        )
+        for host in ["localhost", "127.0.0.1", "[::1]", "::1", "::ffff:127.0.0.1", "0.0.0.0", "::", "example.com."] {
+            XCTAssertNil(PortalDestination(remoteAppScheme: .https, host: host, port: 443), host)
+        }
+    }
+
+    func testDestinationRejectsMissingExtraAndCrossKindJSONMembers() throws {
+        for json in [
+            #"{"kind":"localApp"}"#,
+            #"{"kind":"localApp","port":80,"host":"example.com"}"#,
+            #"{"kind":"remoteApp","scheme":"https","host":"example.com","port":443,"extra":true}"#,
+            #"{"kind":"remoteApp","scheme":"https","host":"example.com"}"#,
+        ] {
+            XCTAssertThrowsError(try JSONDecoder().decode(PortalDestination.self, from: Data(json.utf8)), json)
+        }
+    }
+
     func testLocalAppPortalDestinationAcceptsOnlyValidPorts() throws {
         XCTAssertEqual(try XCTUnwrap(PortalDestination(localAppPort: 1)).localAppPort, 1)
         XCTAssertEqual(try XCTUnwrap(PortalDestination(localAppPort: 65535)).localAppPort, 65535)
         XCTAssertNil(PortalDestination(localAppPort: 0))
     }
 
-    func testVersionThreeInstallationDefaultsRequireLoggingChoiceAndHaveNotOfferedLogin() {
+    func testVersionFourInstallationDefaultsRequireLoggingChoiceAndHaveNotOfferedLogin() {
         let installation = InstallationRecord()
 
-        XCTAssertEqual(installation.version, 3)
+        XCTAssertEqual(installation.version, 4)
         XCTAssertEqual(installation.operationalLogging, .undecided)
         XCTAssertEqual(installation.launchAtLoginOffer, .notOffered)
     }

--- a/PorticoTests/PortalControllerTests.swift
+++ b/PorticoTests/PortalControllerTests.swift
@@ -144,6 +144,32 @@ final class PortalControllerTests: XCTestCase {
         XCTAssertEqual(client.started.count, 1)
     }
 
+    func testRemoteAppCreationValidatesBeforePersistenceAndDoesNotStartLocalDiscovery() throws {
+        let client = FakePortalHelperClient()
+        let store = PortalStore(rootURL: temporaryRoot())
+        try store.save(InstallationRecord(operationalLogging: .enabled))
+        var ids = 0
+        let controller = PortalController(
+            store: store,
+            helper: client,
+            uuidProvider: { ids += 1; return self.portalID },
+            openURL: { _ in }
+        )
+        controller.creationKind = .remoteApp
+        controller.portalName = "hermes"
+        controller.remoteAppHost = "127.0.0.1"
+        controller.remoteAppPort = "443"
+
+        XCTAssertEqual(controller.addPortal(), .invalidRemoteHost)
+        XCTAssertEqual(ids, 0)
+        XCTAssertTrue(client.started.isEmpty)
+
+        controller.remoteAppHost = "App.Example.COM"
+        XCTAssertNil(controller.addPortal())
+        XCTAssertEqual(ids, 1)
+        XCTAssertEqual(controller.portal?.destination, .remoteApp(scheme: .https, host: "app.example.com", port: 443))
+    }
+
     func testInitialDiscoveryAfterConnectionDoesNotChangeManualFields() {
         let client = FakePortalHelperClient(availability: .connecting)
         let controller = PortalController(store: PortalStore(rootURL: temporaryRoot()), helper: client, openURL: { _ in })
@@ -991,12 +1017,12 @@ final class PortalControllerTests: XCTestCase {
         )
         let controller = PortalController(store: store, helper: supervisor, openURL: { _ in })
         supervisor.start(loggingPreference: .enabled)
-        launcher.receive(line: #"{"version":3,"requestId":"handshake-1","result":{"protocolVersion":3}}"#)
+        launcher.receive(line: #"{"version":4,"requestId":"handshake-1","result":{"protocolVersion":4}}"#)
         controller.stopPortal(id: portalID)
 
         launcher.exit(status: 1)
         scheduler.run(delay: 1)
-        launcher.receive(line: #"{"version":3,"requestId":"handshake-2","result":{"protocolVersion":3}}"#)
+        launcher.receive(line: #"{"version":4,"requestId":"handshake-2","result":{"protocolVersion":4}}"#)
 
         let request = try JSONDecoder().decode(
             HelperRequest<ReconcilePortalsPayload>.self,

--- a/PorticoTests/PortalStoreTests.swift
+++ b/PorticoTests/PortalStoreTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import Portico
 
 final class PortalStoreTests: XCTestCase {
-    func testNewInstallationUsesVersionThreeDefaults() throws {
+    func testNewInstallationUsesVersionFourDefaults() throws {
         let store = PortalStore(rootURL: temporaryRoot())
 
         XCTAssertEqual(
@@ -13,7 +13,7 @@ final class PortalStoreTests: XCTestCase {
                 launchAtLoginOffer: .notOffered
             )
         )
-        XCTAssertEqual(store.installationURL.lastPathComponent, "installation-v3.json")
+        XCTAssertEqual(store.installationURL.lastPathComponent, "installation-v4.json")
     }
 
     func testVersionOneMigrationEnablesLoggingAndStartsLoginOfferUnspent() throws {
@@ -42,6 +42,46 @@ final class PortalStoreTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: store.versionTwoInstallationURL.path))
     }
 
+    func testVersionThreeMigrationWritesVersionFourBeforeRemovingSource() throws {
+        let store = PortalStore(rootURL: temporaryRoot())
+        try FileManager.default.createDirectory(at: store.rootURL, withIntermediateDirectories: true)
+        try Data(
+            #"{"version":3,"portals":[{"id":"9F55CA93-D7B3-4EAB-A871-310EA576005A","name":"hermes","localAppPort":8787,"createdAt":807692800,"lifecycle":"active"}],"alerts":[],"operationalLogging":"enabled","launchAtLoginOffer":"notOffered"}"#.utf8
+        ).write(to: store.versionThreeInstallationURL)
+
+        let installation = try store.loadInstallation()
+
+        XCTAssertEqual(installation.portals.first?.destination, .localApp(port: 8787))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: store.installationURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.versionThreeInstallationURL.path))
+    }
+
+    func testInvalidVersionThreeDestinationFailsClosedWithoutRemovingSource() throws {
+        let store = PortalStore(rootURL: temporaryRoot())
+        try FileManager.default.createDirectory(at: store.rootURL, withIntermediateDirectories: true)
+        let source = Data(
+            #"{"version":3,"portals":[{"id":"9F55CA93-D7B3-4EAB-A871-310EA576005A","name":"hermes","localAppPort":0,"createdAt":807692800,"lifecycle":"active"}],"alerts":[],"operationalLogging":"enabled","launchAtLoginOffer":"notOffered"}"#.utf8
+        )
+        try source.write(to: store.versionThreeInstallationURL)
+
+        XCTAssertThrowsError(try store.loadInstallation())
+        XCTAssertEqual(try Data(contentsOf: store.versionThreeInstallationURL), source)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.installationURL.path))
+    }
+
+    func testInvalidVersionOneDestinationFailsClosedWithoutRemovingSource() throws {
+        let store = PortalStore(rootURL: temporaryRoot())
+        try FileManager.default.createDirectory(at: store.rootURL, withIntermediateDirectories: true)
+        let source = Data(
+            #"{"version":1,"portal":{"id":"9F55CA93-D7B3-4EAB-A871-310EA576005A","name":"hermes","localAppPort":0,"createdAt":807692800}}"#.utf8
+        )
+        try source.write(to: store.legacyConfigurationURL)
+
+        XCTAssertThrowsError(try store.loadInstallation())
+        XCTAssertEqual(try Data(contentsOf: store.legacyConfigurationURL), source)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.installationURL.path))
+    }
+
     func testNonPristineVersionTwoMigrationsPreserveExistingLoggingBehavior() throws {
         let records = [
             #"{"version":2,"portals":[{"id":"9F55CA93-D7B3-4EAB-A871-310EA576005A","name":"hermes","localAppPort":8787,"createdAt":807692800,"lifecycle":"active"}],"alerts":[]}"#,
@@ -61,7 +101,7 @@ final class PortalStoreTests: XCTestCase {
         }
     }
 
-    func testValidVersionThreeWinsAfterInterruptedOlderCleanup() throws {
+    func testValidVersionFourWinsAfterInterruptedOlderCleanup() throws {
         let store = PortalStore(rootURL: temporaryRoot())
         let authoritative = InstallationRecord(
             tailnetBinding: TailnetBinding(name: "opaque-tailnet-id", magicDNSSuffix: "example.ts.net"),
@@ -78,7 +118,7 @@ final class PortalStoreTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: store.legacyConfigurationURL.path))
     }
 
-    func testCorruptVersionThreeFailsClosedWithoutFallingBack() throws {
+    func testCorruptVersionFourFailsClosedWithoutFallingBack() throws {
         let store = PortalStore(rootURL: temporaryRoot())
         try FileManager.default.createDirectory(at: store.rootURL, withIntermediateDirectories: true)
         let corrupt = Data("not-json".utf8)
@@ -90,11 +130,11 @@ final class PortalStoreTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: store.versionTwoInstallationURL.path))
     }
 
-    func testUnsupportedVersionThreeFailsClosedWithoutFallingBack() throws {
+    func testUnsupportedVersionFourFailsClosedWithoutFallingBack() throws {
         let store = PortalStore(rootURL: temporaryRoot())
         try FileManager.default.createDirectory(at: store.rootURL, withIntermediateDirectories: true)
         let unsupported = Data(
-            #"{"version":4,"operationalLogging":"disabled","launchAtLoginOffer":"accepted","portals":[],"alerts":[]}"#.utf8
+            #"{"version":5,"operationalLogging":"disabled","launchAtLoginOffer":"accepted","portals":[],"alerts":[]}"#.utf8
         )
         try unsupported.write(to: store.installationURL)
         try Data(#"{"version":2,"portals":[],"alerts":[]}"#.utf8).write(to: store.versionTwoInstallationURL)
@@ -233,7 +273,7 @@ final class PortalStoreTests: XCTestCase {
         try store.save(installation)
 
         let saved = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(contentsOf: store.installationURL)) as? [String: Any])
-        XCTAssertEqual(saved["version"] as? Int, 3)
+        XCTAssertEqual(saved["version"] as? Int, 4)
         let portals = try XCTUnwrap(saved["portals"] as? [[String: Any]])
         XCTAssertEqual(portals.map { $0["desiredState"] as? String }, ["enabled", "stopped"])
         XCTAssertEqual(saved["operationalLogging"] as? String, "enabled")
@@ -250,7 +290,7 @@ final class PortalStoreTests: XCTestCase {
 
         var installation = try store.loadInstallation()
 
-        XCTAssertEqual(installation.version, 3)
+        XCTAssertEqual(installation.version, 4)
         XCTAssertNil(installation.portals[0].removalAssignedName)
 
         installation.portals[0].lifecycle = .pendingRemoval
@@ -258,7 +298,7 @@ final class PortalStoreTests: XCTestCase {
         try store.save(installation)
 
         XCTAssertEqual(try store.loadInstallation(), installation)
-        XCTAssertEqual(try store.loadInstallation().version, 3)
+        XCTAssertEqual(try store.loadInstallation().version, 4)
     }
 
     func testExplicitNullDesiredStateIsCorruptRatherThanDefaulting() throws {
@@ -291,7 +331,7 @@ final class PortalStoreTests: XCTestCase {
         XCTAssertThrowsError(try store.save(portal))
     }
 
-    func testVersionThreePersistenceUsesTheLocalAppPortAdapter() throws {
+    func testVersionFourPersistenceUsesTheTaggedDestination() throws {
         let store = PortalStore(rootURL: temporaryRoot())
         let portal = PortalConfiguration(
             id: UUID(uuidString: "9f55ca93-d7b3-4eab-a871-310ea576005a")!,
@@ -306,16 +346,17 @@ final class PortalStoreTests: XCTestCase {
             JSONSerialization.jsonObject(with: Data(contentsOf: store.installationURL)) as? [String: Any]
         )
         let savedPortal = try XCTUnwrap((saved["portals"] as? [[String: Any]])?.first)
-        XCTAssertEqual(savedPortal["localAppPort"] as? Int, 8787)
-        XCTAssertNil(savedPortal["destination"])
+        XCTAssertNil(savedPortal["localAppPort"])
+        XCTAssertEqual((savedPortal["destination"] as? [String: Any])?["kind"] as? String, "localApp")
+        XCTAssertEqual((savedPortal["destination"] as? [String: Any])?["port"] as? Int, 8787)
         XCTAssertEqual(try store.loadInstallation().portals.first?.destination, portal.destination)
     }
 
-    func testVersionThreeRejectsAnInvalidLocalAppPort() throws {
+    func testVersionFourRejectsAnInvalidLocalAppPort() throws {
         let store = PortalStore(rootURL: temporaryRoot())
         try FileManager.default.createDirectory(at: store.rootURL, withIntermediateDirectories: true)
         try Data(
-            #"{"version":3,"portals":[{"id":"9F55CA93-D7B3-4EAB-A871-310EA576005A","name":"hermes","localAppPort":0,"createdAt":807692800,"lifecycle":"active"}],"alerts":[],"operationalLogging":"enabled","launchAtLoginOffer":"notOffered"}"#.utf8
+            #"{"version":4,"portals":[{"id":"9F55CA93-D7B3-4EAB-A871-310EA576005A","name":"hermes","destination":{"kind":"localApp","port":0},"createdAt":807692800,"lifecycle":"active"}],"alerts":[],"operationalLogging":"enabled","launchAtLoginOffer":"notOffered"}"#.utf8
         ).write(to: store.installationURL)
 
         XCTAssertThrowsError(try store.loadInstallation())

--- a/helper/internal/portal/proxy.go
+++ b/helper/internal/portal/proxy.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httputil"
+	"net/netip"
 	"net/url"
 	"strconv"
 	"sync"
@@ -34,6 +35,62 @@ func newLoopbackProxy(port int) (http.Handler, error) {
 		http.Error(writer, http.StatusText(http.StatusBadGateway), http.StatusBadGateway)
 	}
 	return proxy, nil
+}
+
+func newDestinationProxy(destination Destination) (http.Handler, error) {
+	if err := destination.Validate(); err != nil {
+		return nil, err
+	}
+	if destination.Kind == DestinationLocalApp {
+		return newLoopbackProxy(int(destination.Port))
+	}
+	target := &url.URL{Scheme: destination.Scheme, Host: net.JoinHostPort(destination.Host, strconv.Itoa(int(destination.Port)))}
+	transport := &http.Transport{DialContext: safeRemoteDialer(net.DefaultResolver.LookupNetIP)}
+	return newRemoteProxy(target, transport), nil
+}
+
+func newRemoteProxy(target *url.URL, transport http.RoundTripper) http.Handler {
+	proxy := &httputil.ReverseProxy{
+		Transport: transport,
+		Rewrite: func(request *httputil.ProxyRequest) {
+			request.SetURL(target)
+		},
+		ErrorLog: log.New(io.Discard, "", 0),
+	}
+	proxy.ErrorHandler = func(writer http.ResponseWriter, _ *http.Request, _ error) {
+		http.Error(writer, http.StatusText(http.StatusBadGateway), http.StatusBadGateway)
+	}
+	return proxy
+}
+
+func safeRemoteDialer(resolve func(context.Context, string, string) ([]netip.Addr, error)) func(context.Context, string, string) (net.Conn, error) {
+	return func(ctx context.Context, network, address string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(address)
+		if err != nil {
+			return nil, err
+		}
+		if literal, err := netip.ParseAddr(host); err == nil {
+			literal = literal.Unmap()
+			if literal.IsLoopback() || literal.IsUnspecified() {
+				return nil, errors.New("loopback Remote App destination")
+			}
+			return (&net.Dialer{}).DialContext(ctx, network, net.JoinHostPort(literal.String(), port))
+		}
+		addresses, err := resolve(ctx, "ip", host)
+		if err != nil {
+			return nil, err
+		}
+		for _, resolved := range addresses {
+			resolved = resolved.Unmap()
+			if resolved.IsLoopback() || resolved.IsUnspecified() {
+				continue
+			}
+			if connection, err := (&net.Dialer{}).DialContext(ctx, network, net.JoinHostPort(resolved.String(), port)); err == nil {
+				return connection, nil
+			}
+		}
+		return nil, errors.New("Remote App destination is unavailable")
+	}
 }
 
 func loopbackDestination(port int) *url.URL {

--- a/helper/internal/portal/proxy_test.go
+++ b/helper/internal/portal/proxy_test.go
@@ -9,6 +9,8 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/netip"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -40,6 +42,70 @@ func TestLoopbackProxyPreservesPublicPathAndQuery(t *testing.T) {
 	wantAuthority := "127.0.0.1:" + portText
 	if response.Header().Get("X-Local-App-Host") != wantAuthority {
 		t.Fatalf("Local App Host = %q, want %q", response.Header().Get("X-Local-App-Host"), wantAuthority)
+	}
+}
+
+func TestRemoteAppHTTPProxyUsesConfiguredAuthority(t *testing.T) {
+	remote := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("X-Remote-Host", request.Host)
+		_, _ = io.WriteString(writer, request.URL.RequestURI())
+	}))
+	defer remote.Close()
+	_, port, err := net.SplitHostPort(strings.TrimPrefix(remote.URL, "http://"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := &url.URL{Scheme: "http", Host: "app.example.com:" + port}
+	transport := &http.Transport{DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, network, strings.TrimPrefix(remote.URL, "http://"))
+	}}
+	proxy := newRemoteProxy(target, transport)
+	response := httptest.NewRecorder()
+	proxy.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "https://portal.example.ts.net/path?ok=yes", nil))
+	if response.Code != http.StatusOK || response.Body.String() != "/path?ok=yes" {
+		t.Fatalf("response = (%d, %q), want proxied Remote App response", response.Code, response.Body.String())
+	}
+	if got := response.Header().Get("X-Remote-Host"); got != "app.example.com:"+port {
+		t.Fatalf("Remote App authority = %q, want %q", got, "app.example.com:"+port)
+	}
+}
+
+func TestRemoteAppHTTPSProxyUsesTrustedTestTransport(t *testing.T) {
+	remote := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		_, _ = io.WriteString(writer, "trusted TLS")
+	}))
+	defer remote.Close()
+	_, port, err := net.SplitHostPort(strings.TrimPrefix(remote.URL, "https://"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	transport := remote.Client().Transport.(*http.Transport).Clone()
+	transport.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, network, strings.TrimPrefix(remote.URL, "https://"))
+	}
+	proxy := newRemoteProxy(&url.URL{Scheme: "https", Host: "example.com:" + port}, transport)
+	response := httptest.NewRecorder()
+	proxy.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "https://portal.example.ts.net/", nil))
+	if response.Code != http.StatusOK || response.Body.String() != "trusted TLS" {
+		t.Fatalf("response = (%d, %q), want trusted HTTPS Remote App", response.Code, response.Body.String())
+	}
+}
+
+func TestRemoteAppDialerNeverDialsLoopbackResolution(t *testing.T) {
+	dial := safeRemoteDialer(func(context.Context, string, string) ([]netip.Addr, error) {
+		return []netip.Addr{netip.MustParseAddr("127.0.0.1")}, nil
+	})
+	if connection, err := dial(context.Background(), "tcp", "app.example.com:443"); err == nil || connection != nil {
+		t.Fatalf("loopback resolution dial = (%v, %v), want rejection", connection, err)
+	}
+}
+
+func TestRemoteAppDialerNeverDialsIPv4MappedLoopbackResolution(t *testing.T) {
+	dial := safeRemoteDialer(func(context.Context, string, string) ([]netip.Addr, error) {
+		return []netip.Addr{netip.MustParseAddr("::ffff:127.0.0.1")}, nil
+	})
+	if connection, err := dial(context.Background(), "tcp", "app.example.com:443"); err == nil || connection != nil {
+		t.Fatalf("IPv4-mapped loopback resolution dial = (%v, %v), want rejection", connection, err)
 	}
 }
 

--- a/helper/internal/portal/runtime.go
+++ b/helper/internal/portal/runtime.go
@@ -2,8 +2,10 @@ package portal
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net"
+	"net/netip"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -26,8 +28,111 @@ const (
 type Config struct {
 	ID           string
 	Name         string
-	Port         uint16
+	Destination  Destination
 	DesiredState DesiredState
+}
+
+type Destination struct {
+	Kind   string `json:"kind"`
+	Scheme string `json:"scheme,omitempty"`
+	Host   string `json:"host,omitempty"`
+	Port   uint16 `json:"port"`
+}
+
+func (d *Destination) UnmarshalJSON(data []byte) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	var kind string
+	if raw, ok := fields["kind"]; !ok || json.Unmarshal(raw, &kind) != nil {
+		return errors.New("invalid destination")
+	}
+	if kind == DestinationLocalApp {
+		if len(fields) != 2 || fields["port"] == nil {
+			return errors.New("invalid Local App destination")
+		}
+		var port uint16
+		if err := json.Unmarshal(fields["port"], &port); err != nil {
+			return err
+		}
+		*d = Destination{Kind: kind, Port: port}
+	} else if kind == DestinationRemoteApp {
+		if len(fields) != 4 || fields["scheme"] == nil || fields["host"] == nil || fields["port"] == nil {
+			return errors.New("invalid Remote App destination")
+		}
+		var scheme, host string
+		var port uint16
+		if err := json.Unmarshal(fields["scheme"], &scheme); err != nil {
+			return err
+		}
+		if err := json.Unmarshal(fields["host"], &host); err != nil {
+			return err
+		}
+		if err := json.Unmarshal(fields["port"], &port); err != nil {
+			return err
+		}
+		*d = Destination{Kind: kind, Scheme: scheme, Host: host, Port: port}
+	} else {
+		return errors.New("invalid destination kind")
+	}
+	return d.Validate()
+}
+
+const (
+	DestinationLocalApp  = "localApp"
+	DestinationRemoteApp = "remoteApp"
+)
+
+func (d Destination) Validate() error {
+	if d.Port == 0 {
+		return errors.New("invalid destination")
+	}
+	switch d.Kind {
+	case DestinationLocalApp:
+		if d.Scheme != "" || d.Host != "" {
+			return errors.New("invalid Local App destination")
+		}
+	case DestinationRemoteApp:
+		if d.Scheme != "http" && d.Scheme != "https" {
+			return errors.New("invalid Remote App scheme")
+		}
+		if !isCanonicalRemoteHost(d.Host) || isLoopbackHost(d.Host) {
+			return errors.New("invalid Remote App host")
+		}
+	default:
+		return errors.New("invalid destination kind")
+	}
+	return nil
+}
+
+func isCanonicalRemoteHost(host string) bool {
+	if host == "" || strings.TrimSpace(host) != host || strings.ContainsAny(host, "[]%") {
+		return false
+	}
+	if address, err := netip.ParseAddr(host); err == nil {
+		return address.String() == host
+	}
+	if len(host) > 253 || host != strings.ToLower(host) || strings.HasSuffix(host, ".") {
+		return false
+	}
+	for _, label := range strings.Split(host, ".") {
+		if !dnsLabelPattern.MatchString(label) {
+			return false
+		}
+	}
+	return true
+}
+
+func isLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	if address, err := netip.ParseAddr(host); err == nil {
+		address = address.Unmap()
+		return address.IsLoopback() || address.IsUnspecified()
+	}
+	return false
 }
 
 type DesiredState string
@@ -56,7 +161,7 @@ var (
 )
 
 func (c Config) Validate() error {
-	if !uuidPattern.MatchString(c.ID) || !dnsLabelPattern.MatchString(c.Name) || c.Port == 0 {
+	if !uuidPattern.MatchString(c.ID) || !dnsLabelPattern.MatchString(c.Name) || c.Destination.Validate() != nil {
 		return errors.New("invalid portal configuration")
 	}
 	return nil
@@ -218,8 +323,8 @@ func (r *Runtime) reconcilePortalLocked(
 	if portal.config.Name != config.Name {
 		return OutcomeStartFailed
 	}
-	if portal.config.Port != config.Port {
-		if err := portal.updatePort(config.Port); err != nil {
+	if portal.config.Destination != config.Destination {
+		if err := portal.updateDestination(config.Destination); err != nil {
 			return OutcomeStartFailed
 		}
 	}
@@ -393,20 +498,20 @@ func (r *portalRuntime) start(ctx context.Context, config Config, node Node, emi
 	return nil
 }
 
-func (r *portalRuntime) updatePort(port uint16) error {
+func (r *portalRuntime) updateDestination(destination Destination) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.config == nil {
 		return errors.New("portal is not running")
 	}
-	handler, err := newLoopbackProxy(int(port))
+	handler, err := newDestinationProxy(destination)
 	if err != nil {
 		return err
 	}
 	if r.proxy != nil {
 		r.proxy.replaceHandler(handler)
 	}
-	r.config.Port = port
+	r.config.Destination = destination
 	return nil
 }
 
@@ -507,7 +612,7 @@ func (r *portalRuntime) ensureProxyLocked() error {
 	if r.proxy != nil {
 		return nil
 	}
-	handler, err := newLoopbackProxy(int(r.config.Port))
+	handler, err := newDestinationProxy(r.config.Destination)
 	if err != nil {
 		return err
 	}

--- a/helper/internal/portal/runtime_test.go
+++ b/helper/internal/portal/runtime_test.go
@@ -21,6 +21,19 @@ import (
 const testPortalID = "9f55ca93-d7b3-4eab-a871-310ea576005a"
 const secondPortalID = "5ea74329-3144-4ba2-925f-138d14d61fcc"
 
+func localAppDestination(port uint16) Destination {
+	return Destination{Kind: DestinationLocalApp, Port: port}
+}
+
+func TestDestinationRejectsIPv4MappedLoopback(t *testing.T) {
+	destination := Destination{
+		Kind: DestinationRemoteApp, Scheme: "https", Host: "::ffff:127.0.0.1", Port: 443,
+	}
+	if err := destination.Validate(); err == nil {
+		t.Fatal("Destination.Validate() succeeded for IPv4-mapped loopback")
+	}
+}
+
 func TestRuntimeReconcileContinuesAfterStartFailureAndRetainsOwnershipUntilCleanup(t *testing.T) {
 	root := t.TempDir()
 	created := make(map[string][]*fakeNode)
@@ -35,8 +48,8 @@ func TestRuntimeReconcileContinuesAfterStartFailureAndRetainsOwnershipUntilClean
 		return node
 	})
 	desired := []Config{
-		{ID: testPortalID, Name: "hermes", Port: 8787, DesiredState: DesiredStateEnabled},
-		{ID: secondPortalID, Name: "atlas", Port: 8788, DesiredState: DesiredStateEnabled},
+		{ID: testPortalID, Name: "hermes", Destination: localAppDestination(8787), DesiredState: DesiredStateEnabled},
+		{ID: secondPortalID, Name: "atlas", Destination: localAppDestination(8788), DesiredState: DesiredStateEnabled},
 	}
 
 	entries, err := runtime.Reconcile(context.Background(), desired, func(Event) {})
@@ -118,7 +131,7 @@ func TestRuntimePortEditPreservesIdentityAndDrainsAcceptedHTTPAndWebSocketTraffi
 	factory.node.realListener = tailnetListener
 	runtime := NewRuntime(t.TempDir(), factory.New)
 	desired := []Config{{
-		ID: testPortalID, Name: "hermes", Port: uint16(oldPort), DesiredState: DesiredStateEnabled,
+		ID: testPortalID, Name: "hermes", Destination: localAppDestination(uint16(oldPort)), DesiredState: DesiredStateEnabled,
 	}}
 	if entries, reconcileErr := runtime.Reconcile(context.Background(), desired, func(Event) {}); reconcileErr != nil || entries[0].Outcome != OutcomeConverged {
 		t.Fatalf("initial Reconcile = (%+v, %v), want converged", entries, reconcileErr)
@@ -154,7 +167,7 @@ func TestRuntimePortEditPreservesIdentityAndDrainsAcceptedHTTPAndWebSocketTraffi
 	}
 	defer oldWebSocket.CloseNow()
 
-	desired[0].Port = uint16(newPort)
+	desired[0].Destination = localAppDestination(uint16(newPort))
 	entries, err := runtime.Reconcile(context.Background(), desired, func(Event) {})
 	if err != nil || entries[0].Outcome != OutcomeConverged {
 		t.Fatalf("port-edit Reconcile = (%+v, %v), want converged", entries, err)
@@ -197,8 +210,8 @@ func TestRuntimeReconcileStopsAndOmitsPortalsWithoutDeletingIdentity(t *testing.
 		return node
 	})
 	desired := []Config{
-		{ID: testPortalID, Name: "hermes", Port: 8787, DesiredState: DesiredStateEnabled},
-		{ID: secondPortalID, Name: "atlas", Port: 8788, DesiredState: DesiredStateEnabled},
+		{ID: testPortalID, Name: "hermes", Destination: localAppDestination(8787), DesiredState: DesiredStateEnabled},
+		{ID: secondPortalID, Name: "atlas", Destination: localAppDestination(8788), DesiredState: DesiredStateEnabled},
 	}
 	if _, err := runtime.Reconcile(context.Background(), desired, func(Event) {}); err != nil {
 		t.Fatal(err)
@@ -210,7 +223,7 @@ func TestRuntimeReconcileStopsAndOmitsPortalsWithoutDeletingIdentity(t *testing.
 	}
 
 	entries, err := runtime.Reconcile(context.Background(), []Config{{
-		ID: testPortalID, Name: "hermes", Port: 8787, DesiredState: DesiredStateStopped,
+		ID: testPortalID, Name: "hermes", Destination: localAppDestination(8787), DesiredState: DesiredStateStopped,
 	}}, func(Event) {})
 
 	if err != nil {
@@ -233,7 +246,7 @@ func TestRuntimeReconcileStopsAndOmitsPortalsWithoutDeletingIdentity(t *testing.
 	}
 
 	entries, err = runtime.Reconcile(context.Background(), []Config{{
-		ID: testPortalID, Name: "hermes", Port: 8787, DesiredState: DesiredStateStopped,
+		ID: testPortalID, Name: "hermes", Destination: localAppDestination(8787), DesiredState: DesiredStateStopped,
 	}}, func(Event) {})
 	if err != nil || len(entries) != 1 || entries[0].PortalID != testPortalID || entries[0].Outcome != OutcomeConverged {
 		t.Fatalf("already-converged retry = (%+v, %v)", entries, err)
@@ -251,7 +264,7 @@ func TestRuntimeReconcileRetainsOwnershipAfterCloseFailure(t *testing.T) {
 		created = append(created, node)
 		return node
 	})
-	enabled := Config{ID: testPortalID, Name: "hermes", Port: 8787, DesiredState: DesiredStateEnabled}
+	enabled := Config{ID: testPortalID, Name: "hermes", Destination: localAppDestination(8787), DesiredState: DesiredStateEnabled}
 	if _, err := runtime.Reconcile(context.Background(), []Config{enabled}, func(Event) {}); err != nil {
 		t.Fatal(err)
 	}
@@ -275,8 +288,8 @@ func TestRuntimeReconcileRejectsWholeInvalidSnapshotBeforeMutation(t *testing.T)
 		return &fakeNode{watcher: newFakeWatcher()}
 	})
 	configs := []Config{
-		{ID: testPortalID, Name: "hermes", Port: 8787, DesiredState: DesiredStateEnabled},
-		{ID: secondPortalID, Name: "Atlas", Port: 8788, DesiredState: DesiredStateEnabled},
+		{ID: testPortalID, Name: "hermes", Destination: localAppDestination(8787), DesiredState: DesiredStateEnabled},
+		{ID: secondPortalID, Name: "Atlas", Destination: localAppDestination(8788), DesiredState: DesiredStateEnabled},
 	}
 
 	if entries, err := runtime.Reconcile(context.Background(), configs, func(Event) {}); err == nil || entries != nil {
@@ -284,6 +297,22 @@ func TestRuntimeReconcileRejectsWholeInvalidSnapshotBeforeMutation(t *testing.T)
 	}
 	if created != 0 {
 		t.Fatalf("created %d nodes before validating the full snapshot", created)
+	}
+}
+
+func TestRemoteAppDestinationRejectsLoopbackAndNoncanonicalHosts(t *testing.T) {
+	for _, destination := range []Destination{
+		{Kind: DestinationRemoteApp, Scheme: "https", Host: "localhost", Port: 443},
+		{Kind: DestinationRemoteApp, Scheme: "https", Host: "127.0.0.1", Port: 443},
+		{Kind: DestinationRemoteApp, Scheme: "https", Host: "[::1]", Port: 443},
+		{Kind: DestinationRemoteApp, Scheme: "https", Host: "Example.COM", Port: 443},
+	} {
+		if err := destination.Validate(); err == nil {
+			t.Fatalf("Validate(%+v) = nil, want rejection", destination)
+		}
+	}
+	if err := (Destination{Kind: DestinationRemoteApp, Scheme: "https", Host: "app.example.com", Port: 443}).Validate(); err != nil {
+		t.Fatalf("valid Remote App rejected: %v", err)
 	}
 }
 
@@ -345,8 +374,8 @@ func TestRuntimeKeepsTwoIndependentPortalsOnline(t *testing.T) {
 	}
 
 	configs := []Config{
-		{ID: testPortalID, Name: "hermes", Port: 8787, DesiredState: DesiredStateEnabled},
-		{ID: secondPortalID, Name: "atlas", Port: 8788, DesiredState: DesiredStateEnabled},
+		{ID: testPortalID, Name: "hermes", Destination: localAppDestination(8787), DesiredState: DesiredStateEnabled},
+		{ID: secondPortalID, Name: "atlas", Destination: localAppDestination(8788), DesiredState: DesiredStateEnabled},
 	}
 	if _, err := runtime.Reconcile(context.Background(), configs, emit); err != nil {
 		t.Fatalf("Reconcile Portals: %v", err)
@@ -372,8 +401,8 @@ func TestCleanupRejectedPortalClosesAndDeletesOnlyAddressedPortal(t *testing.T) 
 		return node
 	})
 	configs := []Config{
-		{ID: testPortalID, Name: "hermes", Port: 8787, DesiredState: DesiredStateEnabled},
-		{ID: secondPortalID, Name: "atlas", Port: 8788, DesiredState: DesiredStateEnabled},
+		{ID: testPortalID, Name: "hermes", Destination: localAppDestination(8787), DesiredState: DesiredStateEnabled},
+		{ID: secondPortalID, Name: "atlas", Destination: localAppDestination(8788), DesiredState: DesiredStateEnabled},
 	}
 	if _, err := runtime.Reconcile(context.Background(), configs, func(Event) {}); err != nil {
 		t.Fatalf("Reconcile: %v", err)
@@ -417,8 +446,8 @@ func TestRemovePortalClosesAndDeletesOnlyAddressedPortal(t *testing.T) {
 		return node
 	})
 	configs := []Config{
-		{ID: testPortalID, Name: "hermes", Port: 8787, DesiredState: DesiredStateEnabled},
-		{ID: secondPortalID, Name: "atlas", Port: 8788, DesiredState: DesiredStateEnabled},
+		{ID: testPortalID, Name: "hermes", Destination: localAppDestination(8787), DesiredState: DesiredStateEnabled},
+		{ID: secondPortalID, Name: "atlas", Destination: localAppDestination(8788), DesiredState: DesiredStateEnabled},
 	}
 	if _, err := runtime.Reconcile(context.Background(), configs, func(Event) {}); err != nil {
 		t.Fatalf("Reconcile: %v", err)
@@ -460,7 +489,7 @@ func TestRemovePortalDeletesStateCreatedWhileRuntimeCloses(t *testing.T) {
 	}
 	runtime := NewRuntime(root, func(_, _ string) Node { return node })
 	if _, err := runtime.Reconcile(context.Background(), []Config{{
-		ID: testPortalID, Name: "hermes", Port: 8787, DesiredState: DesiredStateEnabled,
+		ID: testPortalID, Name: "hermes", Destination: localAppDestination(8787), DesiredState: DesiredStateEnabled,
 	}}, func(Event) {}); err != nil {
 		t.Fatalf("Reconcile: %v", err)
 	}
@@ -482,7 +511,7 @@ func TestRemovePortalRejectsUntrustedTargetsWithoutClosingRuntime(t *testing.T) 
 	root := t.TempDir()
 	node := &fakeNode{watcher: newFakeWatcher(), status: Status{BackendState: "Starting"}}
 	runtime := NewRuntime(root, func(_, _ string) Node { return node })
-	if err := reconcileOne(runtime, Config{ID: testPortalID, Name: "hermes", Port: 8787}, func(Event) {}); err != nil {
+	if err := reconcileOne(runtime, Config{ID: testPortalID, Name: "hermes", Destination: localAppDestination(8787)}, func(Event) {}); err != nil {
 		t.Fatalf("Reconcile: %v", err)
 	}
 	t.Cleanup(func() { _ = runtime.Close() })
@@ -515,7 +544,7 @@ func TestRemovePortalPreservesStateAndOwnershipWhenCloseFails(t *testing.T) {
 		closeResults: []error{errors.New("close failed"), nil},
 	}
 	runtime := NewRuntime(root, func(_, _ string) Node { return node })
-	if err := reconcileOne(runtime, Config{ID: testPortalID, Name: "hermes", Port: 8787}, func(Event) {}); err != nil {
+	if err := reconcileOne(runtime, Config{ID: testPortalID, Name: "hermes", Destination: localAppDestination(8787)}, func(Event) {}); err != nil {
 		t.Fatalf("Reconcile: %v", err)
 	}
 	stateDirectory := filepath.Join(root, testPortalID)
@@ -613,7 +642,7 @@ func TestCleanupWaitsForStartBeforeDeletingAnyPortalState(t *testing.T) {
 	}
 	startDone := make(chan error, 1)
 	go func() {
-		startDone <- reconcileOne(runtime, Config{ID: testPortalID, Name: "hermes", Port: 8787}, func(Event) {})
+		startDone <- reconcileOne(runtime, Config{ID: testPortalID, Name: "hermes", Destination: localAppDestination(8787)}, func(Event) {})
 	}()
 	<-blocked.startEntered
 	cleanupDone := make(chan error, 1)
@@ -640,7 +669,7 @@ func TestCleanupWaitsForStartBeforeDeletingAnyPortalState(t *testing.T) {
 func TestRuntimeUsesUUIDStateDirectoryAndStableIdentity(t *testing.T) {
 	factory := newFakeFactory()
 	root := t.TempDir()
-	config := Config{ID: testPortalID, Name: "hermes", Port: 8787}
+	config := Config{ID: testPortalID, Name: "hermes", Destination: localAppDestination(8787)}
 
 	for range 2 {
 		runtime := NewRuntime(root, factory.New)
@@ -663,9 +692,9 @@ func TestRuntimeUsesUUIDStateDirectoryAndStableIdentity(t *testing.T) {
 
 func TestConfigRejectsUntrustedPathsAndDestinations(t *testing.T) {
 	invalid := []Config{
-		{ID: "../escape", Name: "hermes", Port: 8787},
-		{ID: testPortalID, Name: "Hermes", Port: 8787},
-		{ID: testPortalID, Name: "hermes", Port: 0},
+		{ID: "../escape", Name: "hermes", Destination: localAppDestination(8787)},
+		{ID: testPortalID, Name: "Hermes", Destination: localAppDestination(8787)},
+		{ID: testPortalID, Name: "hermes", Destination: localAppDestination(0)},
 	}
 	for _, config := range invalid {
 		if err := config.Validate(); err == nil {
@@ -698,7 +727,7 @@ func TestRuntimeMapsStructuredStatus(t *testing.T) {
 			}
 			var events []Event
 			runtime := NewRuntime(t.TempDir(), factory.New)
-			if err := reconcileOne(runtime, Config{ID: testPortalID, Name: "hermes", Port: 8787}, func(event Event) {
+			if err := reconcileOne(runtime, Config{ID: testPortalID, Name: "hermes", Destination: localAppDestination(8787)}, func(event Event) {
 				events = append(events, event)
 			}); err != nil {
 				t.Fatalf("Start: %v", err)
@@ -739,7 +768,7 @@ func TestAuthenticateEmitsTransientURLFromFreshNotification(t *testing.T) {
 	factory := newFakeFactory()
 	events := make(chan Event, 8)
 	runtime := NewRuntime(t.TempDir(), factory.New)
-	if err := reconcileOne(runtime, Config{ID: testPortalID, Name: "hermes", Port: 8787}, func(event Event) {
+	if err := reconcileOne(runtime, Config{ID: testPortalID, Name: "hermes", Destination: localAppDestination(8787)}, func(event Event) {
 		events <- event
 	}); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -769,7 +798,7 @@ func TestStartAndCloseAreSerialized(t *testing.T) {
 	runtime := NewRuntime(t.TempDir(), factory.New)
 	startDone := make(chan error, 1)
 	go func() {
-		startDone <- reconcileOne(runtime, Config{ID: testPortalID, Name: "hermes", Port: 8787}, func(Event) {})
+		startDone <- reconcileOne(runtime, Config{ID: testPortalID, Name: "hermes", Destination: localAppDestination(8787)}, func(Event) {})
 	}()
 	<-factory.node.startEntered
 	closeDone := make(chan error, 1)
@@ -800,7 +829,7 @@ func TestOnlineRuntimeListensTLSAndClosesListenerBeforeNode(t *testing.T) {
 		CertDomains:  []string{"hermes.example.ts.net"},
 	}
 	runtime := NewRuntime(t.TempDir(), factory.New)
-	if err := reconcileOne(runtime, Config{ID: testPortalID, Name: "hermes", Port: 8787}, func(Event) {}); err != nil {
+	if err := reconcileOne(runtime, Config{ID: testPortalID, Name: "hermes", Destination: localAppDestination(8787)}, func(Event) {}); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
 	if factory.node.listenNetwork != "tcp" || factory.node.listenAddress != ":443" {
@@ -822,7 +851,7 @@ func TestRuntimeCloseReturnsListenerFailure(t *testing.T) {
 		CertDomains:  []string{"hermes.example.ts.net"},
 	}
 	runtime := NewRuntime(t.TempDir(), factory.New)
-	if err := reconcileOne(runtime, Config{ID: testPortalID, Name: "hermes", Port: 8787}, func(Event) {}); err != nil {
+	if err := reconcileOne(runtime, Config{ID: testPortalID, Name: "hermes", Destination: localAppDestination(8787)}, func(Event) {}); err != nil {
 		t.Fatal(err)
 	}
 	factory.node.listener.closeErr = errors.New("close failed")
@@ -950,7 +979,7 @@ func newOnlineRuntimeWithLocalApp(t *testing.T, handler http.Handler) (*Runtime,
 	}
 	factory.node.realListener = listener
 	runtime := NewRuntime(t.TempDir(), factory.New)
-	if err := reconcileOne(runtime, Config{ID: testPortalID, Name: "hermes", Port: uint16(port)}, func(Event) {}); err != nil {
+	if err := reconcileOne(runtime, Config{ID: testPortalID, Name: "hermes", Destination: localAppDestination(uint16(port))}, func(Event) {}); err != nil {
 		_ = listener.Close()
 		t.Fatal(err)
 	}

--- a/helper/internal/protocol/server.go
+++ b/helper/internal/protocol/server.go
@@ -16,7 +16,7 @@ import (
 	"github.com/chrisbanes/portico/helper/internal/portal"
 )
 
-const Version = 3
+const Version = 4
 
 const invalidRequestDiagnostic = "portico-helper: invalid request\n"
 
@@ -71,7 +71,7 @@ type discoverLocalAppsResult struct {
 type reconcilePortalPayload struct {
 	PortalID     string              `json:"portalId"`
 	PortalName   string              `json:"portalName"`
-	LocalAppPort uint16              `json:"localAppPort"`
+	Destination  portal.Destination  `json:"destination"`
 	DesiredState portal.DesiredState `json:"desiredState"`
 }
 
@@ -365,7 +365,9 @@ func ServeWithServices(input io.Reader, output, diagnostics io.Writer, services 
 
 func validatedPortalID(raw string) (string, bool) {
 	portalID := strings.ToLower(raw)
-	err := (portal.Config{ID: portalID, Name: "a", Port: 1}).Validate()
+	err := (portal.Config{
+		ID: portalID, Name: "a", Destination: portal.Destination{Kind: portal.DestinationLocalApp, Port: 1},
+	}).Validate()
 	return portalID, err == nil
 }
 
@@ -380,7 +382,7 @@ func decodeReconcilePortalsPayload(raw json.RawMessage) ([]portal.Config, error)
 		config := portal.Config{
 			ID:           strings.ToLower(requested.PortalID),
 			Name:         requested.PortalName,
-			Port:         requested.LocalAppPort,
+			Destination:  requested.Destination,
 			DesiredState: requested.DesiredState,
 		}
 		if err := config.Validate(); err != nil {

--- a/helper/internal/protocol/server_test.go
+++ b/helper/internal/protocol/server_test.go
@@ -15,15 +15,15 @@ import (
 	"github.com/chrisbanes/portico/helper/internal/portal"
 )
 
-func TestServeReconcilesLiteralProtocolVersionThreeSnapshot(t *testing.T) {
+func TestServeReconcilesLiteralProtocolVersionFourSnapshot(t *testing.T) {
 	runtime := &fakeRuntime{reconcileEntries: []portal.ReconcileEntry{
 		{PortalID: "5ea74329-3144-4ba2-925f-138d14d61fcc", Outcome: portal.OutcomeConverged},
 		{PortalID: "9f55ca93-d7b3-4eab-a871-310ea576005a", Outcome: portal.OutcomeStartFailed},
 	}}
 	input := bytes.NewBufferString(
-		`{"version":3,"requestId":"reconcile-1","command":"reconcilePortals","payload":{"portals":[` +
-			`{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","portalName":"hermes","localAppPort":8787,"desiredState":"enabled"},` +
-			`{"portalId":"5EA74329-3144-4BA2-925F-138D14D61FCC","portalName":"atlas","localAppPort":8788,"desiredState":"stopped"}` +
+		`{"version":4,"requestId":"reconcile-1","command":"reconcilePortals","payload":{"portals":[` +
+			`{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","portalName":"hermes","destination":{"kind":"localApp","port":8787},"desiredState":"enabled"},` +
+			`{"portalId":"5EA74329-3144-4BA2-925F-138D14D61FCC","portalName":"atlas","destination":{"kind":"localApp","port":8788},"desiredState":"stopped"}` +
 			`]}}` + "\n",
 	)
 	var output bytes.Buffer
@@ -37,9 +37,9 @@ func TestServeReconcilesLiteralProtocolVersionThreeSnapshot(t *testing.T) {
 	if len(runtime.reconciled) != 2 || runtime.reconciled[0].ID != "9f55ca93-d7b3-4eab-a871-310ea576005a" || runtime.reconciled[1].DesiredState != portal.DesiredStateStopped {
 		t.Fatalf("reconciled = %+v, want normalized complete snapshot", runtime.reconciled)
 	}
-	const want = `{"version":3,"requestId":"reconcile-1","result":{"entries":[{"portalId":"5ea74329-3144-4ba2-925f-138d14d61fcc","outcome":"converged"},{"portalId":"9f55ca93-d7b3-4eab-a871-310ea576005a","outcome":"startFailed"}]}}` + "\n"
+	const want = `{"version":4,"requestId":"reconcile-1","result":{"entries":[{"portalId":"5ea74329-3144-4ba2-925f-138d14d61fcc","outcome":"converged"},{"portalId":"9f55ca93-d7b3-4eab-a871-310ea576005a","outcome":"startFailed"}]}}` + "\n"
 	if output.String() != want {
-		t.Fatalf("output = %q, want exact protocol-v3 result %q", output.String(), want)
+		t.Fatalf("output = %q, want exact protocol-v4 result %q", output.String(), want)
 	}
 }
 
@@ -50,7 +50,7 @@ func TestDiscoverLocalAppsReturnsOnlyStableSanitizedCandidates(t *testing.T) {
 		{LocalAppPort: 9000, ProcessLabel: "hermes", SuggestedPortalName: "hermes"},
 		{LocalAppPort: 7000, ProcessLabel: "first", SuggestedPortalName: "first"},
 	}}
-	input := bytes.NewBufferString(`{"version":3,"requestId":"discover-1","command":"discoverLocalApps","payload":{}}` + "\n")
+	input := bytes.NewBufferString(`{"version":4,"requestId":"discover-1","command":"discoverLocalApps","payload":{}}` + "\n")
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
 
@@ -59,7 +59,7 @@ func TestDiscoverLocalAppsReturnsOnlyStableSanitizedCandidates(t *testing.T) {
 	if exitCode != 0 || diagnostics.Len() != 0 {
 		t.Fatalf("ServeWithServices = (exit %d, diagnostics %q), want success", exitCode, diagnostics.String())
 	}
-	const want = `{"version":3,"requestId":"discover-1","result":{"candidates":[{"localAppPort":7000,"processLabel":"first","suggestedPortalName":"first"},{"localAppPort":8000,"processLabel":"atlas","suggestedPortalName":"atlas"},{"localAppPort":9000,"processLabel":"hermes","suggestedPortalName":"hermes"}]}}` + "\n"
+	const want = `{"version":4,"requestId":"discover-1","result":{"candidates":[{"localAppPort":7000,"processLabel":"first","suggestedPortalName":"first"},{"localAppPort":8000,"processLabel":"atlas","suggestedPortalName":"atlas"},{"localAppPort":9000,"processLabel":"hermes","suggestedPortalName":"hermes"}]}}` + "\n"
 	if output.String() != want {
 		t.Fatalf("output = %q, want %q", output.String(), want)
 	}
@@ -70,13 +70,13 @@ func TestDiscoverLocalAppsCollapsesDisagreeingDuplicateOwners(t *testing.T) {
 		{LocalAppPort: 8787, ProcessLabel: "python3", SuggestedPortalName: "hermes"},
 		{LocalAppPort: 8787, ProcessLabel: "node", SuggestedPortalName: "atlas"},
 	}}
-	input := bytes.NewBufferString(`{"version":3,"requestId":"discover-1","command":"discoverLocalApps","payload":{}}` + "\n")
+	input := bytes.NewBufferString(`{"version":4,"requestId":"discover-1","command":"discoverLocalApps","payload":{}}` + "\n")
 	var output bytes.Buffer
 
 	if exitCode := ServeWithServices(input, &output, &bytes.Buffer{}, Services{LocalAppDiscoverer: discoverer}); exitCode != 0 {
 		t.Fatalf("ServeWithServices exit code = %d, want success", exitCode)
 	}
-	const want = `{"version":3,"requestId":"discover-1","result":{"candidates":[{"localAppPort":8787,"processLabel":"Port 8787"}]}}` + "\n"
+	const want = `{"version":4,"requestId":"discover-1","result":{"candidates":[{"localAppPort":8787,"processLabel":"Port 8787"}]}}` + "\n"
 	if output.String() != want {
 		t.Fatalf("output = %q, want %q", output.String(), want)
 	}
@@ -84,7 +84,7 @@ func TestDiscoverLocalAppsCollapsesDisagreeingDuplicateOwners(t *testing.T) {
 
 func TestDiscoverLocalAppsRequiresEmptyPayload(t *testing.T) {
 	const secret = "do-not-copy"
-	input := bytes.NewBufferString(`{"version":3,"requestId":"discover-1","command":"discoverLocalApps","payload":{"unexpected":"` + secret + `"}}` + "\n")
+	input := bytes.NewBufferString(`{"version":4,"requestId":"discover-1","command":"discoverLocalApps","payload":{"unexpected":"` + secret + `"}}` + "\n")
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
 
@@ -100,7 +100,7 @@ func TestDiscoverLocalAppsRequiresEmptyPayload(t *testing.T) {
 
 func TestDiscoverLocalAppsReturnsFixedSecretFreeFailure(t *testing.T) {
 	const secret = "token=do-not-copy"
-	input := bytes.NewBufferString(`{"version":3,"requestId":"discover-1","command":"discoverLocalApps","payload":{}}` + "\n")
+	input := bytes.NewBufferString(`{"version":4,"requestId":"discover-1","command":"discoverLocalApps","payload":{}}` + "\n")
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
 
@@ -109,7 +109,7 @@ func TestDiscoverLocalAppsReturnsFixedSecretFreeFailure(t *testing.T) {
 	if exitCode != 0 || diagnostics.Len() != 0 {
 		t.Fatalf("ServeWithServices = (exit %d, diagnostics %q), want correlated failure", exitCode, diagnostics.String())
 	}
-	const want = `{"version":3,"requestId":"discover-1","error":{"code":"discoveryFailure","message":"local app discovery failed"}}` + "\n"
+	const want = `{"version":4,"requestId":"discover-1","error":{"code":"discoveryFailure","message":"local app discovery failed"}}` + "\n"
 	if output.String() != want {
 		t.Fatalf("output = %q, want %q", output.String(), want)
 	}
@@ -131,10 +131,10 @@ func TestDiscoverLocalAppsCancelsBeforeRuntimeCloseAndShutdownAcknowledgement(t 
 		})
 	}()
 
-	_, _ = io.WriteString(input, `{"version":3,"requestId":"discover-1","command":"discoverLocalApps","payload":{}}`+"\n")
+	_, _ = io.WriteString(input, `{"version":4,"requestId":"discover-1","command":"discoverLocalApps","payload":{}}`+"\n")
 	<-discoverer.started
 	go func() {
-		_, _ = io.WriteString(input, `{"version":3,"requestId":"shutdown-1","command":"shutdown","payload":{}}`+"\n")
+		_, _ = io.WriteString(input, `{"version":4,"requestId":"shutdown-1","command":"shutdown","payload":{}}`+"\n")
 		_ = input.Close()
 	}()
 
@@ -144,14 +144,14 @@ func TestDiscoverLocalAppsCancelsBeforeRuntimeCloseAndShutdownAcknowledgement(t 
 	if !runtime.closedAfterDiscoveryCancellation {
 		t.Fatal("runtime closed before in-flight discovery observed cancellation")
 	}
-	const want = `{"version":3,"requestId":"shutdown-1","result":{"accepted":true}}` + "\n"
+	const want = `{"version":4,"requestId":"shutdown-1","result":{"accepted":true}}` + "\n"
 	if output.String() != want || diagnostics.Len() != 0 {
 		t.Fatalf("ServeWithServices = (output %q, diagnostics %q), want only post-close shutdown acknowledgement", output.String(), diagnostics.String())
 	}
 }
 
 func TestDiscoverLocalAppsFailsServeWhenResponseCannotBeWritten(t *testing.T) {
-	input := bytes.NewBufferString(`{"version":3,"requestId":"discover-1","command":"discoverLocalApps","payload":{}}` + "\n")
+	input := bytes.NewBufferString(`{"version":4,"requestId":"discover-1","command":"discoverLocalApps","payload":{}}` + "\n")
 
 	exitCode := ServeWithServices(input, errorWriter{}, &bytes.Buffer{}, Services{LocalAppDiscoverer: fakeDiscoverer{}})
 
@@ -214,7 +214,7 @@ func (r *shutdownOrderingRuntime) Close() error {
 }
 
 func TestServeCorrelatesHandshakeResponse(t *testing.T) {
-	input := bytes.NewBufferString(`{"version":3,"requestId":"request-1","command":"handshake","payload":{}}` + "\n")
+	input := bytes.NewBufferString(`{"version":4,"requestId":"request-1","command":"handshake","payload":{}}` + "\n")
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
 
@@ -231,8 +231,8 @@ func TestServeCorrelatesHandshakeResponse(t *testing.T) {
 	if err := json.NewDecoder(&output).Decode(&response); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if response.Version != 3 || response.RequestID != "request-1" || string(response.Result) != `{"protocolVersion":3}` {
-		t.Fatalf("response = %+v, want correlated version-three handshake", response)
+	if response.Version != 4 || response.RequestID != "request-1" || string(response.Result) != `{"protocolVersion":4}` {
+		t.Fatalf("response = %+v, want correlated version-four handshake", response)
 	}
 	if diagnostics.Len() != 0 {
 		t.Fatalf("diagnostics = %q, want empty", diagnostics.String())
@@ -244,7 +244,7 @@ func TestServeReconciliationSerializesStructuredStatusEvent(t *testing.T) {
 		PortalID: "9f55ca93-d7b3-4eab-a871-310ea576005a", Outcome: portal.OutcomeConverged,
 	}}}
 	input := bytes.NewBufferString(
-		`{"version":3,"requestId":"reconcile-1","command":"reconcilePortals","payload":{"portals":[{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","portalName":"hermes","localAppPort":8787,"desiredState":"enabled"}]}}` + "\n",
+		`{"version":4,"requestId":"reconcile-1","command":"reconcilePortals","payload":{"portals":[{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","portalName":"hermes","destination":{"kind":"localApp","port":8787},"desiredState":"enabled"}]}}` + "\n",
 	)
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
@@ -269,7 +269,7 @@ func TestServeReconciliationSerializesStructuredStatusEvent(t *testing.T) {
 	if payload["tailnetName"] != "opaque-identity-do-not-display" || payload["magicDNSSuffix"] != "example.ts.net" {
 		t.Fatalf("payload = %+v, want exact identity and separate display suffix", payload)
 	}
-	const wantResponse = `{"version":3,"requestId":"reconcile-1","result":{"entries":[{"portalId":"9f55ca93-d7b3-4eab-a871-310ea576005a","outcome":"converged"}]}}`
+	const wantResponse = `{"version":4,"requestId":"reconcile-1","result":{"entries":[{"portalId":"9f55ca93-d7b3-4eab-a871-310ea576005a","outcome":"converged"}]}}`
 	if lines[1] != wantResponse {
 		t.Fatalf("response = %q, want %q", lines[1], wantResponse)
 	}
@@ -280,8 +280,8 @@ func TestServeAuthenticatesCorrelatedPortalAndEmitsTransientURL(t *testing.T) {
 		PortalID: "9f55ca93-d7b3-4eab-a871-310ea576005a", Outcome: portal.OutcomeConverged,
 	}}}
 	input := bytes.NewBufferString(
-		`{"version":3,"requestId":"reconcile-1","command":"reconcilePortals","payload":{"portals":[{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","portalName":"hermes","localAppPort":8787,"desiredState":"enabled"}]}}` + "\n" +
-			`{"version":3,"requestId":"auth-1","command":"authenticatePortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A"}}` + "\n",
+		`{"version":4,"requestId":"reconcile-1","command":"reconcilePortals","payload":{"portals":[{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","portalName":"hermes","destination":{"kind":"localApp","port":8787},"desiredState":"enabled"}]}}` + "\n" +
+			`{"version":4,"requestId":"auth-1","command":"authenticatePortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A"}}` + "\n",
 	)
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
@@ -302,7 +302,7 @@ func TestServeAuthenticatesCorrelatedPortalAndEmitsTransientURL(t *testing.T) {
 func TestServeCleansUpOnlyCorrelatedRejectedPortal(t *testing.T) {
 	runtime := &fakeRuntime{}
 	input := bytes.NewBufferString(
-		`{"version":3,"requestId":"cleanup-1","command":"cleanupRejectedPortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A"}}` + "\n",
+		`{"version":4,"requestId":"cleanup-1","command":"cleanupRejectedPortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A"}}` + "\n",
 	)
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
@@ -312,16 +312,16 @@ func TestServeCleansUpOnlyCorrelatedRejectedPortal(t *testing.T) {
 	if exitCode != 0 || diagnostics.Len() != 0 || runtime.cleaned != "9f55ca93-d7b3-4eab-a871-310ea576005a" {
 		t.Fatalf("ServeWithRuntime = (exit %d, cleaned %q, diagnostics %q), want correlated cleanup", exitCode, runtime.cleaned, diagnostics.String())
 	}
-	const want = `{"version":3,"requestId":"cleanup-1","result":{"accepted":true}}` + "\n"
+	const want = `{"version":4,"requestId":"cleanup-1","result":{"accepted":true}}` + "\n"
 	if output.String() != want {
 		t.Fatalf("output = %q, want %q", output.String(), want)
 	}
 }
 
-func TestServeRemovesOnlyCorrelatedPortalWithProtocolVersionThree(t *testing.T) {
+func TestServeRemovesOnlyCorrelatedPortalWithProtocolVersionFour(t *testing.T) {
 	runtime := &fakeRuntime{}
 	input := bytes.NewBufferString(
-		`{"version":3,"requestId":"remove-1","command":"removePortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A"}}` + "\n",
+		`{"version":4,"requestId":"remove-1","command":"removePortal","payload":{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A"}}` + "\n",
 	)
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
@@ -331,7 +331,7 @@ func TestServeRemovesOnlyCorrelatedPortalWithProtocolVersionThree(t *testing.T) 
 	if exitCode != 0 || diagnostics.Len() != 0 || runtime.removed != "9f55ca93-d7b3-4eab-a871-310ea576005a" {
 		t.Fatalf("ServeWithRuntime = (exit %d, removed %q, diagnostics %q), want correlated removal", exitCode, runtime.removed, diagnostics.String())
 	}
-	const want = `{"version":3,"requestId":"remove-1","result":{"accepted":true}}` + "\n"
+	const want = `{"version":4,"requestId":"remove-1","result":{"accepted":true}}` + "\n"
 	if output.String() != want {
 		t.Fatalf("output = %q, want %q", output.String(), want)
 	}
@@ -347,7 +347,7 @@ func TestServeRejectsUntrustedRemovalPayloadWithoutRuntimeCall(t *testing.T) {
 	for name, payload := range fixtures {
 		t.Run(name, func(t *testing.T) {
 			runtime := &fakeRuntime{}
-			input := bytes.NewBufferString(`{"version":3,"requestId":"remove-1","command":"removePortal","payload":` + payload + `}` + "\n")
+			input := bytes.NewBufferString(`{"version":4,"requestId":"remove-1","command":"removePortal","payload":` + payload + `}` + "\n")
 			var output bytes.Buffer
 
 			if exitCode := ServeWithRuntime(input, &output, &bytes.Buffer{}, runtime); exitCode != 0 {
@@ -364,14 +364,14 @@ func TestServeMapsRemovalFailureToFixedRuntimeError(t *testing.T) {
 	const secret = "path=/private/secret"
 	runtime := &fakeRuntime{removeErr: errors.New(secret)}
 	input := bytes.NewBufferString(
-		`{"version":3,"requestId":"remove-1","command":"removePortal","payload":{"portalId":"9f55ca93-d7b3-4eab-a871-310ea576005a"}}` + "\n",
+		`{"version":4,"requestId":"remove-1","command":"removePortal","payload":{"portalId":"9f55ca93-d7b3-4eab-a871-310ea576005a"}}` + "\n",
 	)
 	var output bytes.Buffer
 
 	if exitCode := ServeWithRuntime(input, &output, &bytes.Buffer{}, runtime); exitCode != 0 {
 		t.Fatalf("ServeWithRuntime exit code = %d, want correlated failure", exitCode)
 	}
-	const want = `{"version":3,"requestId":"remove-1","error":{"code":"runtimeFailure","message":"portal runtime failed"}}` + "\n"
+	const want = `{"version":4,"requestId":"remove-1","error":{"code":"runtimeFailure","message":"portal runtime failed"}}` + "\n"
 	if output.String() != want || strings.Contains(output.String(), secret) {
 		t.Fatalf("output = %q, want fixed secret-free runtime error", output.String())
 	}
@@ -383,15 +383,15 @@ func TestServeRejectsInvalidReconciliationWithoutRuntimeMutationOrLeaks(t *testi
 		"missing portals": `{}`,
 		"null portals":    `{"portals":null}`,
 		"duplicate uuid": `{"portals":[` +
-			`{"portalId":"9f55ca93-d7b3-4eab-a871-310ea576005a","portalName":"hermes","localAppPort":8787,"desiredState":"enabled"},` +
-			`{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","portalName":"hermes","localAppPort":8787,"desiredState":"stopped"}]}`,
-		"invalid desired state": `{"portals":[{"portalId":"9f55ca93-d7b3-4eab-a871-310ea576005a","portalName":"hermes","localAppPort":8787,"desiredState":"paused"}]}`,
-		"unknown portal field":  `{"portals":[{"portalId":"9f55ca93-d7b3-4eab-a871-310ea576005a","portalName":"hermes","localAppPort":8787,"desiredState":"enabled","url":"` + secret + `"}]}`,
+			`{"portalId":"9f55ca93-d7b3-4eab-a871-310ea576005a","portalName":"hermes","destination":{"kind":"localApp","port":8787},"desiredState":"enabled"},` +
+			`{"portalId":"9F55CA93-D7B3-4EAB-A871-310EA576005A","portalName":"hermes","destination":{"kind":"localApp","port":8787},"desiredState":"stopped"}]}`,
+		"invalid desired state": `{"portals":[{"portalId":"9f55ca93-d7b3-4eab-a871-310ea576005a","portalName":"hermes","destination":{"kind":"localApp","port":8787},"desiredState":"paused"}]}`,
+		"unknown portal field":  `{"portals":[{"portalId":"9f55ca93-d7b3-4eab-a871-310ea576005a","portalName":"hermes","destination":{"kind":"localApp","port":8787},"desiredState":"enabled","url":"` + secret + `"}]}`,
 	}
 	for name, payload := range fixtures {
 		t.Run(name, func(t *testing.T) {
 			runtime := &fakeRuntime{}
-			input := bytes.NewBufferString(`{"version":3,"requestId":"reconcile-1","command":"reconcilePortals","payload":` + payload + `}` + "\n")
+			input := bytes.NewBufferString(`{"version":4,"requestId":"reconcile-1","command":"reconcilePortals","payload":` + payload + `}` + "\n")
 			var output bytes.Buffer
 			var diagnostics bytes.Buffer
 
@@ -407,16 +407,16 @@ func TestServeRejectsInvalidReconciliationWithoutRuntimeMutationOrLeaks(t *testi
 	}
 }
 
-func TestServeRejectsImperativeStartPortalInProtocolVersionThree(t *testing.T) {
+func TestServeRejectsImperativeStartPortalInProtocolVersionFour(t *testing.T) {
 	input := bytes.NewBufferString(
-		`{"version":3,"requestId":"start-1","command":"startPortal","payload":{"portalId":"9f55ca93-d7b3-4eab-a871-310ea576005a","portalName":"hermes","localAppPort":8787}}` + "\n",
+		`{"version":4,"requestId":"start-1","command":"startPortal","payload":{"portalId":"9f55ca93-d7b3-4eab-a871-310ea576005a","portalName":"hermes","destination":{"kind":"localApp","port":8787}}}` + "\n",
 	)
 	var output bytes.Buffer
 
 	if exitCode := ServeWithRuntime(input, &output, &bytes.Buffer{}, &fakeRuntime{}); exitCode != 0 {
 		t.Fatalf("ServeWithRuntime exit code = %d", exitCode)
 	}
-	const want = `{"version":3,"requestId":"start-1","error":{"code":"unknownCommand","message":"unsupported command"}}` + "\n"
+	const want = `{"version":4,"requestId":"start-1","error":{"code":"unknownCommand","message":"unsupported command"}}` + "\n"
 	if output.String() != want {
 		t.Fatalf("output = %q, want protocol-v1 lifecycle rejection", output.String())
 	}
@@ -424,7 +424,7 @@ func TestServeRejectsImperativeStartPortalInProtocolVersionThree(t *testing.T) {
 
 func TestServeClosesRuntimeOnShutdown(t *testing.T) {
 	runtime := &fakeRuntime{}
-	input := bytes.NewBufferString(`{"version":3,"requestId":"shutdown-1","command":"shutdown","payload":{}}` + "\n")
+	input := bytes.NewBufferString(`{"version":4,"requestId":"shutdown-1","command":"shutdown","payload":{}}` + "\n")
 	var output bytes.Buffer
 
 	if exitCode := ServeWithRuntime(input, &output, &bytes.Buffer{}, runtime); exitCode != 0 || !runtime.closed {
@@ -434,7 +434,7 @@ func TestServeClosesRuntimeOnShutdown(t *testing.T) {
 
 func TestServeAcknowledgesShutdownAfterRuntimeCloseCompletes(t *testing.T) {
 	runtime := &fakeRuntime{closeEntered: make(chan struct{}), releaseClose: make(chan struct{})}
-	input := bytes.NewBufferString(`{"version":3,"requestId":"shutdown-1","command":"shutdown","payload":{}}` + "\n")
+	input := bytes.NewBufferString(`{"version":4,"requestId":"shutdown-1","command":"shutdown","payload":{}}` + "\n")
 	var output bytes.Buffer
 	done := make(chan int, 1)
 	go func() { done <- ServeWithRuntime(input, &output, &bytes.Buffer{}, runtime) }()
@@ -512,8 +512,8 @@ func (r *fakeRuntime) Close() error {
 
 func TestServeAcknowledgesShutdownAndStops(t *testing.T) {
 	input := bytes.NewBufferString(
-		`{"version":3,"requestId":"shutdown-1","command":"shutdown","payload":{}}` + "\n" +
-			`{"version":3,"requestId":"ignored","command":"handshake","payload":{}}` + "\n",
+		`{"version":4,"requestId":"shutdown-1","command":"shutdown","payload":{}}` + "\n" +
+			`{"version":4,"requestId":"ignored","command":"handshake","payload":{}}` + "\n",
 	)
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
@@ -523,7 +523,7 @@ func TestServeAcknowledgesShutdownAndStops(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("Serve() exit code = %d, want 0", exitCode)
 	}
-	const want = "{\"version\":3,\"requestId\":\"shutdown-1\",\"result\":{\"accepted\":true}}\n"
+	const want = "{\"version\":4,\"requestId\":\"shutdown-1\",\"result\":{\"accepted\":true}}\n"
 	if output.String() != want {
 		t.Fatalf("output = %q, want %q", output.String(), want)
 	}
@@ -533,7 +533,7 @@ func TestServeAcknowledgesShutdownAndStops(t *testing.T) {
 }
 
 func TestServeReturnsCorrelatedErrorForUnknownCommand(t *testing.T) {
-	input := bytes.NewBufferString(`{"version":3,"requestId":"unknown-1","command":"surprise","payload":{}}` + "\n")
+	input := bytes.NewBufferString(`{"version":4,"requestId":"unknown-1","command":"surprise","payload":{}}` + "\n")
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
 
@@ -542,7 +542,7 @@ func TestServeReturnsCorrelatedErrorForUnknownCommand(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("Serve() exit code = %d, want 0", exitCode)
 	}
-	const want = "{\"version\":3,\"requestId\":\"unknown-1\",\"error\":{\"code\":\"unknownCommand\",\"message\":\"unsupported command\"}}\n"
+	const want = "{\"version\":4,\"requestId\":\"unknown-1\",\"error\":{\"code\":\"unknownCommand\",\"message\":\"unsupported command\"}}\n"
 	if output.String() != want {
 		t.Fatalf("output = %q, want %q", output.String(), want)
 	}
@@ -552,7 +552,7 @@ func TestServeReturnsCorrelatedErrorForUnknownCommand(t *testing.T) {
 }
 
 func TestServeReturnsCorrelatedErrorForUnsupportedVersion(t *testing.T) {
-	input := bytes.NewBufferString(`{"version":2,"requestId":"version-2","command":"handshake","payload":{}}` + "\n")
+	input := bytes.NewBufferString(`{"version":3,"requestId":"version-3","command":"handshake","payload":{}}` + "\n")
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
 
@@ -561,7 +561,7 @@ func TestServeReturnsCorrelatedErrorForUnsupportedVersion(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("Serve() exit code = %d, want 0", exitCode)
 	}
-	const want = "{\"version\":3,\"requestId\":\"version-2\",\"error\":{\"code\":\"unsupportedVersion\",\"message\":\"unsupported protocol version\"}}\n"
+	const want = "{\"version\":4,\"requestId\":\"version-3\",\"error\":{\"code\":\"unsupportedVersion\",\"message\":\"unsupported protocol version\"}}\n"
 	if output.String() != want {
 		t.Fatalf("output = %q, want %q", output.String(), want)
 	}
@@ -572,7 +572,7 @@ func TestServeReturnsCorrelatedErrorForUnsupportedVersion(t *testing.T) {
 
 func TestServeRejectsMalformedInputWithoutLeakingIt(t *testing.T) {
 	const secret = "token=do-not-copy"
-	input := bytes.NewBufferString(`{"version":3,"requestId":"` + secret + `"` + "\n")
+	input := bytes.NewBufferString(`{"version":4,"requestId":"` + secret + `"` + "\n")
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
 
@@ -594,7 +594,7 @@ func TestServeRejectsMalformedInputWithoutLeakingIt(t *testing.T) {
 }
 
 func TestServeRejectsTrailingContentAfterRequest(t *testing.T) {
-	input := bytes.NewBufferString(`{"version":3,"requestId":"request-1","command":"handshake","payload":{}} trailing` + "\n")
+	input := bytes.NewBufferString(`{"version":4,"requestId":"request-1","command":"handshake","payload":{}} trailing` + "\n")
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
 
@@ -608,12 +608,12 @@ func TestServeRejectsTrailingContentAfterRequest(t *testing.T) {
 func TestServeRejectsStructurallyInvalidRequests(t *testing.T) {
 	fixtures := map[string]string{
 		"missing version":    `{"requestId":"request-1","command":"handshake","payload":{}}`,
-		"missing request ID": `{"version":3,"command":"handshake","payload":{}}`,
-		"missing command":    `{"version":3,"requestId":"request-1","payload":{}}`,
-		"missing payload":    `{"version":3,"requestId":"request-1","command":"handshake"}`,
-		"non-object payload": `{"version":3,"requestId":"request-1","command":"handshake","payload":[]}`,
-		"non-empty payload":  `{"version":3,"requestId":"request-1","command":"handshake","payload":{"unexpected":true}}`,
-		"unknown field":      `{"version":3,"requestId":"request-1","command":"handshake","payload":{},"extra":true}`,
+		"missing request ID": `{"version":4,"command":"handshake","payload":{}}`,
+		"missing command":    `{"version":4,"requestId":"request-1","payload":{}}`,
+		"missing payload":    `{"version":4,"requestId":"request-1","command":"handshake"}`,
+		"non-object payload": `{"version":4,"requestId":"request-1","command":"handshake","payload":[]}`,
+		"non-empty payload":  `{"version":4,"requestId":"request-1","command":"handshake","payload":{"unexpected":true}}`,
+		"unknown field":      `{"version":4,"requestId":"request-1","command":"handshake","payload":{},"extra":true}`,
 	}
 
 	for name, fixture := range fixtures {


### PR DESCRIPTION
Fixes #32

Adds exact v4 tagged Local App/Remote App destinations across persistence and helper reconciliation, v1-v3 migration, Remote App creation, and loopback-safe Mac-network proxying.

Validation:
- Focused Swift suites: 94 tests, 0 failures
- `go build ./cmd/portico-helper && go test ./... -count=1`
- `git diff --check`