### PR TITLE
Make Remote App proxying production-safe

### DIFF
--- a/PorticoTests/PortalPresentationTests.swift
+++ b/PorticoTests/PortalPresentationTests.swift
@@ -52,6 +52,39 @@ final class PortalPresentationTests: XCTestCase {
         )
     }
 
+    func testOnlineRemoteAppHasOnlyFixedPortalPresentation() {
+        let portal = PortalConfiguration(
+            id: UUID(uuidString: "9F55CA93-D7B3-4EAB-A871-310EA576005A")!,
+            name: "hermes",
+            destination: .remoteApp(scheme: .https, host: "app.example.com", port: 443),
+            createdAt: Date(),
+            desiredState: .enabled
+        )
+        let status = PortalStatusPayload(
+            state: .online,
+            stableNodeId: nil,
+            assignedName: "hermes",
+            portalURL: URL(string: "https://hermes.example.ts.net/"),
+            addresses: [],
+            magicDNSSuffix: "example.ts.net"
+        )
+
+        let presentation = PortalPresentation(
+            portal: portal,
+            status: status,
+            reachability: .unknown,
+            isStale: false
+        )
+
+        XCTAssertNil(portal.localAppPort)
+        XCTAssertEqual(presentation.portalName, "hermes")
+        XCTAssertEqual(presentation.assignedName, "hermes")
+        XCTAssertEqual(presentation.desiredState, "Enabled")
+        XCTAssertEqual(presentation.tailscaleState, "Online")
+        XCTAssertEqual(presentation.portalURLLabel, "Portal URL")
+        XCTAssertNil(presentation.collisionExplanation)
+    }
+
     func testAnnouncementsAreFixedAndContainNoRuntimeFacts() {
         XCTAssertEqual(PorticoAnnouncement.text(for: .helperConnected), "Helper connected.")
         XCTAssertEqual(PorticoAnnouncement.text(for: .helperTerminalFailure), "Helper unavailable.")

--- a/helper/internal/portal/proxy.go
+++ b/helper/internal/portal/proxy.go
@@ -54,13 +54,31 @@ func newRemoteProxy(target *url.URL, transport http.RoundTripper) http.Handler {
 		Transport: transport,
 		Rewrite: func(request *httputil.ProxyRequest) {
 			request.SetURL(target)
+			request.SetXForwarded()
+			request.Out.Header.Set("X-Forwarded-Proto", "https")
 		},
-		ErrorLog: log.New(io.Discard, "", 0),
+		FlushInterval: -1,
+		ErrorLog:      log.New(io.Discard, "", 0),
 	}
 	proxy.ErrorHandler = func(writer http.ResponseWriter, _ *http.Request, _ error) {
 		http.Error(writer, http.StatusText(http.StatusBadGateway), http.StatusBadGateway)
 	}
-	return proxy
+	return &remoteProxy{proxy: proxy, transport: transport}
+}
+
+type remoteProxy struct {
+	proxy     *httputil.ReverseProxy
+	transport http.RoundTripper
+}
+
+func (p *remoteProxy) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	p.proxy.ServeHTTP(writer, request)
+}
+
+func (p *remoteProxy) CloseIdleConnections() {
+	if transport, ok := p.transport.(interface{ CloseIdleConnections() }); ok {
+		transport.CloseIdleConnections()
+	}
 }
 
 func safeRemoteDialer(resolve func(context.Context, string, string) ([]netip.Addr, error)) func(context.Context, string, string) (net.Conn, error) {
@@ -144,6 +162,7 @@ func (p *proxyServer) close() error {
 	cancel()
 	closeErr := p.server.Close()
 	listenerErr := p.listener.Close()
+	p.handler.closeIdleConnections()
 	p.handler.wait()
 	p.doneOnce.Do(func() { p.serveErr = <-p.done })
 	serveErr := p.serveErr
@@ -195,6 +214,15 @@ func (h *trackedHandler) stopAccepting() {
 	h.mu.Lock()
 	h.isAccepting = false
 	h.mu.Unlock()
+}
+
+func (h *trackedHandler) closeIdleConnections() {
+	h.mu.Lock()
+	handler := h.handler
+	h.mu.Unlock()
+	if closer, ok := handler.(interface{ CloseIdleConnections() }); ok {
+		closer.CloseIdleConnections()
+	}
 }
 
 func (h *trackedHandler) wait() {

--- a/helper/internal/portal/proxy_test.go
+++ b/helper/internal/portal/proxy_test.go
@@ -70,6 +70,47 @@ func TestRemoteAppHTTPProxyUsesConfiguredAuthority(t *testing.T) {
 	}
 }
 
+func TestRemoteAppHTTPProxyCanonicalizesForwardingHeaders(t *testing.T) {
+	received := make(chan *http.Request, 1)
+	remote := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		received <- request.Clone(request.Context())
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	defer remote.Close()
+	_, port, err := net.SplitHostPort(strings.TrimPrefix(remote.URL, "http://"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	transport := &http.Transport{DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, network, strings.TrimPrefix(remote.URL, "http://"))
+	}}
+	proxy := newRemoteProxy(&url.URL{Scheme: "http", Host: "app.example.com:" + port}, transport)
+	request := httptest.NewRequest(http.MethodGet, "https://portal.example.ts.net/app", nil)
+	request.RemoteAddr = "100.64.0.7:54321"
+	request.Header.Set("Forwarded", "for=attacker;host=attacker.example;proto=http")
+	request.Header.Set("X-Forwarded-For", "192.0.2.1")
+	request.Header.Set("X-Forwarded-Host", "attacker.example")
+	request.Header.Set("X-Forwarded-Proto", "http")
+	proxy.ServeHTTP(httptest.NewRecorder(), request)
+
+	got := <-received
+	if got.Host != "app.example.com:"+port {
+		t.Fatalf("Remote App Host = %q, want configured authority", got.Host)
+	}
+	if forwarded := got.Header.Get("Forwarded"); forwarded != "" {
+		t.Fatalf("Forwarded = %q, want removed", forwarded)
+	}
+	if got := got.Header.Values("X-Forwarded-For"); len(got) != 1 || got[0] != "100.64.0.7" {
+		t.Fatalf("X-Forwarded-For = %q, want actual client address", got)
+	}
+	if got := got.Header.Values("X-Forwarded-Host"); len(got) != 1 || got[0] != "portal.example.ts.net" {
+		t.Fatalf("X-Forwarded-Host = %q, want public Portal host", got)
+	}
+	if got := got.Header.Values("X-Forwarded-Proto"); len(got) != 1 || got[0] != "https" {
+		t.Fatalf("X-Forwarded-Proto = %q, want HTTPS", got)
+	}
+}
+
 func TestRemoteAppHTTPSProxyUsesTrustedTestTransport(t *testing.T) {
 	remote := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		_, _ = io.WriteString(writer, "trusted TLS")
@@ -88,6 +129,273 @@ func TestRemoteAppHTTPSProxyUsesTrustedTestTransport(t *testing.T) {
 	proxy.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "https://portal.example.ts.net/", nil))
 	if response.Code != http.StatusOK || response.Body.String() != "trusted TLS" {
 		t.Fatalf("response = (%d, %q), want trusted HTTPS Remote App", response.Code, response.Body.String())
+	}
+}
+
+func TestRemoteAppHTTPSProxyCanonicalizesForwardingHeaders(t *testing.T) {
+	received := make(chan *http.Request, 1)
+	remote := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		received <- request.Clone(request.Context())
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	defer remote.Close()
+	_, port, err := net.SplitHostPort(strings.TrimPrefix(remote.URL, "https://"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	transport := remote.Client().Transport.(*http.Transport).Clone()
+	transport.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, network, strings.TrimPrefix(remote.URL, "https://"))
+	}
+	proxy := newRemoteProxy(&url.URL{Scheme: "https", Host: "app.example.com:" + port}, transport)
+	request := httptest.NewRequest(http.MethodGet, "https://portal.example.ts.net/app", nil)
+	request.RemoteAddr = "100.64.0.7:54321"
+	request.Header.Set("Forwarded", "for=attacker;host=attacker.example;proto=http")
+	request.Header.Set("X-Forwarded-For", "192.0.2.1")
+	request.Header.Set("X-Forwarded-Host", "attacker.example")
+	request.Header.Set("X-Forwarded-Proto", "http")
+	proxy.ServeHTTP(httptest.NewRecorder(), request)
+
+	got := <-received
+	if got.Host != "app.example.com:"+port {
+		t.Fatalf("Remote App Host = %q, want configured authority", got.Host)
+	}
+	if got.Header.Get("Forwarded") != "" || got.Header.Get("X-Forwarded-For") != "100.64.0.7" ||
+		got.Header.Get("X-Forwarded-Host") != "portal.example.ts.net" || got.Header.Get("X-Forwarded-Proto") != "https" {
+		t.Fatalf("forwarding headers = %#v, want canonical HTTPS values", got.Header)
+	}
+}
+
+func TestRemoteAppProxyReturnsOnlyGenericBadGatewayForDestinationFailures(t *testing.T) {
+	const providerSecret = "provider-error-do-not-expose"
+	for _, test := range []struct {
+		name      string
+		newTarget func(*testing.T) (*url.URL, http.RoundTripper)
+	}{
+		{
+			name: "DNS",
+			newTarget: func(*testing.T) (*url.URL, http.RoundTripper) {
+				transport := &http.Transport{
+					DialContext: safeRemoteDialer(func(context.Context, string, string) ([]netip.Addr, error) {
+						return nil, errors.New("DNS: " + providerSecret)
+					}),
+				}
+				return &url.URL{Scheme: "https", Host: "app.example.com:443"}, transport
+			},
+		},
+		{
+			name: "connection",
+			newTarget: func(*testing.T) (*url.URL, http.RoundTripper) {
+				transport := &http.Transport{DialContext: func(context.Context, string, string) (net.Conn, error) {
+					return nil, errors.New("connection: " + providerSecret)
+				}}
+				return &url.URL{Scheme: "https", Host: "app.example.com:443"}, transport
+			},
+		},
+		{
+			name: "TLS",
+			newTarget: func(t *testing.T) (*url.URL, http.RoundTripper) {
+				remote := httptest.NewTLSServer(http.NotFoundHandler())
+				t.Cleanup(remote.Close)
+				target, err := url.Parse(remote.URL)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return target, http.DefaultTransport.(*http.Transport).Clone()
+			},
+		},
+		{
+			name: "response",
+			newTarget: func(*testing.T) (*url.URL, http.RoundTripper) {
+				return &url.URL{Scheme: "https", Host: "app.example.com:443"}, responseFailureRoundTripper{
+					err: errors.New("response: " + providerSecret),
+				}
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			target, transport := test.newTarget(t)
+			assertRemoteAppFailureIsRedacted(t, newRemoteProxy(target, transport), providerSecret)
+		})
+	}
+}
+
+func assertRemoteAppFailureIsRedacted(t *testing.T, proxy http.Handler, providerSecret string) {
+	t.Helper()
+	const requestSecret = "request-body-do-not-log"
+	var logs bytes.Buffer
+	previousWriter := log.Writer()
+	previousFlags := log.Flags()
+	previousPrefix := log.Prefix()
+	log.SetOutput(&logs)
+	log.SetFlags(0)
+	log.SetPrefix("")
+	t.Cleanup(func() {
+		log.SetOutput(previousWriter)
+		log.SetFlags(previousFlags)
+		log.SetPrefix(previousPrefix)
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "https://portal.example.ts.net/", strings.NewReader(requestSecret))
+	request.Header.Set("Authorization", "Bearer "+requestSecret)
+	response := httptest.NewRecorder()
+	proxy.ServeHTTP(response, request)
+	if response.Code != http.StatusBadGateway || response.Body.String() != "Bad Gateway\n" {
+		t.Fatalf("response = (%d, %q), want generic bad gateway", response.Code, response.Body.String())
+	}
+	for _, secret := range []string{providerSecret, requestSecret} {
+		if strings.Contains(response.Body.String(), secret) || strings.Contains(logs.String(), secret) {
+			t.Fatalf("secret %q leaked", secret)
+		}
+	}
+}
+
+func TestRemoteAppProxyStreamsImmediately(t *testing.T) {
+	for _, useTLS := range []bool{false, true} {
+		t.Run(strconv.FormatBool(useTLS), func(t *testing.T) {
+			release := make(chan struct{})
+			remote := startRemoteAppServer(t, useTLS, http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+				const firstWrite = "first chunk\n"
+				writer.Header().Set("Content-Length", strconv.Itoa(len(firstWrite)+len("finished\n")))
+				_, _ = io.WriteString(writer, firstWrite)
+				writer.(http.Flusher).Flush()
+				<-release
+				_, _ = io.WriteString(writer, "finished\n")
+			}))
+			proxy := newTestRemoteProxyServer(t, remote)
+
+			response, err := (&http.Client{Timeout: 2 * time.Second}).Get(proxy.URL)
+			if err != nil {
+				close(release)
+				t.Fatal(err)
+			}
+			defer response.Body.Close()
+			delivered := make([]byte, len("first chunk\n"))
+			if _, err := io.ReadFull(response.Body, delivered); err != nil {
+				close(release)
+				t.Fatal(err)
+			}
+			if string(delivered) != "first chunk\n" {
+				close(release)
+				t.Fatalf("first delivery = %q, want response before Remote App completion", delivered)
+			}
+			close(release)
+		})
+	}
+}
+
+func TestRemoteAppProxyFlushesSSEImmediately(t *testing.T) {
+	for _, useTLS := range []bool{false, true} {
+		t.Run(strconv.FormatBool(useTLS), func(t *testing.T) {
+			release := make(chan struct{})
+			remote := startRemoteAppServer(t, useTLS, http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+				writer.Header().Set("Content-Type", "text/event-stream")
+				_, _ = io.WriteString(writer, "data: first\n\n")
+				writer.(http.Flusher).Flush()
+				<-release
+			}))
+			proxy := newTestRemoteProxyServer(t, remote)
+
+			response, err := (&http.Client{Timeout: 2 * time.Second}).Get(proxy.URL)
+			if err != nil {
+				close(release)
+				t.Fatal(err)
+			}
+			defer response.Body.Close()
+			delivered := make([]byte, len("data: first\n\n"))
+			if _, err := io.ReadFull(response.Body, delivered); err != nil {
+				close(release)
+				t.Fatal(err)
+			}
+			if string(delivered) != "data: first\n\n" {
+				close(release)
+				t.Fatalf("first delivery = %q, want SSE event before Remote App completion", delivered)
+			}
+			close(release)
+		})
+	}
+}
+
+func TestRemoteAppProxyProxiesWebSocketBidirectionally(t *testing.T) {
+	for _, useTLS := range []bool{false, true} {
+		t.Run(strconv.FormatBool(useTLS), func(t *testing.T) {
+			remote := startRemoteAppServer(t, useTLS, http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				connection, err := websocket.Accept(writer, request, nil)
+				if err != nil {
+					return
+				}
+				defer connection.CloseNow()
+				messageType, message, err := connection.Read(request.Context())
+				if err != nil {
+					return
+				}
+				_ = connection.Write(request.Context(), messageType, append([]byte("app-to-client:"), message...))
+			}))
+			proxy := newTestRemoteProxyServer(t, remote)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			connection, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(proxy.URL, "http"), nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer connection.CloseNow()
+			if err := connection.Write(ctx, websocket.MessageText, []byte("client-to-app")); err != nil {
+				t.Fatal(err)
+			}
+			messageType, message, err := connection.Read(ctx)
+			if err != nil || messageType != websocket.MessageText || string(message) != "app-to-client:client-to-app" {
+				t.Fatalf("WebSocket response = (%v, %q, %v), want bidirectional Remote App message", messageType, message, err)
+			}
+		})
+	}
+}
+
+func TestRemoteAppProxyPropagatesCancellation(t *testing.T) {
+	for _, useTLS := range []bool{false, true} {
+		t.Run(strconv.FormatBool(useTLS), func(t *testing.T) {
+			requestEntered := make(chan struct{})
+			requestCanceled := make(chan struct{})
+			remote := startRemoteAppServer(t, useTLS, http.HandlerFunc(func(_ http.ResponseWriter, request *http.Request) {
+				close(requestEntered)
+				<-request.Context().Done()
+				close(requestCanceled)
+			}))
+			proxy := newTestRemoteProxyServer(t, remote)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			request, err := http.NewRequestWithContext(ctx, http.MethodGet, proxy.URL, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			requestDone := make(chan error, 1)
+			go func() {
+				response, err := http.DefaultClient.Do(request)
+				if response != nil {
+					_ = response.Body.Close()
+				}
+				requestDone <- err
+			}()
+			select {
+			case <-requestEntered:
+			case <-time.After(2 * time.Second):
+				t.Fatal("Remote App request did not start")
+			}
+			cancel()
+			select {
+			case <-requestCanceled:
+			case <-time.After(2 * time.Second):
+				t.Fatal("client cancellation did not reach Remote App")
+			}
+			select {
+			case err := <-requestDone:
+				if err == nil {
+					t.Fatal("client request completed without cancellation error")
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("client request did not finish after cancellation")
+			}
+		})
 	}
 }
 
@@ -339,6 +647,41 @@ func newTestProxyServer(t *testing.T, localAppURL string) *httptest.Server {
 	return httptest.NewServer(proxy)
 }
 
+func startRemoteAppServer(t *testing.T, useTLS bool, handler http.Handler) *httptest.Server {
+	t.Helper()
+	server := httptest.NewUnstartedServer(handler)
+	if useTLS {
+		server.StartTLS()
+	} else {
+		server.Start()
+	}
+	t.Cleanup(server.Close)
+	return server
+}
+
+func newTestRemoteProxyServer(t *testing.T, remote *httptest.Server) *httptest.Server {
+	t.Helper()
+	remoteURL, err := url.Parse(remote.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, port, err := net.SplitHostPort(remoteURL.Host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	if remoteURL.Scheme == "https" {
+		transport = remote.Client().Transport.(*http.Transport).Clone()
+	}
+	transport.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, network, remoteURL.Host)
+	}
+	target := &url.URL{Scheme: remoteURL.Scheme, Host: "app.example.com:" + port}
+	proxy := httptest.NewServer(newRemoteProxy(target, transport))
+	t.Cleanup(proxy.Close)
+	return proxy
+}
+
 func localAppPort(t *testing.T, localAppURL string) (int, string) {
 	t.Helper()
 	_, portText, err := net.SplitHostPort(strings.TrimPrefix(localAppURL, "http://"))
@@ -386,14 +729,18 @@ func TestLoopbackDestinationCannotContainHostSchemePathOrURL(t *testing.T) {
 	}
 }
 
-func TestProxyCloseCanRetryAfterUnconfirmedListenerClose(t *testing.T) {
+func TestRemoteProxyCloseCanRetryAfterUnconfirmedListenerClose(t *testing.T) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
 	}
 	flaky := &flakyCloseListener{Listener: listener}
 	flaky.failuresRemaining.Store(2)
-	proxy := startProxyServer(context.Background(), flaky, http.NotFoundHandler())
+	proxy := startProxyServer(
+		context.Background(),
+		flaky,
+		newRemoteProxy(&url.URL{Scheme: "https", Host: "app.example.com:443"}, &http.Transport{}),
+	)
 
 	if err := proxy.close(); err == nil {
 		t.Fatal("first close succeeded, want unconfirmed close failure")
@@ -410,9 +757,69 @@ func TestProxyCloseCanRetryAfterUnconfirmedListenerClose(t *testing.T) {
 	}
 }
 
+func TestProxyCloseClosesRemoteTransportIdleConnections(t *testing.T) {
+	remote := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(writer, "ok")
+	}))
+	defer remote.Close()
+	remoteURL, err := url.Parse(remote.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, port, err := net.SplitHostPort(remoteURL.Host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	transport := &closeTrackingTransport{Transport: http.DefaultTransport.(*http.Transport).Clone()}
+	transport.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, network, remoteURL.Host)
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxy := startProxyServer(context.Background(), listener, newRemoteProxy(
+		&url.URL{Scheme: "http", Host: "app.example.com:" + port}, transport,
+	))
+	response, err := http.Get("http://" + listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = io.Copy(io.Discard, response.Body)
+	_ = response.Body.Close()
+
+	if err := proxy.close(); err != nil {
+		t.Fatal(err)
+	}
+	if !transport.closed.Load() {
+		t.Fatal("Remote App transport idle connections were not closed")
+	}
+}
+
 type flakyCloseListener struct {
 	net.Listener
 	failuresRemaining atomic.Int32
+}
+
+type responseFailureRoundTripper struct {
+	err error
+}
+
+func (r responseFailureRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("response-body-do-not-log")),
+	}, r.err
+}
+
+type closeTrackingTransport struct {
+	*http.Transport
+	closed atomic.Bool
+}
+
+func (t *closeTrackingTransport) CloseIdleConnections() {
+	t.closed.Store(true)
+	t.Transport.CloseIdleConnections()
 }
 
 func (l *flakyCloseListener) Close() error {

--- a/helper/internal/portal/runtime.go
+++ b/helper/internal/portal/runtime.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net"
+	"net/http"
 	"net/netip"
 	"os"
 	"path/filepath"
@@ -229,10 +230,11 @@ type Event struct {
 }
 
 type Runtime struct {
-	mu        sync.Mutex
-	stateRoot string
-	factory   NodeFactory
-	portals   map[string]*portalRuntime
+	mu                  sync.Mutex
+	stateRoot           string
+	factory             NodeFactory
+	proxyForDestination func(Destination) (http.Handler, error)
+	portals             map[string]*portalRuntime
 }
 
 type portalRuntime struct {
@@ -244,13 +246,19 @@ type portalRuntime struct {
 	runContext            context.Context
 	watchDone             sync.WaitGroup
 	emit                  func(Event)
+	proxyForDestination   func(Destination) (http.Handler, error)
 	authenticationPending bool
 	proxy                 *proxyServer
 	isRunning             bool
 }
 
 func NewRuntime(stateRoot string, factory NodeFactory) *Runtime {
-	return &Runtime{stateRoot: stateRoot, factory: factory, portals: make(map[string]*portalRuntime)}
+	return &Runtime{
+		stateRoot:           stateRoot,
+		factory:             factory,
+		proxyForDestination: newDestinationProxy,
+		portals:             make(map[string]*portalRuntime),
+	}
 }
 
 func (r *Runtime) Reconcile(ctx context.Context, configs []Config, emit func(Event)) ([]ReconcileEntry, error) {
@@ -333,7 +341,7 @@ func (r *Runtime) reconcilePortalLocked(
 
 func (r *Runtime) startPortalLocked(ctx context.Context, config Config, emit func(Event)) ReconcileOutcome {
 	node := r.factory(filepath.Join(r.stateRoot, config.ID), config.Name)
-	portal := &portalRuntime{}
+	portal := &portalRuntime{proxyForDestination: r.proxyForDestination}
 	r.portals[config.ID] = portal
 	if err := portal.start(ctx, config, node, emit); err != nil {
 		if closeErr := portal.close(); closeErr == nil {
@@ -504,7 +512,7 @@ func (r *portalRuntime) updateDestination(destination Destination) error {
 	if r.config == nil {
 		return errors.New("portal is not running")
 	}
-	handler, err := newDestinationProxy(destination)
+	handler, err := r.proxyForDestination(destination)
 	if err != nil {
 		return err
 	}
@@ -612,7 +620,7 @@ func (r *portalRuntime) ensureProxyLocked() error {
 	if r.proxy != nil {
 		return nil
 	}
-	handler, err := newDestinationProxy(r.config.Destination)
+	handler, err := r.proxyForDestination(r.config.Destination)
 	if err != nil {
 		return err
 	}

--- a/helper/internal/portal/runtime_test.go
+++ b/helper/internal/portal/runtime_test.go
@@ -7,9 +7,11 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -23,6 +25,23 @@ const secondPortalID = "5ea74329-3144-4ba2-925f-138d14d61fcc"
 
 func localAppDestination(port uint16) Destination {
 	return Destination{Kind: DestinationLocalApp, Port: port}
+}
+
+func remoteAppDestination(t *testing.T, remote *httptest.Server) Destination {
+	t.Helper()
+	remoteURL, err := url.Parse(remote.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, portText, err := net.SplitHostPort(remoteURL.Host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.ParseUint(portText, 10, 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return Destination{Kind: DestinationRemoteApp, Scheme: remoteURL.Scheme, Host: "app.example.com", Port: uint16(port)}
 }
 
 func TestDestinationRejectsIPv4MappedLoopback(t *testing.T) {
@@ -927,6 +946,10 @@ func TestRuntimeCloseClosesIdleConnection(t *testing.T) {
 	if !factory.node.listenerClosedBeforeNode {
 		t.Fatal("TLS listener was not closed before the tsnet node")
 	}
+	if response, err = http.Get(proxyURL); err == nil {
+		_ = response.Body.Close()
+		t.Fatal("Remote App proxy accepted a new request after Runtime.Close")
+	}
 }
 
 func TestRuntimeCloseClosesWebSocket(t *testing.T) {
@@ -962,6 +985,232 @@ func TestRuntimeCloseClosesWebSocket(t *testing.T) {
 	}
 }
 
+func TestRuntimeCloseCancelsActiveRemoteAppRequestBeforeNodeClose(t *testing.T) {
+	requestEntered := make(chan struct{})
+	handlerExited := make(chan struct{})
+	remote := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, request *http.Request) {
+		close(requestEntered)
+		<-request.Context().Done()
+		close(handlerExited)
+	}))
+	t.Cleanup(remote.Close)
+	runtime, proxyURL, factory, _ := newOnlineRuntimeWithRemoteApp(t, remote, func(Event) {})
+	factory.node.observeClose = func() {
+		select {
+		case <-handlerExited:
+			factory.node.handlersExitedBeforeNode = true
+		default:
+		}
+	}
+
+	requestDone := make(chan error, 1)
+	go func() {
+		response, err := http.Get(proxyURL)
+		if response != nil {
+			_ = response.Body.Close()
+		}
+		requestDone <- err
+	}()
+	waitForSignal(t, requestEntered, "active Remote App request")
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- runtime.Close() }()
+	waitForSignal(t, handlerExited, "active Remote App handler exit")
+	if err := waitForRuntimeClose(t, closeDone); err != nil {
+		t.Fatal(err)
+	}
+	_ = waitForError(t, requestDone, "Remote App client request")
+	if !factory.node.handlersExitedBeforeNode {
+		t.Fatal("tsnet node closed before the active Remote App handler exited")
+	}
+}
+
+func TestRuntimeCloseClosesIdleRemoteAppTransport(t *testing.T) {
+	remote := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(writer, "ok")
+	}))
+	t.Cleanup(remote.Close)
+	runtime, proxyURL, factory, transport := newOnlineRuntimeWithRemoteApp(t, remote, func(Event) {})
+	response, err := http.Get(proxyURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = io.Copy(io.Discard, response.Body)
+	_ = response.Body.Close()
+
+	if err := runtime.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if !transport.closed.Load() {
+		t.Fatal("Remote App idle transport connections were not closed")
+	}
+	if !factory.node.listenerClosedBeforeNode {
+		t.Fatal("TLS listener was not closed before the tsnet node")
+	}
+}
+
+func TestRemoteAppDestinationFailureDoesNotPublishPortalHealth(t *testing.T) {
+	remote := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		connection, _, err := writer.(http.Hijacker).Hijack()
+		if err == nil {
+			_ = connection.Close()
+		}
+	}))
+	t.Cleanup(remote.Close)
+	events := make([]Event, 0, 1)
+	_, proxyURL, _, _ := newOnlineRuntimeWithRemoteApp(t, remote, func(event Event) {
+		events = append(events, event)
+	})
+	if len(events) != 1 || events[0].Status == nil || events[0].Status.State != StateOnline {
+		t.Fatalf("initial events = %+v, want only Online status", events)
+	}
+
+	response, err := http.Get(proxyURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want generic bad gateway", response.StatusCode)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events after destination failure = %+v, want no health event", events)
+	}
+}
+
+func TestRuntimeCloseClosesTrustedHTTPSRemoteAppWebSocket(t *testing.T) {
+	handlerEntered := make(chan struct{})
+	handlerExited := make(chan struct{})
+	remote := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		connection, err := websocket.Accept(writer, request, nil)
+		if err != nil {
+			return
+		}
+		defer connection.CloseNow()
+		close(handlerEntered)
+		_, _, _ = connection.Read(request.Context())
+		close(handlerExited)
+	}))
+	t.Cleanup(remote.Close)
+	runtime, proxyURL, _, _ := newOnlineRuntimeWithRemoteApp(t, remote, func(Event) {})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	connection, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(proxyURL, "http"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer connection.CloseNow()
+	waitForSignal(t, handlerEntered, "trusted HTTPS Remote App WebSocket handler")
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- runtime.Close() }()
+	waitForSignal(t, handlerExited, "trusted HTTPS Remote App WebSocket handler exit")
+	if _, _, err := connection.Read(ctx); err == nil {
+		t.Fatal("client WebSocket remained open after Runtime.Close")
+	}
+	if err := waitForRuntimeClose(t, closeDone); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRemoteAppPortalsKeepTrafficAndFailuresIsolated(t *testing.T) {
+	firstRemote := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path == "/fail" {
+			connection, _, err := writer.(http.Hijacker).Hijack()
+			if err == nil {
+				_ = connection.Close()
+			}
+			return
+		}
+		_, _ = io.WriteString(writer, "first")
+	}))
+	t.Cleanup(firstRemote.Close)
+	secondRemote := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(writer, "second")
+	}))
+	t.Cleanup(secondRemote.Close)
+	firstListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		_ = firstListener.Close()
+		t.Fatal(err)
+	}
+	firstDestination := remoteAppDestination(t, firstRemote)
+	secondDestination := remoteAppDestination(t, secondRemote)
+	listeners := map[string]net.Listener{testPortalID: firstListener, secondPortalID: secondListener}
+	remotes := map[uint16]*httptest.Server{
+		firstDestination.Port:  firstRemote,
+		secondDestination.Port: secondRemote,
+	}
+	runtime := NewRuntime(t.TempDir(), func(dir, _ string) Node {
+		portalID := filepath.Base(dir)
+		return &fakeNode{
+			watcher:      newFakeWatcher(),
+			realListener: listeners[portalID],
+			status: Status{
+				BackendState: "Running",
+				DNSName:      "hermes.example.ts.net.",
+				CertDomains:  []string{"hermes.example.ts.net"},
+			},
+		}
+	})
+	runtime.proxyForDestination = func(destination Destination) (http.Handler, error) {
+		remote := remotes[destination.Port]
+		remoteURL, err := url.Parse(remote.URL)
+		if err != nil {
+			return nil, err
+		}
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, network, remoteURL.Host)
+		}
+		target := &url.URL{
+			Scheme: destination.Scheme,
+			Host:   net.JoinHostPort(destination.Host, strconv.Itoa(int(destination.Port))),
+		}
+		return newRemoteProxy(target, transport), nil
+	}
+	events := make([]Event, 0, 2)
+	entries, err := runtime.Reconcile(context.Background(), []Config{
+		{
+			ID: testPortalID, Name: "hermes", Destination: firstDestination, DesiredState: DesiredStateEnabled,
+		},
+		{
+			ID: secondPortalID, Name: "atlas", Destination: secondDestination, DesiredState: DesiredStateEnabled,
+		},
+	}, func(event Event) {
+		events = append(events, event)
+	})
+	if err != nil || len(entries) != 2 ||
+		entries[0].Outcome != OutcomeConverged || entries[1].Outcome != OutcomeConverged {
+		t.Fatalf("Reconcile = (%+v, %v), want both Remote Apps online", entries, err)
+	}
+	t.Cleanup(func() { _ = runtime.Close() })
+
+	assertRemoteAppResponse(t, "http://"+firstListener.Addr().String(), "/", http.StatusOK, "first")
+	assertRemoteAppResponse(t, "http://"+secondListener.Addr().String(), "/", http.StatusOK, "second")
+	assertRemoteAppResponse(t, "http://"+firstListener.Addr().String(), "/fail", http.StatusBadGateway, "Bad Gateway\n")
+	assertRemoteAppResponse(t, "http://"+secondListener.Addr().String(), "/", http.StatusOK, "second")
+	if len(events) != 2 {
+		t.Fatalf("events after first Remote App failure = %+v, want only initial Online states", events)
+	}
+}
+
+func assertRemoteAppResponse(t *testing.T, baseURL, path string, wantStatus int, wantBody string) {
+	t.Helper()
+	response, err := http.Get(baseURL + path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil || response.StatusCode != wantStatus || string(body) != wantBody {
+		t.Fatalf("response = (%d, %q, %v), want (%d, %q)", response.StatusCode, body, err, wantStatus, wantBody)
+	}
+}
+
 func newOnlineRuntimeWithLocalApp(t *testing.T, handler http.Handler) (*Runtime, string, *fakeFactory) {
 	t.Helper()
 	localApp := httptest.NewServer(handler)
@@ -985,6 +1234,56 @@ func newOnlineRuntimeWithLocalApp(t *testing.T, handler http.Handler) (*Runtime,
 	}
 	t.Cleanup(func() { _ = runtime.Close() })
 	return runtime, "http://" + listener.Addr().String(), factory
+}
+
+func newOnlineRuntimeWithRemoteApp(
+	t *testing.T,
+	remote *httptest.Server,
+	emit func(Event),
+) (*Runtime, string, *fakeFactory, *closeTrackingTransport) {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	remoteURL, err := url.Parse(remote.URL)
+	if err != nil {
+		_ = listener.Close()
+		t.Fatal(err)
+	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	if remoteURL.Scheme == "https" {
+		transport = remote.Client().Transport.(*http.Transport).Clone()
+	}
+	trackedTransport := &closeTrackingTransport{Transport: transport}
+	trackedTransport.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, network, remoteURL.Host)
+	}
+	factory := newFakeFactory()
+	factory.status = Status{
+		BackendState: "Running",
+		DNSName:      "hermes.example.ts.net.",
+		CertDomains:  []string{"hermes.example.ts.net"},
+	}
+	factory.node.realListener = listener
+	runtime := NewRuntime(t.TempDir(), factory.New)
+	runtime.proxyForDestination = func(destination Destination) (http.Handler, error) {
+		target := &url.URL{
+			Scheme: destination.Scheme,
+			Host:   net.JoinHostPort(destination.Host, strconv.Itoa(int(destination.Port))),
+		}
+		return newRemoteProxy(target, trackedTransport), nil
+	}
+	if err := reconcileOne(runtime, Config{
+		ID:          testPortalID,
+		Name:        "hermes",
+		Destination: remoteAppDestination(t, remote),
+	}, emit); err != nil {
+		_ = listener.Close()
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = runtime.Close() })
+	return runtime, "http://" + listener.Addr().String(), factory, trackedTransport
 }
 
 func reconcileOne(runtime *Runtime, config Config, emit func(Event)) error {


### PR DESCRIPTION
Fixes #33

- Canonicalize Remote App forwarding metadata and flush streaming responses immediately.
- Close Remote transport idle connections during Portal shutdown without changing destination repointing semantics.
- Cover redacted failures, HTTP/HTTPS streaming and WebSockets, fake-tsnet shutdown, isolation, and fixed Swift presentation.