### PR TITLE
Add native Portal creation sheet

### DIFF
--- a/Portico/AppDelegate.swift
+++ b/Portico/AppDelegate.swift
@@ -31,7 +31,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             supervisorScheduler = scheduler
         }
         let launcher: HelperLaunching = testConfiguration.map {
-            UITestHelperLauncher(scenario: $0.scenario)
+            UITestHelperLauncher(configuration: $0)
         } ?? ProcessHelperLauncher()
         let reachabilityProbe: LocalAppProbing = testConfiguration.map {
             UITestLocalAppProbe(result: $0.reachabilityResult)

--- a/Portico/PortalController.swift
+++ b/Portico/PortalController.swift
@@ -14,6 +14,12 @@ enum PortalCreationKind: String, CaseIterable, Identifiable {
     var id: Self { self }
 }
 
+enum PortalCreationOutcome: Equatable {
+    case validationError(PortalValidationError)
+    case persistenceFailure
+    case persisted(PortalConfiguration)
+}
+
 struct PortalDestinationEdit: Equatable {
     var kind: PortalCreationKind
     var localAppPort: String
@@ -94,6 +100,7 @@ final class PortalController: ObservableObject {
     @Published private(set) var alerts: [InstallationAlert] = []
     @Published private(set) var tailnetDisplaySuffix: String?
     @Published private(set) var message: String?
+    @Published private(set) var portalCreationError: String?
     @Published private(set) var localApps: [LocalAppCandidatePayload] = []
     @Published private(set) var isRefreshingLocalApps = false
     @Published private(set) var localAppsMessage: String?
@@ -300,7 +307,7 @@ final class PortalController: ObservableObject {
     }
 
     @discardableResult
-    func addPortal() -> PortalValidationError? {
+    func addPortal() -> PortalCreationOutcome? {
         guard operationalLogging != .undecided else {
             message = "Choose an operational-support logging setting before adding a Portal."
             return nil
@@ -309,8 +316,8 @@ final class PortalController: ObservableObject {
         do {
             destination = try newPortalDestination()
         } catch let error as PortalValidationError {
-            message = "Enter a lower-case DNS label and valid destination details."
-            return error
+            portalCreationError = "Enter a lower-case DNS label and valid destination details."
+            return .validationError(error)
         } catch {
             return nil
         }
@@ -326,20 +333,28 @@ final class PortalController: ObservableObject {
             try store.save(updated)
             installation = updated
             publishInstallation()
-            message = nil
-            portalName = ""
-            localAppPort = ""
-            remoteAppHost = ""
-            remoteAppPort = ""
-            discoveryGeneration += 1
-            localApps = []
-            isRefreshingLocalApps = false
-            localAppsMessage = nil
+            portalCreationError = nil
+            discardPortalDraft()
             scheduleReconciliation()
+            return .persisted(configuration)
         } catch {
-            message = "The Portal could not be saved."
+            portalCreationError = "The Portal could not be saved."
+            return .persistenceFailure
         }
-        return nil
+    }
+
+    func discardPortalDraft() {
+        portalName = ""
+        localAppPort = ""
+        creationKind = .localApp
+        remoteAppScheme = .https
+        remoteAppHost = ""
+        remoteAppPort = ""
+        discoveryGeneration += 1
+        localApps = []
+        isRefreshingLocalApps = false
+        localAppsMessage = nil
+        portalCreationError = nil
     }
 
     func startPortal(id: UUID) {

--- a/Portico/PorticoApp.swift
+++ b/Portico/PorticoApp.swift
@@ -77,6 +77,7 @@ private struct OverviewView: View {
     @ObservedObject var controller: PortalController
     @ObservedObject var supervisor: HelperSupervisor
     @State private var selection: Destination? = .overview
+    @State private var showingAddPortal = false
 
     var body: some View {
         NavigationSplitView {
@@ -86,61 +87,97 @@ private struct OverviewView: View {
             }
             .navigationTitle("Portico")
         } detail: {
-            Form {
-                Section("Overview") {
-                    LabeledContent("Helper", value: supervisor.availability.title)
-                        .accessibilityIdentifier("overview-helper-state")
-                    LabeledContent("Tailnet", value: controller.tailnetDisplaySuffix ?? "Not connected")
-                        .accessibilityIdentifier("overview-tailnet")
-                }
-                if PortalPresentation.showsPrerequisiteGuidance(portalCount: controller.portals.count) {
-                    Section("Before creating your first Portal") {
-                        ForEach(PortalPresentation.prerequisiteGuidance, id: \.self) { guidance in
-                            Label(guidance, systemImage: "info.circle")
+            Group {
+                if controller.portals.isEmpty, controller.operationalLogging != .undecided {
+                    VStack(spacing: 16) {
+                        ContentUnavailableView {
+                            Label("No Portals", systemImage: "door.left.hand.open")
+                        } description: {
+                            Text("Add a Portal to give a Local App a private tailnet doorway.")
+                        }
+                        Button("Add Portal") { showingAddPortal = true }
+                            .buttonStyle(.borderedProminent)
+                            .accessibilityIdentifier("overview-empty-add-portal")
+                    }
+                    .accessibilityElement(children: .contain)
+                } else {
+                    Form {
+                        Section("Overview") {
+                            LabeledContent("Helper", value: supervisor.availability.title)
+                                .accessibilityIdentifier("overview-helper-state")
+                            LabeledContent("Tailnet", value: controller.tailnetDisplaySuffix ?? "Not connected")
+                                .accessibilityIdentifier("overview-tailnet")
+                        }
+                        if PortalPresentation.showsPrerequisiteGuidance(portalCount: controller.portals.count) {
+                            Section("Before creating your first Portal") {
+                                ForEach(PortalPresentation.prerequisiteGuidance, id: \.self) { guidance in
+                                    Label(guidance, systemImage: "info.circle")
+                                }
+                            }
+                            .accessibilityIdentifier("overview-first-portal-guidance")
+                        }
+                        Section("Operational-support logging") {
+                            if controller.operationalLogging == .undecided {
+                                Button("Allow Operational-support Logging") {
+                                    controller.setOperationalLogging(.enabled)
+                                }
+                                .accessibilityIdentifier("overview-logging-enabled")
+                                Button("Disable Operational-support Logging") {
+                                    controller.setOperationalLogging(.disabled)
+                                }
+                                .accessibilityIdentifier("overview-logging-disabled")
+                            } else {
+                                Text(controller.operationalLogging == .enabled
+                                    ? "Operational-support logging is allowed."
+                                    : "Operational-support logging is disabled.")
+                            }
+                        }
+                        if !controller.portals.isEmpty {
+                            Section("Portals") {
+                                ForEach(controller.portals.filter { $0.lifecycle == .active }, id: \.id) { portal in
+                                    Text(portal.name)
+                                        .accessibilityIdentifier("overview-portal-\(portal.name)")
+                                }
+                            }
+                        }
+                        if let message = controller.message {
+                            Text(message)
+                                .foregroundStyle(.secondary)
+                                .accessibilityIdentifier("overview-message")
                         }
                     }
-                    .accessibilityIdentifier("overview-first-portal-guidance")
-                }
-                Section("Operational-support logging") {
-                    if controller.operationalLogging == .undecided {
-                        Button("Allow Operational-support Logging") {
-                            controller.setOperationalLogging(.enabled)
-                        }
-                        .accessibilityIdentifier("overview-logging-enabled")
-                        Button("Disable Operational-support Logging") {
-                            controller.setOperationalLogging(.disabled)
-                        }
-                        .accessibilityIdentifier("overview-logging-disabled")
-                    } else {
-                        Text(controller.operationalLogging == .enabled
-                            ? "Operational-support logging is allowed."
-                            : "Operational-support logging is disabled.")
-                    }
-                }
-                Section {
-                    Button("Add Portal") {}
-                        .disabled(true)
-                        .accessibilityIdentifier("overview-add-portal")
-                }
-                if let message = controller.message {
-                    Text(message)
-                        .foregroundStyle(.secondary)
-                        .accessibilityIdentifier("overview-message")
+                    .formStyle(.grouped)
                 }
             }
-            .formStyle(.grouped)
             .navigationTitle("Overview")
             .accessibilityIdentifier("management-overview")
+            .toolbar {
+                Button("Add Portal") { showingAddPortal = true }
+                    .disabled(controller.operationalLogging == .undecided)
+                    .accessibilityIdentifier("overview-add-portal")
+            }
+            .sheet(isPresented: Binding(
+                get: { showingAddPortal },
+                set: { isPresented in
+                    if !isPresented { controller.discardPortalDraft() }
+                    showingAddPortal = isPresented
+                }
+            )) {
+                AddPortalSheet(
+                    controller: controller,
+                    cancel: {
+                        controller.discardPortalDraft()
+                        showingAddPortal = false
+                    },
+                    dismissAfterPersistence: { showingAddPortal = false }
+                )
+            }
         }
     }
 }
 
 private struct PortalView: View {
     private enum AccessibilityFocusTarget: Hashable {
-        case portalNameField
-        case localAppPortField
-        case remoteAppHostField
-        case remoteAppPortField
         case portal(UUID)
         case removalNotice(UUID)
     }
@@ -153,7 +190,6 @@ private struct PortalView: View {
     @State private var showingResetConfirmation = false
     @State private var removalCandidate: PortalConfiguration?
     @State private var removalCompletionFocusID: UUID?
-    @FocusState private var inputFocus: AccessibilityFocusTarget?
     @AccessibilityFocusState private var accessibilityFocus: AccessibilityFocusTarget?
 
     var body: some View {
@@ -206,7 +242,6 @@ private struct PortalView: View {
                 .accessibilityFocused($accessibilityFocus, equals: .portal(portal.id))
                 Divider()
             }
-            addPortalForm
             if controller.canResetTailnet {
                 Divider()
                 Button("Reset Tailnet", role: .destructive) {
@@ -295,11 +330,26 @@ private struct PortalView: View {
         .keyboardShortcut("q")
         .accessibilityIdentifier("quit")
     }
+}
 
-    private var addPortalForm: some View {
+private struct AddPortalSheet: View {
+    private enum FocusTarget: Hashable {
+        case portalName
+        case localAppPort
+        case remoteAppHost
+        case remoteAppPort
+    }
+
+    @ObservedObject var controller: PortalController
+    let cancel: () -> Void
+    let dismissAfterPersistence: () -> Void
+    @FocusState private var inputFocus: FocusTarget?
+    @AccessibilityFocusState private var accessibilityFocus: FocusTarget?
+
+    var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Add Portal").font(.headline)
-                .accessibilityIdentifier("add-form")
+                .accessibilityIdentifier("add-portal-sheet")
             if PortalPresentation.showsPrerequisiteGuidance(portalCount: controller.portals.count) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Before creating your first Portal").font(.subheadline)
@@ -311,56 +361,38 @@ private struct PortalView: View {
                 .accessibilityElement(children: .contain)
                 .accessibilityIdentifier("add-guidance")
             }
-            if controller.operationalLogging == .undecided {
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("Choose operational-support logging before adding a Portal.")
-                        .font(.caption)
-                    HStack {
-                        Button("Allow Operational-support Logging") {
-                            controller.setOperationalLogging(.enabled)
-                        }
-                        .accessibilityIdentifier("logging-enabled")
-                        Button("Disable Operational-support Logging") {
-                            controller.setOperationalLogging(.disabled)
-                        }
-                        .accessibilityIdentifier("logging-disabled")
-                    }
-                }
-                .accessibilityElement(children: .contain)
-                .accessibilityIdentifier("logging-choice")
-            }
             HStack {
                 Text("Detected Local Apps").font(.subheadline)
                 Spacer()
                 Button("Refresh") { controller.refreshLocalApps() }
                     .disabled(!controller.actionAvailability().refreshLocalApps)
+                    .accessibilityIdentifier("refresh-local-apps")
             }
             if controller.isRefreshingLocalApps {
                 ProgressView()
                     .controlSize(.small)
             }
             ForEach(controller.localApps, id: \.localAppPort) { candidate in
-                Button {
+                Button("Use \(candidate.processLabel) on port \(candidate.localAppPort)") {
                     controller.selectLocalApp(candidate)
-                } label: {
-                    HStack {
-                        Text(candidate.processLabel)
-                        Spacer()
-                        Text(String(candidate.localAppPort))
-                            .foregroundStyle(.secondary)
-                    }
                 }
-                .buttonStyle(.plain)
+                .accessibilityIdentifier("local-app-\(candidate.localAppPort)")
             }
             if let message = controller.localAppsMessage {
                 Text(message)
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+            if let error = controller.portalCreationError {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("add-portal-error")
+            }
             TextField("Portal Name", text: $controller.portalName)
                 .accessibilityIdentifier("portal-name-field")
-                .focused($inputFocus, equals: .portalNameField)
-                .accessibilityFocused($accessibilityFocus, equals: .portalNameField)
+                .focused($inputFocus, equals: .portalName)
+                .accessibilityFocused($accessibilityFocus, equals: .portalName)
                 .onSubmit { validateNameAndAdvance() }
             Picker("Destination", selection: $controller.creationKind) {
                 Text("Local App").tag(PortalCreationKind.localApp)
@@ -371,8 +403,8 @@ private struct PortalView: View {
             if controller.creationKind == .localApp {
                 TextField("Local App Port", text: $controller.localAppPort)
                     .accessibilityIdentifier("local-app-port-field")
-                    .focused($inputFocus, equals: .localAppPortField)
-                    .accessibilityFocused($accessibilityFocus, equals: .localAppPortField)
+                    .focused($inputFocus, equals: .localAppPort)
+                    .accessibilityFocused($accessibilityFocus, equals: .localAppPort)
                     .onSubmit { submitPortal() }
             } else {
                 Picker("Scheme", selection: $controller.remoteAppScheme) {
@@ -382,55 +414,70 @@ private struct PortalView: View {
                 .accessibilityIdentifier("remote-app-scheme")
                 TextField("Remote App Host", text: $controller.remoteAppHost)
                     .accessibilityIdentifier("remote-app-host-field")
-                    .focused($inputFocus, equals: .remoteAppHostField)
-                    .accessibilityFocused($accessibilityFocus, equals: .remoteAppHostField)
+                    .focused($inputFocus, equals: .remoteAppHost)
+                    .accessibilityFocused($accessibilityFocus, equals: .remoteAppHost)
                 TextField("Remote App Port", text: $controller.remoteAppPort)
                     .accessibilityIdentifier("remote-app-port-field")
-                    .focused($inputFocus, equals: .remoteAppPortField)
-                    .accessibilityFocused($accessibilityFocus, equals: .remoteAppPortField)
+                    .focused($inputFocus, equals: .remoteAppPort)
+                    .accessibilityFocused($accessibilityFocus, equals: .remoteAppPort)
                     .onSubmit { submitPortal() }
             }
-            Button("Add Portal") { submitPortal() }
-                .buttonStyle(.borderedProminent)
-                .disabled(!controller.actionAvailability().addPortal)
-                .accessibilityIdentifier("add-portal")
+            HStack {
+                Spacer()
+                Button("Cancel", action: cancel)
+                    .keyboardShortcut(.cancelAction)
+                    .accessibilityIdentifier("add-portal-cancel")
+                Button("Add Portal") { submitPortal() }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(!controller.actionAvailability().addPortal)
+                    .keyboardShortcut(.defaultAction)
+                    .accessibilityIdentifier("add-portal")
+            }
         }
+        .padding()
+        .frame(width: 480)
+        .onAppear { inputFocus = .portalName }
     }
 
     private func validateNameAndAdvance() {
         do {
             _ = try PortalInputValidator.validate(name: controller.portalName, port: "1")
-            let target: AccessibilityFocusTarget = controller.creationKind == .localApp
-                ? .localAppPortField
-                : .remoteAppHostField
+            let target: FocusTarget = controller.creationKind == .localApp
+                ? .localAppPort
+                : .remoteAppHost
             inputFocus = target
             accessibilityFocus = target
         } catch {
-            inputFocus = .portalNameField
-            accessibilityFocus = .portalNameField
+            inputFocus = .portalName
+            accessibilityFocus = .portalName
         }
     }
 
     private func submitPortal() {
         switch controller.addPortal() {
-        case .invalidName:
-            inputFocus = .portalNameField
-            accessibilityFocus = .portalNameField
-        case .invalidPort:
-            let target: AccessibilityFocusTarget = controller.creationKind == .localApp
-                ? .localAppPortField
-                : .remoteAppPortField
+        case .validationError(.invalidName):
+            inputFocus = .portalName
+            accessibilityFocus = .portalName
+        case .validationError(.invalidPort):
+            let target: FocusTarget = controller.creationKind == .localApp
+                ? .localAppPort
+                : .remoteAppPort
             inputFocus = target
             accessibilityFocus = target
-        case .invalidRemoteHost:
-            inputFocus = .remoteAppHostField
-            accessibilityFocus = .remoteAppHostField
-        case nil:
+        case .validationError(.invalidRemoteHost):
+            inputFocus = .remoteAppHost
+            accessibilityFocus = .remoteAppHost
+        case .persisted:
+            dismissAfterPersistence()
+        case .persistenceFailure, nil:
             break
         }
     }
 
-    private func cancelRemoval() {
+}
+
+private extension PortalView {
+    func cancelRemoval() {
         guard let portal = removalCandidate else { return }
         removalCandidate = nil
         DispatchQueue.main.async {

--- a/Portico/UITestLaunchConfiguration.swift
+++ b/Portico/UITestLaunchConfiguration.swift
@@ -4,6 +4,7 @@ import Foundation
 
 enum UITestScenario: String {
     case firstRun = "first-run"
+    case creation
     case online
     case remoteOnline = "remote-online"
     case authenticating
@@ -49,6 +50,8 @@ struct UITestLaunchConfiguration {
         switch scenario {
         case .firstRun:
             break
+        case .creation:
+            try store.save(InstallationRecord(operationalLogging: .enabled))
         case .migrated:
             try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
             try Data(#"{"version":2,"portals":[],"alerts":[]}"#.utf8).write(to: store.versionTwoInstallationURL)
@@ -150,10 +153,12 @@ final class UITestRestartGate {
 
 final class UITestHelperLauncher: HelperLaunching {
     private let scenario: UITestScenario
+    private let rootURL: URL
     private var launchCount = 0
 
-    init(scenario: UITestScenario) {
-        self.scenario = scenario
+    init(configuration: UITestLaunchConfiguration) {
+        scenario = configuration.scenario
+        rootURL = configuration.rootURL
     }
 
     func launch(
@@ -170,6 +175,7 @@ final class UITestHelperLauncher: HelperLaunching {
         launchCount += 1
         return UITestHelperProcess(
             scenario: scenario,
+            rootURL: rootURL,
             onLine: onLine,
             onEOF: onEOF,
             onExit: onExit
@@ -184,6 +190,7 @@ private final class UITestHelperProcess: HelperProcess {
     }
 
     private let scenario: UITestScenario
+    private let rootURL: URL
     private let onLine: (Data) -> Void
     private let onEOF: () -> Void
     private let onExit: (Int32) -> Void
@@ -193,11 +200,13 @@ private final class UITestHelperProcess: HelperProcess {
 
     init(
         scenario: UITestScenario,
+        rootURL: URL,
         onLine: @escaping (Data) -> Void,
         onEOF: @escaping () -> Void,
         onExit: @escaping (Int32) -> Void
     ) {
         self.scenario = scenario
+        self.rootURL = rootURL
         self.onLine = onLine
         self.onEOF = onEOF
         self.onExit = onExit
@@ -212,6 +221,7 @@ private final class UITestHelperProcess: HelperProcess {
             shutdownRequested = true
         case .reconcilePortals:
             let request = try JSONDecoder().decode(HelperRequest<ReconcilePortalsPayload>.self, from: data)
+            recordEnrollmentIfNeeded(for: request.payload.portals)
             respond(
                 ReconcilePortalsResult(entries: request.payload.portals.map {
                     ReconcilePortalEntry(portalId: $0.portalId, outcome: .converged)
@@ -231,7 +241,14 @@ private final class UITestHelperProcess: HelperProcess {
                 respond(RemovePortalResult(accepted: true), requestID: envelope.requestId)
             }
         case .discoverLocalApps:
-            respond(DiscoverLocalAppsResult(candidates: []), requestID: envelope.requestId)
+            let candidates: [LocalAppCandidatePayload] = scenario == .creation ? [
+                LocalAppCandidatePayload(
+                    localAppPort: 3000,
+                    processLabel: "node",
+                    suggestedPortalName: "detected-portal"
+                ),
+            ] : []
+            respond(DiscoverLocalAppsResult(candidates: candidates), requestID: envelope.requestId)
         }
     }
 
@@ -258,6 +275,14 @@ private final class UITestHelperProcess: HelperProcess {
             error: nil
         )
         deliver(response)
+    }
+
+    private func recordEnrollmentIfNeeded(for portals: [ReconcilePortalPayload]) {
+        guard !portals.isEmpty else { return }
+        try? Data("enrolled\n".utf8).write(
+            to: rootURL.appendingPathComponent("helper-enrollment.txt"),
+            options: .atomic
+        )
     }
 
     private func respondError(code: String, requestID: String) {

--- a/PorticoTests/PortalControllerTests.swift
+++ b/PorticoTests/PortalControllerTests.swift
@@ -120,19 +120,19 @@ final class PortalControllerTests: XCTestCase {
 
         controller.portalName = "Invalid Name"
         controller.localAppPort = "8787"
-        XCTAssertEqual(controller.addPortal(), .invalidName)
+        XCTAssertEqual(controller.addPortal(), .validationError(.invalidName))
         XCTAssertNil(controller.portal)
         XCTAssertEqual(UUIDCreationCount, 0)
         XCTAssertTrue(client.started.isEmpty)
 
         controller.portalName = "hermes"
         controller.localAppPort = "0"
-        XCTAssertEqual(controller.addPortal(), .invalidPort)
+        XCTAssertEqual(controller.addPortal(), .validationError(.invalidPort))
         XCTAssertNil(controller.portal)
         XCTAssertEqual(UUIDCreationCount, 0)
 
         controller.localAppPort = "8787"
-        XCTAssertNil(controller.addPortal())
+        XCTAssertNotNil(controller.addPortal())
         let portal = try XCTUnwrap(controller.portal)
         XCTAssertEqual(portal.id, portalID)
         XCTAssertEqual(UUIDCreationCount, 1)
@@ -142,6 +142,77 @@ final class PortalControllerTests: XCTestCase {
         controller.addPortal()
         XCTAssertEqual(UUIDCreationCount, 1)
         XCTAssertEqual(client.started.count, 1)
+    }
+
+    func testCreationOutcomesAndDiscardedDraftKeepPersistenceAndHelperWorkSeparate() throws {
+        let client = FakePortalHelperClient()
+        let store = PortalStore(rootURL: temporaryRoot())
+        try store.save(InstallationRecord(operationalLogging: .enabled))
+        let controller = PortalController(
+            store: store,
+            helper: client,
+            uuidProvider: { self.portalID },
+            dateProvider: { Date(timeIntervalSince1970: 1_786_000_000) },
+            openURL: { _ in }
+        )
+        let candidate = LocalAppCandidatePayload(
+            localAppPort: 3000,
+            processLabel: "node",
+            suggestedPortalName: "detected"
+        )
+
+        controller.portalName = "Invalid Name"
+        controller.localAppPort = "3000"
+        XCTAssertEqual(controller.addPortal(), .validationError(.invalidName))
+        XCTAssertEqual(controller.portalCreationError, "Enter a lower-case DNS label and valid destination details.")
+
+        client.completeDiscovery(.success([candidate]))
+        controller.selectLocalApp(candidate)
+        controller.remoteAppHost = "draft.example.com"
+        controller.remoteAppPort = "443"
+        controller.reportInitialPersistenceFailure()
+        controller.discardPortalDraft()
+
+        XCTAssertEqual(controller.portalName, "")
+        XCTAssertEqual(controller.localAppPort, "")
+        XCTAssertEqual(controller.remoteAppHost, "")
+        XCTAssertEqual(controller.remoteAppPort, "")
+        XCTAssertTrue(controller.localApps.isEmpty)
+        XCTAssertNil(controller.localAppsMessage)
+        XCTAssertNil(controller.portalCreationError)
+        XCTAssertEqual(controller.message, "Saved Portal configuration could not be loaded.")
+        XCTAssertNil(try store.load())
+        XCTAssertTrue(client.started.isEmpty)
+
+        controller.portalName = "hermes"
+        controller.localAppPort = "8787"
+        let portal = PortalConfiguration(
+            id: portalID,
+            name: "hermes",
+            localAppPort: 8787,
+            createdAt: Date(timeIntervalSince1970: 1_786_000_000)
+        )
+        XCTAssertEqual(controller.addPortal(), .persisted(portal))
+        XCTAssertEqual(try store.load(), portal)
+        XCTAssertEqual(client.started, [portal])
+    }
+
+    func testCreationReportsPersistenceFailureWithoutDiscardingDraft() throws {
+        struct ExpectedFailure: Error {}
+        let root = temporaryRoot()
+        try PortalStore(rootURL: root).save(InstallationRecord(operationalLogging: .enabled))
+        let store = PortalStore(rootURL: root, writeData: { _, _ in throw ExpectedFailure() })
+        let client = FakePortalHelperClient()
+        let controller = PortalController(store: store, helper: client, openURL: { _ in })
+        controller.portalName = "hermes"
+        controller.localAppPort = "8787"
+
+        XCTAssertEqual(controller.addPortal(), .persistenceFailure)
+        XCTAssertEqual(controller.portalCreationError, "The Portal could not be saved.")
+        XCTAssertEqual(controller.portalName, "hermes")
+        XCTAssertEqual(controller.localAppPort, "8787")
+        XCTAssertNil(try store.load())
+        XCTAssertTrue(client.started.isEmpty)
     }
 
     func testRemoteAppCreationValidatesBeforePersistenceAndDoesNotStartLocalDiscovery() throws {
@@ -160,12 +231,12 @@ final class PortalControllerTests: XCTestCase {
         controller.remoteAppHost = "127.0.0.1"
         controller.remoteAppPort = "443"
 
-        XCTAssertEqual(controller.addPortal(), .invalidRemoteHost)
+        XCTAssertEqual(controller.addPortal(), .validationError(.invalidRemoteHost))
         XCTAssertEqual(ids, 0)
         XCTAssertTrue(client.started.isEmpty)
 
         controller.remoteAppHost = "App.Example.COM"
-        XCTAssertNil(controller.addPortal())
+        XCTAssertNotNil(controller.addPortal())
         XCTAssertEqual(ids, 1)
         XCTAssertEqual(controller.portal?.destination, .remoteApp(scheme: .https, host: "app.example.com", port: 443))
     }

--- a/PorticoUITests/PorticoUITests.swift
+++ b/PorticoUITests/PorticoUITests.swift
@@ -13,29 +13,31 @@ final class PorticoUITests: XCTestCase {
         XCTAssertTrue(app.buttons["overview-logging-enabled"].exists)
         XCTAssertTrue(app.buttons["overview-logging-disabled"].exists)
 
-        openMenuBarExtra(app)
+        app.buttons["overview-logging-enabled"].click()
+        XCTAssertTrue(app.staticTexts["No Portals"].waitForExistence(timeout: 3), app.debugDescription)
+        XCTAssertTrue(app.buttons["overview-add-portal"].isEnabled)
+        let emptyStateAddPortal = app.buttons["overview-empty-add-portal"]
+        XCTAssertTrue(emptyStateAddPortal.waitForExistence(timeout: 3), app.debugDescription)
+        emptyStateAddPortal.click()
+        XCTAssertTrue(app.descendants(matching: .any)["add-portal-sheet"].waitForExistence(timeout: 3))
+        XCTAssertFalse(app.buttons["add-portal"].isEnabled)
 
-        XCTAssertTrue(
-            app.descendants(matching: .any)["add-guidance"].waitForExistence(timeout: 3),
-            app.debugDescription
-        )
-        XCTAssertEqual(app.staticTexts["helper-state"].value as? String, "Awaiting logging choice")
-        let addPortal = app.buttons["add-portal"]
-        XCTAssertTrue(addPortal.exists)
-        XCTAssertFalse(addPortal.isEnabled)
-        XCTAssertTrue(app.buttons["logging-enabled"].exists)
-        XCTAssertTrue(app.buttons["logging-disabled"].exists)
+        app.buttons["add-portal-cancel"].click()
+        XCTAssertFalse(app.descendants(matching: .any)["add-portal-sheet"].waitForExistence(timeout: 1))
+        openMenuBarExtra(app)
+        XCTAssertFalse(app.descendants(matching: .any)["add-portal-sheet"].exists)
+        XCTAssertFalse(app.buttons["add-portal"].exists)
     }
 
-    func testOverviewAddPortalRemainsDisabledAfterLoggingChoice() {
+    func testOverviewToolbarOpensTheSameAddPortalSheet() {
         let app = launch(scenario: "first-run")
 
         let overview = app.descendants(matching: .any)["management-overview"]
         XCTAssertTrue(overview.waitForExistence(timeout: 3), app.debugDescription)
         app.buttons["overview-logging-enabled"].click()
-        XCTAssertTrue(app.staticTexts["Operational-support logging is allowed."].waitForExistence(timeout: 3))
-
-        openMenuBarExtra(app)
+        XCTAssertTrue(app.staticTexts["No Portals"].waitForExistence(timeout: 3))
+        app.buttons["overview-add-portal"].click()
+        XCTAssertTrue(app.descendants(matching: .any)["add-portal-sheet"].waitForExistence(timeout: 3))
         let portalName = app.textFields["portal-name-field"]
         XCTAssertTrue(portalName.waitForExistence(timeout: 3), app.debugDescription)
         portalName.click()
@@ -45,7 +47,67 @@ final class PorticoUITests: XCTestCase {
         localAppPort.typeKey("a", modifierFlags: .command)
         localAppPort.typeText("8080")
         XCTAssertTrue(app.buttons["add-portal"].isEnabled)
-        XCTAssertFalse(app.buttons["overview-add-portal"].isEnabled)
+        app.typeKey(.escape, modifierFlags: [])
+        XCTAssertFalse(app.descendants(matching: .any)["add-portal-sheet"].waitForExistence(timeout: 1))
+        app.buttons["overview-add-portal"].click()
+        XCTAssertTrue(app.textFields["portal-name-field"].waitForExistence(timeout: 3))
+        XCTAssertEqual(app.textFields["portal-name-field"].value as? String, "")
+        XCTAssertEqual(app.textFields["local-app-port-field"].value as? String, "")
+    }
+
+    func testAddPortalSheetPreservesDiscoveryAndDiscardsOnlyUncommittedDrafts() {
+        let root = makeRoot()
+        let app = launch(scenario: "creation", root: root)
+        app.typeKey("o", modifierFlags: [.command, .shift])
+        XCTAssertTrue(app.staticTexts["No Portals"].waitForExistence(timeout: 3))
+        XCTAssertTrue(app.buttons["overview-add-portal"].waitForExistence(timeout: 3))
+        app.buttons["overview-add-portal"].click()
+        XCTAssertTrue(app.descendants(matching: .any)["add-portal-sheet"].waitForExistence(timeout: 3))
+
+        app.buttons["refresh-local-apps"].click()
+        let candidate = app.buttons["local-app-3000"]
+        XCTAssertTrue(candidate.waitForExistence(timeout: 3), app.debugDescription)
+        candidate.click()
+        XCTAssertTrue(waitForValue("detected-portal", element: app.textFields["portal-name-field"], timeout: 3))
+        XCTAssertTrue(waitForValue("3000", element: app.textFields["local-app-port-field"], timeout: 3))
+
+        let portalName = app.textFields["portal-name-field"]
+        portalName.click()
+        portalName.typeKey("a", modifierFlags: .command)
+        portalName.typeText("Invalid Name")
+        portalName.typeKey(.return, modifierFlags: [])
+        XCTAssertEqual(portalName.value(forKey: "hasKeyboardFocus") as? Bool, true)
+        let localPort = app.textFields["local-app-port-field"]
+        portalName.typeKey("a", modifierFlags: .command)
+        portalName.typeText("manual-portal")
+        localPort.click()
+        localPort.typeKey("a", modifierFlags: .command)
+        localPort.typeText("0")
+        localPort.typeKey(.return, modifierFlags: [])
+        XCTAssertEqual(localPort.value(forKey: "hasKeyboardFocus") as? Bool, true)
+
+        app.typeKey(.escape, modifierFlags: [])
+        XCTAssertFalse(app.descendants(matching: .any)["add-portal-sheet"].waitForExistence(timeout: 1))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: "\(root)/helper-enrollment.txt"))
+
+        app.buttons["overview-add-portal"].click()
+        XCTAssertTrue(app.textFields["portal-name-field"].waitForExistence(timeout: 3))
+        XCTAssertEqual(app.textFields["portal-name-field"].value as? String, "")
+        XCTAssertEqual(app.textFields["local-app-port-field"].value as? String, "")
+        app.buttons["refresh-local-apps"].click()
+        XCTAssertTrue(candidate.waitForExistence(timeout: 3))
+        candidate.click()
+        portalName.click()
+        portalName.typeKey("a", modifierFlags: .command)
+        portalName.typeText("manual-portal")
+        localPort.click()
+        localPort.typeKey("a", modifierFlags: .command)
+        localPort.typeText("4321")
+        app.buttons["add-portal"].click()
+
+        XCTAssertFalse(app.descendants(matching: .any)["add-portal-sheet"].waitForExistence(timeout: 3))
+        XCTAssertTrue(app.staticTexts["overview-portal-manual-portal"].waitForExistence(timeout: 3))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: "\(root)/helper-enrollment.txt"))
     }
 
     func testOpenPorticoRaisesTheManagementWindowAndClosingItKeepsTheMenuBarAppRunning() {


### PR DESCRIPTION
## Summary
- move Portal creation into one management-owned native sheet
- add decided-logging empty-state and toolbar entry points
- cover discovery, draft dismissal, validation focus, and durable completion

## Validation
- xcodebuild macOS test
- go build and go test ./...

Fixes #38