### PR TITLE
Fix Portal destination repointing

### DIFF
--- a/Portico/PortalActionAvailability.swift
+++ b/Portico/PortalActionAvailability.swift
@@ -13,7 +13,7 @@ struct PortalActionContext {
     var removalState: PortalRemovalState?
     var hasTailnetBinding: Bool
     var portalCount: Int
-    var isEditedPortValid: Bool
+    var isEditedDestinationValid: Bool
     var isRefreshingLocalApps: Bool
 
     init(
@@ -29,7 +29,7 @@ struct PortalActionContext {
         removalState: PortalRemovalState? = nil,
         hasTailnetBinding: Bool = false,
         portalCount: Int = 0,
-        isEditedPortValid: Bool = false,
+        isEditedDestinationValid: Bool = false,
         isRefreshingLocalApps: Bool = false
     ) {
         self.loggingPreference = loggingPreference
@@ -44,7 +44,7 @@ struct PortalActionContext {
         self.removalState = removalState
         self.hasTailnetBinding = hasTailnetBinding
         self.portalCount = portalCount
-        self.isEditedPortValid = isEditedPortValid
+        self.isEditedDestinationValid = isEditedDestinationValid
         self.isRefreshingLocalApps = isRefreshingLocalApps
     }
 }
@@ -54,7 +54,7 @@ struct PortalActionAvailability: Equatable {
     let refreshLocalApps: Bool
     let start: Bool
     let stop: Bool
-    let editPort: Bool
+    let editDestination: Bool
     let authenticate: Bool
     let copyPortalURL: Bool
     let openPortalURL: Bool
@@ -71,7 +71,7 @@ struct PortalActionAvailability: Equatable {
         refreshLocalApps = helperConnected && !context.isRefreshingLocalApps
         start = isActive && context.desiredState == .stopped
         stop = isActive && context.desiredState == .enabled
-        editPort = isActive && context.isEditedPortValid
+        editDestination = isActive && context.isEditedDestinationValid
         authenticate = isActive
             && context.desiredState == .enabled
             && helperConnected

--- a/Portico/PortalController.swift
+++ b/Portico/PortalController.swift
@@ -14,6 +14,63 @@ enum PortalCreationKind: String, CaseIterable, Identifiable {
     var id: Self { self }
 }
 
+struct PortalDestinationEdit: Equatable {
+    var kind: PortalCreationKind
+    var localAppPort: String
+    var remoteAppScheme: RemoteAppScheme
+    var remoteAppHost: String
+    var remoteAppPort: String
+
+    init(
+        kind: PortalCreationKind,
+        localAppPort: String = "",
+        remoteAppScheme: RemoteAppScheme = .https,
+        remoteAppHost: String = "",
+        remoteAppPort: String = ""
+    ) {
+        self.kind = kind
+        self.localAppPort = localAppPort
+        self.remoteAppScheme = remoteAppScheme
+        self.remoteAppHost = remoteAppHost
+        self.remoteAppPort = remoteAppPort
+    }
+
+    init(destination: PortalDestination) {
+        switch destination {
+        case let .localApp(port):
+            self.init(kind: .localApp, localAppPort: String(port))
+        case let .remoteApp(scheme, host, port):
+            self.init(
+                kind: .remoteApp,
+                remoteAppScheme: scheme,
+                remoteAppHost: host,
+                remoteAppPort: String(port)
+            )
+        }
+    }
+
+    func validated(name: String) throws -> PortalDestination {
+        switch kind {
+        case .localApp:
+            let port = try PortalInputValidator.validate(name: name, port: localAppPort)
+            guard let destination = PortalDestination(localAppPort: port) else {
+                throw PortalValidationError.invalidPort
+            }
+            return destination
+        case .remoteApp:
+            let port = try PortalInputValidator.validate(name: name, port: remoteAppPort)
+            guard let destination = PortalDestination(
+                remoteAppScheme: remoteAppScheme,
+                host: remoteAppHost,
+                port: port
+            ) else {
+                throw PortalValidationError.invalidRemoteHost
+            }
+            return destination
+        }
+    }
+}
+
 struct PortalRemovalNotice: Equatable, Identifiable {
     let id: UUID
     let portalName: String
@@ -341,24 +398,18 @@ final class PortalController: ObservableObject {
         removalNotices.removeAll { $0.id == id }
     }
 
-    func updateLocalAppPort(id: UUID, port: String) {
+    func updateDestination(id: UUID, edit: PortalDestinationEdit) {
         guard let index = installation.portals.firstIndex(where: {
             $0.id == id && $0.lifecycle == .active
         }) else { return }
-        let localAppPort: UInt16
+        let destination: PortalDestination
         do {
-            localAppPort = try PortalInputValidator.validate(
-                name: installation.portals[index].name,
-                port: port
-            )
+            destination = try edit.validated(name: installation.portals[index].name)
         } catch {
-            message = "Enter a port from 1 through 65535."
+            message = "Enter valid destination details."
             return
         }
-        guard installation.portals[index].destination.localAppPort != nil,
-              installation.portals[index].destination.localAppPort != localAppPort,
-              let destination = PortalDestination(localAppPort: localAppPort)
-        else { return }
+        guard installation.portals[index].destination != destination else { return }
         var updated = installation
         updated.portals[index].destination = destination
         _ = savePortalOperation(updated)
@@ -416,15 +467,15 @@ final class PortalController: ObservableObject {
 
     func actionAvailability(
         for portal: PortalConfiguration? = nil,
-        editedPort: String? = nil
+        editedDestination: PortalDestinationEdit? = nil
     ) -> PortalActionAvailability {
         let addInputsValid = portal == nil && (try? newPortalDestination()) != nil
-        let editedPortValid: Bool
-        if let portal, let localPort = portal.localAppPort, let editedPort, editedPort != String(localPort),
-           let parsed = try? PortalInputValidator.validate(name: portal.name, port: editedPort) {
-            editedPortValid = parsed > 0
+        let editedDestinationValid: Bool
+        if let portal, let editedDestination,
+           let destination = try? editedDestination.validated(name: portal.name) {
+            editedDestinationValid = destination != portal.destination
         } else {
-            editedPortValid = false
+            editedDestinationValid = false
         }
         let status = portal.flatMap { statuses[$0.id] }
         return PortalActionAvailability(context: PortalActionContext(
@@ -440,26 +491,19 @@ final class PortalController: ObservableObject {
             removalState: portal.flatMap { removalStates[$0.id] },
             hasTailnetBinding: installation.tailnetBinding != nil,
             portalCount: installation.portals.count,
-            isEditedPortValid: editedPortValid,
+            isEditedDestinationValid: editedDestinationValid,
             isRefreshingLocalApps: isRefreshingLocalApps
         ))
     }
 
     private func newPortalDestination() throws -> PortalDestination {
-        switch creationKind {
-        case .localApp:
-            let port = try PortalInputValidator.validate(name: portalName, port: localAppPort)
-            guard let destination = PortalDestination(localAppPort: port) else { throw PortalValidationError.invalidPort }
-            return destination
-        case .remoteApp:
-            let port = try PortalInputValidator.validate(name: portalName, port: remoteAppPort)
-            guard let destination = PortalDestination(
-                remoteAppScheme: remoteAppScheme,
-                host: remoteAppHost,
-                port: port
-            ) else { throw PortalValidationError.invalidRemoteHost }
-            return destination
-        }
+        try PortalDestinationEdit(
+            kind: creationKind,
+            localAppPort: localAppPort,
+            remoteAppScheme: remoteAppScheme,
+            remoteAppHost: remoteAppHost,
+            remoteAppPort: remoteAppPort
+        ).validated(name: portalName)
     }
 
     func copyPortalURL(id: UUID) {

--- a/Portico/PorticoApp.swift
+++ b/Portico/PorticoApp.swift
@@ -412,14 +412,14 @@ private struct PortalStatusView: View {
     @ObservedObject var controller: PortalController
     let portal: PortalConfiguration
     let onRemove: () -> Void
-    @State private var localAppPort: String
+    @State private var destinationEdit: PortalDestinationEdit
     @FocusState private var startStopFocused: Bool
 
     init(controller: PortalController, portal: PortalConfiguration, onRemove: @escaping () -> Void) {
         self.controller = controller
         self.portal = portal
         self.onRemove = onRemove
-        _localAppPort = State(initialValue: portal.localAppPort.map(String.init) ?? "")
+        _destinationEdit = State(initialValue: PortalDestinationEdit(destination: portal.destination))
     }
 
     var body: some View {
@@ -432,7 +432,10 @@ private struct PortalStatusView: View {
             isStale: isStale
         )
         let rowActions = controller.actionAvailability(for: portal)
-        let editedPortActions = controller.actionAvailability(for: portal, editedPort: localAppPort)
+        let editedDestinationActions = controller.actionAvailability(
+            for: portal,
+            editedDestination: destinationEdit
+        )
         Text(presentation.portalName).font(.headline)
             .accessibilityLabel("Portal Name, \(presentation.portalName)")
             .accessibilityIdentifier("portal-name")
@@ -477,39 +480,67 @@ private struct PortalStatusView: View {
                     .accessibilityIdentifier("authenticate")
             }
         }
-        HStack {
-            if portal.localAppPort != nil {
-                Text("Local App Port")
-                Spacer()
-                TextField("Local App Port", text: $localAppPort)
-                    .frame(width: 80)
-                    .onSubmit(updatePort)
-                    .accessibilityIdentifier("edit-local-app-port")
-                Button("Update") { updatePort() }
-                    .controlSize(.small)
-                    .disabled(!editedPortActions.editPort)
-                    .accessibilityIdentifier("update-local-app-port")
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Button("Local App") { destinationEdit.kind = .localApp }
+                    .accessibilityIdentifier("edit-destination-local")
+                    .disabled(destinationEdit.kind == .localApp)
+                Button("Remote App") { destinationEdit.kind = .remoteApp }
+                    .accessibilityIdentifier("edit-destination-remote")
+                    .disabled(destinationEdit.kind == .remoteApp)
+            }
+            .buttonStyle(.bordered)
+            if destinationEdit.kind == .localApp {
+                HStack {
+                    TextField("Local App Port", text: $destinationEdit.localAppPort)
+                        .frame(width: 80)
+                        .onSubmit { updateDestination() }
+                        .accessibilityIdentifier("edit-local-app-port")
+                    Button("Update Destination") { updateDestination() }
+                        .controlSize(.small)
+                        .disabled(!editedDestinationActions.editDestination)
+                        .accessibilityIdentifier("update-destination")
+                }
             } else {
-                Text("Remote App")
-                Spacer()
-            }
-            Button(portal.desiredState == .enabled ? "Stop" : "Start") {
-                if portal.desiredState == .enabled {
-                    controller.stopPortal(id: portal.id)
-                } else {
-                    controller.startPortal(id: portal.id)
+                HStack {
+                    Picker("Scheme", selection: $destinationEdit.remoteAppScheme) {
+                        Text("HTTP").tag(RemoteAppScheme.http)
+                        Text("HTTPS").tag(RemoteAppScheme.https)
+                    }
+                    .accessibilityIdentifier("edit-remote-app-scheme")
+                    TextField("Remote App Host", text: $destinationEdit.remoteAppHost)
+                        .accessibilityIdentifier("edit-remote-app-host")
                 }
-                DispatchQueue.main.async {
-                    startStopFocused = true
+                HStack {
+                    TextField("Remote App Port", text: $destinationEdit.remoteAppPort)
+                        .frame(width: 80)
+                        .onSubmit { updateDestination() }
+                        .accessibilityIdentifier("edit-remote-app-port")
+                    Button("Update Destination") { updateDestination() }
+                        .controlSize(.small)
+                        .disabled(!editedDestinationActions.editDestination)
+                        .accessibilityIdentifier("update-destination")
                 }
             }
-            .controlSize(.small)
-            .focusable()
-            .focused($startStopFocused)
-            .accessibilityIdentifier("start-stop")
-            .disabled(portal.desiredState == .enabled
-                ? !rowActions.stop
-                : !rowActions.start)
+            HStack {
+                Button(portal.desiredState == .enabled ? "Stop" : "Start") {
+                    if portal.desiredState == .enabled {
+                        controller.stopPortal(id: portal.id)
+                    } else {
+                        controller.startPortal(id: portal.id)
+                    }
+                    DispatchQueue.main.async {
+                        startStopFocused = true
+                    }
+                }
+                .controlSize(.small)
+                .focusable()
+                .focused($startStopFocused)
+                .accessibilityIdentifier("start-stop")
+                .disabled(portal.desiredState == .enabled
+                    ? !rowActions.stop
+                    : !rowActions.start)
+            }
         }
         Button("Diagnostics") { openWindow(id: "diagnostics") }
             .controlSize(.small)
@@ -519,8 +550,8 @@ private struct PortalStatusView: View {
             .accessibilityIdentifier("remove-portal")
     }
 
-    private func updatePort() {
-        controller.updateLocalAppPort(id: portal.id, port: localAppPort)
+    private func updateDestination() {
+        controller.updateDestination(id: portal.id, edit: destinationEdit)
     }
 }
 

--- a/Portico/UITestLaunchConfiguration.swift
+++ b/Portico/UITestLaunchConfiguration.swift
@@ -5,6 +5,7 @@ import Foundation
 enum UITestScenario: String {
     case firstRun = "first-run"
     case online
+    case remoteOnline = "remote-online"
     case authenticating
     case stale
     case restarting
@@ -62,6 +63,17 @@ struct UITestLaunchConfiguration {
                 operationalLogging: .enabled,
                 launchAtLoginOffer: .notOffered
             ))
+        case .remoteOnline:
+            try store.save(InstallationRecord(
+                tailnetBinding: Self.tailnetBinding,
+                portals: [Self.portal(destination: .remoteApp(
+                    scheme: .https,
+                    host: "app.example.com",
+                    port: 443
+                ))],
+                operationalLogging: .enabled,
+                launchAtLoginOffer: .declined
+            ))
         case .online, .authenticating, .stale, .restarting, .terminalFailure:
             try store.save(InstallationRecord(
                 tailnetBinding: Self.tailnetBinding,
@@ -92,13 +104,14 @@ struct UITestLaunchConfiguration {
     )
 
     private static func portal(
+        destination: PortalDestination = .localApp(port: 8080),
         lifecycle: PortalLifecycle = .active,
         removalAssignedName: String? = nil
     ) -> PortalConfiguration {
         PortalConfiguration(
             id: portalID,
             name: "portal-one",
-            localAppPort: 8080,
+            destination: destination,
             createdAt: Date(timeIntervalSince1970: 1_700_000_000),
             desiredState: .enabled,
             lifecycle: lifecycle,
@@ -259,7 +272,7 @@ private final class UITestHelperProcess: HelperProcess {
     }
 
     private func emitStatuses(for portals: [ReconcilePortalPayload]) {
-        guard [.online, .authenticating, .stale, .restarting, .loginOffer].contains(scenario) else { return }
+        guard [.online, .remoteOnline, .authenticating, .stale, .restarting, .loginOffer].contains(scenario) else { return }
         for portal in portals {
             let state: PortalTailscaleState = scenario == .authenticating ? .authenticating : .online
             deliver(HelperEvent(

--- a/PorticoTests/PortalActionAvailabilityTests.swift
+++ b/PorticoTests/PortalActionAvailabilityTests.swift
@@ -13,13 +13,13 @@ final class PortalActionAvailabilityTests: XCTestCase {
             hasPortalURL: true,
             hasTailnetBinding: true,
             portalCount: 1,
-            isEditedPortValid: true
+            isEditedDestinationValid: true
         )
         let available = PortalActionAvailability(context: activeEnabled)
         XCTAssertTrue(available.addPortal)
         XCTAssertTrue(available.refreshLocalApps)
         XCTAssertTrue(available.stop)
-        XCTAssertTrue(available.editPort)
+        XCTAssertTrue(available.editDestination)
         XCTAssertTrue(available.copyPortalURL)
         XCTAssertTrue(available.openPortalURL)
         XCTAssertTrue(available.diagnostics)
@@ -37,7 +37,7 @@ final class PortalActionAvailabilityTests: XCTestCase {
         let offline = PortalActionAvailability(context: stoppedOffline)
         XCTAssertTrue(offline.addPortal)
         XCTAssertTrue(offline.start)
-        XCTAssertTrue(offline.editPort)
+        XCTAssertTrue(offline.editDestination)
         XCTAssertTrue(offline.copyPortalURL)
         XCTAssertTrue(offline.remove)
         XCTAssertFalse(offline.refreshLocalApps)
@@ -74,5 +74,29 @@ final class PortalActionAvailabilityTests: XCTestCase {
         XCTAssertTrue(reset.resetTailnet)
         XCTAssertTrue(reset.settings)
         XCTAssertTrue(reset.diagnostics)
+    }
+
+    func testActiveAndStoppedPortalsAllowOnlyValidDestinationEdits() {
+        for desiredState in [PortalDesiredState.enabled, .stopped] {
+            let valid = PortalActionAvailability(context: PortalActionContext(
+                loggingPreference: .enabled,
+                inputsValid: true,
+                helperAvailability: .connected,
+                lifecycle: .active,
+                desiredState: desiredState,
+                isEditedDestinationValid: true
+            ))
+            XCTAssertTrue(valid.editDestination)
+
+            let invalid = PortalActionAvailability(context: PortalActionContext(
+                loggingPreference: .enabled,
+                inputsValid: true,
+                helperAvailability: .connected,
+                lifecycle: .active,
+                desiredState: desiredState,
+                isEditedDestinationValid: false
+            ))
+            XCTAssertFalse(invalid.editDestination)
+        }
     }
 }

--- a/PorticoTests/PortalControllerTests.swift
+++ b/PorticoTests/PortalControllerTests.swift
@@ -322,7 +322,7 @@ final class PortalControllerTests: XCTestCase {
         XCTAssertEqual(client.cleaned, [pendingID])
     }
 
-    func testDesiredStateAndPortPersistBeforeReconciliation() throws {
+    func testDesiredStateAndDestinationPersistBeforeReconciliation() throws {
         let saved = PortalConfiguration(
             id: portalID,
             name: "hermes",
@@ -338,12 +338,21 @@ final class PortalControllerTests: XCTestCase {
         }
 
         controller.stopPortal(id: portalID)
-        controller.updateLocalAppPort(id: portalID, port: "4321")
+        controller.updateDestination(id: portalID, edit: PortalDestinationEdit(
+            kind: .remoteApp,
+            remoteAppScheme: .https,
+            remoteAppHost: "app.example.com",
+            remoteAppPort: "443"
+        ))
 
         XCTAssertEqual(client.reconciliations.last?.first?.desiredState, .stopped)
-        XCTAssertEqual(client.reconciliations.last?.first?.localAppPort, 4321)
+        XCTAssertEqual(client.reconciliations.last?.first?.destination, .remoteApp(
+            scheme: .https, host: "app.example.com", port: 443
+        ))
         XCTAssertEqual(try store.loadInstallation().portals.first?.desiredState, .stopped)
-        XCTAssertEqual(try store.loadInstallation().portals.first?.localAppPort, 4321)
+        XCTAssertEqual(try store.loadInstallation().portals.first?.destination, .remoteApp(
+            scheme: .https, host: "app.example.com", port: 443
+        ))
     }
 
     func testSingleFlightCoalescesLatestSnapshotAndIgnoresStaleFailure() throws {
@@ -376,7 +385,7 @@ final class PortalControllerTests: XCTestCase {
         XCTAssertNil(controller.message)
     }
 
-    func testInvalidPortEditDoesNotPersistOrReconcile() throws {
+    func testDestinationEditsValidateAndPreserveIdentityBeforeReconciliation() throws {
         let saved = PortalConfiguration(
             id: portalID,
             name: "hermes",
@@ -390,11 +399,46 @@ final class PortalControllerTests: XCTestCase {
         let controller = PortalController(store: store, helper: client, openURL: { _ in })
         let originalReconciliationCount = client.reconciliations.count
 
-        controller.updateLocalAppPort(id: portalID, port: "0")
+        controller.updateDestination(id: portalID, edit: PortalDestinationEdit(
+            kind: .remoteApp,
+            remoteAppScheme: .https,
+            remoteAppHost: "127.0.0.1",
+            remoteAppPort: "443"
+        ))
 
         XCTAssertEqual(try store.loadInstallation().portals, [saved])
         XCTAssertEqual(client.reconciliations.count, originalReconciliationCount)
-        XCTAssertEqual(controller.message, "Enter a port from 1 through 65535.")
+        XCTAssertEqual(controller.message, "Enter valid destination details.")
+
+        controller.updateDestination(id: portalID, edit: PortalDestinationEdit(
+            kind: .remoteApp,
+            remoteAppScheme: .http,
+            remoteAppHost: "app.example.com",
+            remoteAppPort: "8080"
+        ))
+
+        let changed = try XCTUnwrap(store.loadInstallation().portals.first)
+        XCTAssertEqual(changed.id, saved.id)
+        XCTAssertEqual(changed.name, saved.name)
+        XCTAssertEqual(changed.createdAt, saved.createdAt)
+        XCTAssertEqual(changed.desiredState, saved.desiredState)
+        XCTAssertEqual(changed.destination, .remoteApp(scheme: .http, host: "app.example.com", port: 8080))
+        XCTAssertEqual(client.reconciliations.count, originalReconciliationCount + 1)
+        XCTAssertEqual(client.reconciliations.last, [changed])
+
+        controller.updateDestination(id: portalID, edit: PortalDestinationEdit(
+            kind: .remoteApp,
+            remoteAppScheme: .http,
+            remoteAppHost: "app.example.com",
+            remoteAppPort: "8080"
+        ))
+        XCTAssertEqual(client.reconciliations.count, originalReconciliationCount + 1)
+
+        controller.updateDestination(id: portalID, edit: PortalDestinationEdit(
+            kind: .localApp,
+            localAppPort: "4321"
+        ))
+        XCTAssertEqual(try store.loadInstallation().portals.first?.destination, .localApp(port: 4321))
     }
 
     func testAlreadySatisfiedStartAndStopAreHarmless() throws {
@@ -549,7 +593,10 @@ final class PortalControllerTests: XCTestCase {
         XCTAssertEqual(controller.removalStates[portalID], .removing)
 
         controller.startPortal(id: portalID)
-        controller.updateLocalAppPort(id: portalID, port: "9999")
+        controller.updateDestination(id: portalID, edit: PortalDestinationEdit(
+            kind: .localApp,
+            localAppPort: "9999"
+        ))
         controller.authenticate(id: portalID)
         XCTAssertEqual(client.authenticated, [])
         XCTAssertEqual(try store.loadInstallation().portals.first(where: { $0.id == portalID }), persisted)

--- a/PorticoUITests/PorticoUITests.swift
+++ b/PorticoUITests/PorticoUITests.swift
@@ -47,6 +47,36 @@ final class PorticoUITests: XCTestCase {
         XCTAssertTrue(app.wait(for: .notRunning, timeout: 5))
     }
 
+    func testLocalAndRemoteDestinationEditorsSupportCrossKindChanges() {
+        var app = launch(scenario: "online")
+        openMenuBarExtra(app)
+        XCTAssertTrue(app.textFields["edit-local-app-port"].waitForExistence(timeout: 3))
+        app.buttons["edit-destination-remote"].click()
+        XCTAssertTrue(app.textFields["edit-remote-app-host"].waitForExistence(timeout: 3))
+        XCTAssertFalse(app.textFields["edit-local-app-port"].exists)
+        app.textFields["edit-remote-app-host"].click()
+        app.textFields["edit-remote-app-host"].typeText("app.example.com")
+        app.textFields["edit-remote-app-port"].click()
+        app.textFields["edit-remote-app-port"].typeText("443")
+        XCTAssertTrue(app.buttons["update-destination"].isEnabled)
+        app.buttons["update-destination"].click()
+        XCTAssertTrue(app.buttons["start-stop"].isEnabled)
+
+        app = launch(scenario: "remote-online")
+        openMenuBarExtra(app)
+        XCTAssertTrue(app.textFields["edit-remote-app-host"].waitForExistence(timeout: 3))
+        XCTAssertFalse(app.textFields["edit-local-app-port"].exists)
+        app.buttons["edit-destination-local"].click()
+        XCTAssertTrue(app.textFields["edit-local-app-port"].waitForExistence(timeout: 3))
+        XCTAssertFalse(app.textFields["edit-remote-app-host"].exists)
+        app.textFields["edit-local-app-port"].click()
+        app.textFields["edit-local-app-port"].typeKey("a", modifierFlags: .command)
+        app.textFields["edit-local-app-port"].typeText("8081")
+        XCTAssertTrue(app.buttons["update-destination"].isEnabled)
+        app.buttons["update-destination"].click()
+        XCTAssertTrue(app.buttons["start-stop"].isEnabled)
+    }
+
     func testStaleAndAuthenticatingActions() {
         var app = launch(scenario: "stale")
         openMenuBarExtra(app)

--- a/helper/internal/portal/proxy.go
+++ b/helper/internal/portal/proxy.go
@@ -129,7 +129,7 @@ type proxyServer struct {
 
 func startProxyServer(ctx context.Context, listener net.Listener, handler http.Handler) *proxyServer {
 	serveContext, cancel := context.WithCancel(ctx)
-	tracked := &trackedHandler{handler: handler, isAccepting: true}
+	tracked := newTrackedHandler(handler)
 	server := &http.Server{
 		Handler: tracked,
 		BaseContext: func(net.Listener) context.Context {
@@ -162,8 +162,8 @@ func (p *proxyServer) close() error {
 	cancel()
 	closeErr := p.server.Close()
 	listenerErr := p.listener.Close()
-	p.handler.closeIdleConnections()
 	p.handler.wait()
+	p.handler.closeIdleConnections()
 	p.doneOnce.Do(func() { p.serveErr = <-p.done })
 	serveErr := p.serveErr
 	p.serveErr = nil
@@ -185,9 +185,24 @@ func (p *proxyServer) replaceHandler(handler http.Handler) {
 
 type trackedHandler struct {
 	mu          sync.Mutex
-	handler     http.Handler
+	current     *handlerGeneration
+	generations []*handlerGeneration
 	isAccepting bool
-	active      sync.WaitGroup
+}
+
+type handlerGeneration struct {
+	handler    http.Handler
+	active     sync.WaitGroup
+	retireOnce sync.Once
+}
+
+func newTrackedHandler(handler http.Handler) *trackedHandler {
+	generation := &handlerGeneration{handler: handler}
+	return &trackedHandler{
+		current:     generation,
+		generations: []*handlerGeneration{generation},
+		isAccepting: true,
+	}
 }
 
 func (h *trackedHandler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
@@ -197,34 +212,64 @@ func (h *trackedHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 		http.Error(writer, http.StatusText(http.StatusServiceUnavailable), http.StatusServiceUnavailable)
 		return
 	}
-	handler := h.handler
-	h.active.Add(1)
+	generation := h.current
+	generation.active.Add(1)
 	h.mu.Unlock()
-	defer h.active.Done()
-	handler.ServeHTTP(writer, request)
+	defer generation.active.Done()
+	generation.handler.ServeHTTP(writer, request)
 }
 
 func (h *trackedHandler) replace(handler http.Handler) {
 	h.mu.Lock()
-	h.handler = handler
+	previous := h.current
+	replacement := &handlerGeneration{handler: handler}
+	h.current = replacement
+	h.generations = append(h.generations, replacement)
 	h.mu.Unlock()
+	previous.retire()
 }
 
 func (h *trackedHandler) stopAccepting() {
 	h.mu.Lock()
 	h.isAccepting = false
+	generations := append([]*handlerGeneration(nil), h.generations...)
 	h.mu.Unlock()
-}
-
-func (h *trackedHandler) closeIdleConnections() {
-	h.mu.Lock()
-	handler := h.handler
-	h.mu.Unlock()
-	if closer, ok := handler.(interface{ CloseIdleConnections() }); ok {
-		closer.CloseIdleConnections()
+	for _, generation := range generations {
+		generation.retire()
 	}
 }
 
 func (h *trackedHandler) wait() {
-	h.active.Wait()
+	h.mu.Lock()
+	generations := append([]*handlerGeneration(nil), h.generations...)
+	h.mu.Unlock()
+	for _, generation := range generations {
+		generation.active.Wait()
+	}
+}
+
+func (h *trackedHandler) closeIdleConnections() {
+	h.mu.Lock()
+	generations := append([]*handlerGeneration(nil), h.generations...)
+	h.mu.Unlock()
+	for _, generation := range generations {
+		generation.closeIdleConnections()
+	}
+}
+
+func (g *handlerGeneration) retire() {
+	g.retireOnce.Do(func() {
+		go func() {
+			g.active.Wait()
+			if closer, ok := g.handler.(interface{ CloseIdleConnections() }); ok {
+				closer.CloseIdleConnections()
+			}
+		}()
+	})
+}
+
+func (g *handlerGeneration) closeIdleConnections() {
+	if closer, ok := g.handler.(interface{ CloseIdleConnections() }); ok {
+		closer.CloseIdleConnections()
+	}
 }

--- a/helper/internal/portal/proxy_test.go
+++ b/helper/internal/portal/proxy_test.go
@@ -45,6 +45,69 @@ func TestLoopbackProxyPreservesPublicPathAndQuery(t *testing.T) {
 	}
 }
 
+func TestTrackedHandlerRetiresOnlyDrainedGeneration(t *testing.T) {
+	oldEntered := make(chan struct{})
+	releaseOld := make(chan struct{})
+	oldClosed := make(chan struct{}, 1)
+	old := &closeTrackingHandler{
+		serve: func(writer http.ResponseWriter, _ *http.Request) {
+			close(oldEntered)
+			<-releaseOld
+			_, _ = io.WriteString(writer, "old")
+		},
+		closed: oldClosed,
+	}
+	new := &closeTrackingHandler{serve: func(writer http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(writer, "new")
+	}}
+	handler := newTrackedHandler(old)
+
+	oldResponse := httptest.NewRecorder()
+	oldDone := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(oldResponse, httptest.NewRequest(http.MethodGet, "/", nil))
+		close(oldDone)
+	}()
+	<-oldEntered
+	handler.replace(new)
+	newResponse := httptest.NewRecorder()
+	handler.ServeHTTP(newResponse, httptest.NewRequest(http.MethodGet, "/", nil))
+	if body := newResponse.Body.String(); body != "new" {
+		t.Fatalf("new generation response = %q, want new", body)
+	}
+	select {
+	case <-oldClosed:
+		t.Fatal("old generation closed idle connections before accepted work drained")
+	default:
+	}
+
+	close(releaseOld)
+	<-oldDone
+	select {
+	case <-oldClosed:
+	case <-time.After(time.Second):
+		t.Fatal("old generation did not close idle connections after draining")
+	}
+	if body := oldResponse.Body.String(); body != "old" {
+		t.Fatalf("old generation response = %q, want old", body)
+	}
+}
+
+type closeTrackingHandler struct {
+	serve  func(http.ResponseWriter, *http.Request)
+	closed chan struct{}
+}
+
+func (h *closeTrackingHandler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	h.serve(writer, request)
+}
+
+func (h *closeTrackingHandler) CloseIdleConnections() {
+	if h.closed != nil {
+		h.closed <- struct{}{}
+	}
+}
+
 func TestRemoteAppHTTPProxyUsesConfiguredAuthority(t *testing.T) {
 	remote := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		writer.Header().Set("X-Remote-Host", request.Host)

--- a/helper/internal/portal/runtime_test.go
+++ b/helper/internal/portal/runtime_test.go
@@ -44,6 +44,23 @@ func remoteAppDestination(t *testing.T, remote *httptest.Server) Destination {
 	return Destination{Kind: DestinationRemoteApp, Scheme: remoteURL.Scheme, Host: "app.example.com", Port: uint16(port)}
 }
 
+func trustedRemoteProxy(t *testing.T, destination Destination, remote *httptest.Server) (http.Handler, error) {
+	t.Helper()
+	remoteURL, err := url.Parse(remote.URL)
+	if err != nil {
+		return nil, err
+	}
+	transport := remote.Client().Transport.(*http.Transport).Clone()
+	transport.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, network, remoteURL.Host)
+	}
+	target := &url.URL{
+		Scheme: destination.Scheme,
+		Host:   net.JoinHostPort(destination.Host, strconv.Itoa(int(destination.Port))),
+	}
+	return newRemoteProxy(target, transport), nil
+}
+
 func TestDestinationRejectsIPv4MappedLoopback(t *testing.T) {
 	destination := Destination{
 		Kind: DestinationRemoteApp, Scheme: "https", Host: "::ffff:127.0.0.1", Port: 443,
@@ -216,6 +233,140 @@ func TestRuntimePortEditPreservesIdentityAndDrainsAcceptedHTTPAndWebSocketTraffi
 	remainder, err := io.ReadAll(response.Body)
 	if err != nil || string(remainder) != "old-end\n" {
 		t.Fatalf("old HTTP remainder = (%q, %v), want drained old Local App", remainder, err)
+	}
+}
+
+func TestRuntimeDestinationReplacementFailureRetainsServingPortalAndCanRetry(t *testing.T) {
+	oldLocalApp := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(writer, "old")
+	}))
+	t.Cleanup(oldLocalApp.Close)
+	newLocalApp := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(writer, "new")
+	}))
+	t.Cleanup(newLocalApp.Close)
+	oldPort, _ := localAppPort(t, oldLocalApp.URL)
+	newPort, _ := localAppPort(t, newLocalApp.URL)
+	tailnetListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	factory := newFakeFactory()
+	factory.status = Status{
+		BackendState: "Running",
+		DNSName:      "hermes.example.ts.net.",
+		CertDomains:  []string{"hermes.example.ts.net"},
+	}
+	factory.node.realListener = tailnetListener
+	runtime := NewRuntime(t.TempDir(), factory.New)
+	shouldFail := true
+	runtime.proxyForDestination = func(destination Destination) (http.Handler, error) {
+		if destination.Port == uint16(newPort) && shouldFail {
+			return nil, errors.New("replacement failed")
+		}
+		return newDestinationProxy(destination)
+	}
+	desired := []Config{{
+		ID: testPortalID, Name: "hermes", Destination: localAppDestination(uint16(oldPort)), DesiredState: DesiredStateEnabled,
+	}}
+	if entries, reconcileErr := runtime.Reconcile(context.Background(), desired, func(Event) {}); reconcileErr != nil || entries[0].Outcome != OutcomeConverged {
+		t.Fatalf("initial Reconcile = (%+v, %v), want converged", entries, reconcileErr)
+	}
+	t.Cleanup(func() { _ = runtime.Close() })
+	proxyURL := "http://" + tailnetListener.Addr().String()
+
+	desired[0].Destination = localAppDestination(uint16(newPort))
+	entries, err := runtime.Reconcile(context.Background(), desired, func(Event) {})
+	if err != nil || entries[0].Outcome != OutcomeStartFailed {
+		t.Fatalf("failed replacement = (%+v, %v), want startFailed", entries, err)
+	}
+	response, err := http.Get(proxyURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(response.Body)
+	_ = response.Body.Close()
+	if string(body) != "old" {
+		t.Fatalf("old destination response = %q, want old", body)
+	}
+	if len(factory.created) != 1 || factory.node.realListener != tailnetListener {
+		t.Fatal("failed replacement changed Portal node or listener")
+	}
+
+	shouldFail = false
+	entries, err = runtime.Reconcile(context.Background(), desired, func(Event) {})
+	if err != nil || entries[0].Outcome != OutcomeConverged {
+		t.Fatalf("replacement retry = (%+v, %v), want converged", entries, err)
+	}
+	response, err = http.Get(proxyURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ = io.ReadAll(response.Body)
+	_ = response.Body.Close()
+	if string(body) != "new" {
+		t.Fatalf("replacement retry response = %q, want new", body)
+	}
+}
+
+func TestRuntimeDestinationReplacementReroutesNewRequestsToRemoteTLSOrigin(t *testing.T) {
+	oldRemote := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(writer, "old TLS")
+	}))
+	t.Cleanup(oldRemote.Close)
+	newRemote := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(writer, "new TLS")
+	}))
+	t.Cleanup(newRemote.Close)
+	oldDestination := remoteAppDestination(t, oldRemote)
+	newDestination := remoteAppDestination(t, newRemote)
+	tailnetListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	factory := newFakeFactory()
+	factory.status = Status{
+		BackendState: "Running",
+		DNSName:      "hermes.example.ts.net.",
+		CertDomains:  []string{"hermes.example.ts.net"},
+	}
+	factory.node.realListener = tailnetListener
+	runtime := NewRuntime(t.TempDir(), factory.New)
+	runtime.proxyForDestination = func(destination Destination) (http.Handler, error) {
+		switch destination.Port {
+		case oldDestination.Port:
+			return trustedRemoteProxy(t, destination, oldRemote)
+		case newDestination.Port:
+			return trustedRemoteProxy(t, destination, newRemote)
+		default:
+			return nil, errors.New("unexpected Remote App destination")
+		}
+	}
+	desired := []Config{{
+		ID: testPortalID, Name: "hermes", Destination: oldDestination, DesiredState: DesiredStateEnabled,
+	}}
+	if entries, reconcileErr := runtime.Reconcile(context.Background(), desired, func(Event) {}); reconcileErr != nil || entries[0].Outcome != OutcomeConverged {
+		t.Fatalf("initial Reconcile = (%+v, %v), want converged", entries, reconcileErr)
+	}
+	t.Cleanup(func() { _ = runtime.Close() })
+	proxyURL := "http://" + tailnetListener.Addr().String()
+
+	desired[0].Destination = newDestination
+	entries, err := runtime.Reconcile(context.Background(), desired, func(Event) {})
+	if err != nil || entries[0].Outcome != OutcomeConverged {
+		t.Fatalf("TLS replacement = (%+v, %v), want converged", entries, err)
+	}
+	response, err := http.Get(proxyURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(response.Body)
+	_ = response.Body.Close()
+	if string(body) != "new TLS" {
+		t.Fatalf("TLS replacement response = %q, want new TLS", body)
+	}
+	if len(factory.created) != 1 || factory.node.realListener != tailnetListener {
+		t.Fatal("TLS replacement changed Portal node or listener")
 	}
 }
 


### PR DESCRIPTION
Fixes #34

## Summary
- add destination editing with persistence-before-reconcile validation
- preserve portal identity while forwarding traffic through a replaceable proxy handler
- cover replacement and in-flight HTTP/WebSocket behavior

## Validation
- `go test ./...`
- Swift app and PorticoTests targets build successfully
- Full scheme test execution is delegated to required GitHub Swift CI after a host-local Xcode runner stall