### PR TITLE
Add selected Portal management detail

### DIFF
--- a/Portico/PorticoApp.swift
+++ b/Portico/PorticoApp.swift
@@ -72,6 +72,7 @@ private struct PorticoCommands: Commands {
 private struct OverviewView: View {
     private enum Destination: Hashable {
         case overview
+        case portal(UUID)
     }
 
     @ObservedObject var controller: PortalController
@@ -83,73 +84,35 @@ private struct OverviewView: View {
         NavigationSplitView {
             List(selection: $selection) {
                 Label("Overview", systemImage: "door.left.hand.open")
+                    .accessibilityIdentifier("management-sidebar-overview")
                     .tag(Destination.overview)
+                ForEach(controller.portals.filter { $0.lifecycle == .active }, id: \.id) { portal in
+                    let presentation = PortalPresentation(
+                        portal: portal,
+                        status: controller.statuses[portal.id],
+                        reachability: controller.reachabilityStates[portal.id] ?? .unknown,
+                        isStale: controller.staleStatusIDs.contains(portal.id)
+                    )
+                    Button {
+                        selection = .portal(portal.id)
+                    } label: {
+                        VStack(alignment: .leading) {
+                            Text(presentation.portalName)
+                            Text(presentation.tailscaleState)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityElement(children: .combine)
+                    .accessibilityIdentifier("management-sidebar-portal-\(portal.name)")
+                    .tag(Destination.portal(portal.id))
+                }
             }
             .navigationTitle("Portico")
         } detail: {
-            Group {
-                if controller.portals.isEmpty, controller.operationalLogging != .undecided {
-                    VStack(spacing: 16) {
-                        ContentUnavailableView {
-                            Label("No Portals", systemImage: "door.left.hand.open")
-                        } description: {
-                            Text("Add a Portal to give a Local App a private tailnet doorway.")
-                        }
-                        Button("Add Portal") { showingAddPortal = true }
-                            .buttonStyle(.borderedProminent)
-                            .accessibilityIdentifier("overview-empty-add-portal")
-                    }
-                    .accessibilityElement(children: .contain)
-                } else {
-                    Form {
-                        Section("Overview") {
-                            LabeledContent("Helper", value: supervisor.availability.title)
-                                .accessibilityIdentifier("overview-helper-state")
-                            LabeledContent("Tailnet", value: controller.tailnetDisplaySuffix ?? "Not connected")
-                                .accessibilityIdentifier("overview-tailnet")
-                        }
-                        if PortalPresentation.showsPrerequisiteGuidance(portalCount: controller.portals.count) {
-                            Section("Before creating your first Portal") {
-                                ForEach(PortalPresentation.prerequisiteGuidance, id: \.self) { guidance in
-                                    Label(guidance, systemImage: "info.circle")
-                                }
-                            }
-                            .accessibilityIdentifier("overview-first-portal-guidance")
-                        }
-                        Section("Operational-support logging") {
-                            if controller.operationalLogging == .undecided {
-                                Button("Allow Operational-support Logging") {
-                                    controller.setOperationalLogging(.enabled)
-                                }
-                                .accessibilityIdentifier("overview-logging-enabled")
-                                Button("Disable Operational-support Logging") {
-                                    controller.setOperationalLogging(.disabled)
-                                }
-                                .accessibilityIdentifier("overview-logging-disabled")
-                            } else {
-                                Text(controller.operationalLogging == .enabled
-                                    ? "Operational-support logging is allowed."
-                                    : "Operational-support logging is disabled.")
-                            }
-                        }
-                        if !controller.portals.isEmpty {
-                            Section("Portals") {
-                                ForEach(controller.portals.filter { $0.lifecycle == .active }, id: \.id) { portal in
-                                    Text(portal.name)
-                                        .accessibilityIdentifier("overview-portal-\(portal.name)")
-                                }
-                            }
-                        }
-                        if let message = controller.message {
-                            Text(message)
-                                .foregroundStyle(.secondary)
-                                .accessibilityIdentifier("overview-message")
-                        }
-                    }
-                    .formStyle(.grouped)
-                }
-            }
-            .navigationTitle("Overview")
+            managementContent
+            .navigationTitle(selectedPortal?.name ?? "Overview")
             .accessibilityIdentifier("management-overview")
             .toolbar {
                 Button("Add Portal") { showingAddPortal = true }
@@ -172,7 +135,227 @@ private struct OverviewView: View {
                     dismissAfterPersistence: { showingAddPortal = false }
                 )
             }
+            .onChange(of: controller.portals) { _, portals in
+                guard let currentSelection = selection,
+                      case let .portal(id) = currentSelection,
+                      !portals.contains(where: { $0.id == id && $0.lifecycle == .active })
+                else { return }
+                selection = .overview
+            }
         }
+    }
+
+    private var selectedPortal: PortalConfiguration? {
+        guard let selection, case let .portal(id) = selection else { return nil }
+        return controller.portals.first(where: { $0.id == id && $0.lifecycle == .active })
+    }
+
+    @ViewBuilder
+    private var managementContent: some View {
+        if let selectedPortal {
+            SelectedPortalView(controller: controller, portal: selectedPortal)
+                .id(selectedPortal.id)
+        } else if controller.portals.isEmpty, controller.operationalLogging != .undecided {
+            VStack(spacing: 16) {
+                ContentUnavailableView {
+                    Label("No Portals", systemImage: "door.left.hand.open")
+                } description: {
+                    Text("Add a Portal to give a Local App a private tailnet doorway.")
+                }
+                Button("Add Portal") { showingAddPortal = true }
+                    .buttonStyle(.borderedProminent)
+                    .accessibilityIdentifier("overview-empty-add-portal")
+            }
+            .accessibilityElement(children: .contain)
+        } else {
+            Form {
+                Section("Overview") {
+                    LabeledContent("Helper", value: supervisor.availability.title)
+                        .accessibilityIdentifier("overview-helper-state")
+                    LabeledContent("Tailnet", value: controller.tailnetDisplaySuffix ?? "Not connected")
+                        .accessibilityIdentifier("overview-tailnet")
+                }
+                if PortalPresentation.showsPrerequisiteGuidance(portalCount: controller.portals.count) {
+                    Section("Before creating your first Portal") {
+                        ForEach(PortalPresentation.prerequisiteGuidance, id: \.self) { guidance in
+                            Label(guidance, systemImage: "info.circle")
+                        }
+                    }
+                    .accessibilityIdentifier("overview-first-portal-guidance")
+                }
+                Section("Operational-support logging") {
+                    if controller.operationalLogging == .undecided {
+                        Button("Allow Operational-support Logging") {
+                            controller.setOperationalLogging(.enabled)
+                        }
+                        .accessibilityIdentifier("overview-logging-enabled")
+                        Button("Disable Operational-support Logging") {
+                            controller.setOperationalLogging(.disabled)
+                        }
+                        .accessibilityIdentifier("overview-logging-disabled")
+                    } else {
+                        Text(controller.operationalLogging == .enabled
+                            ? "Operational-support logging is allowed."
+                            : "Operational-support logging is disabled.")
+                    }
+                }
+                if !controller.portals.isEmpty {
+                    Section("Portals") {
+                        ForEach(controller.portals.filter { $0.lifecycle == .active }, id: \.id) { portal in
+                            Text(portal.name)
+                                .accessibilityIdentifier("overview-portal-\(portal.name)")
+                        }
+                    }
+                }
+                if let message = controller.message {
+                    Text(message)
+                        .foregroundStyle(.secondary)
+                        .accessibilityIdentifier("overview-message")
+                }
+            }
+            .formStyle(.grouped)
+        }
+    }
+}
+
+private struct SelectedPortalView: View {
+    @Environment(\.openWindow) private var openWindow
+    @ObservedObject var controller: PortalController
+    let portal: PortalConfiguration
+    @State private var destinationEdit: PortalDestinationEdit
+    @FocusState private var startStopFocused: Bool
+
+    init(controller: PortalController, portal: PortalConfiguration) {
+        self.controller = controller
+        self.portal = portal
+        _destinationEdit = State(initialValue: PortalDestinationEdit(destination: portal.destination))
+    }
+
+    var body: some View {
+        let isStale = controller.staleStatusIDs.contains(portal.id)
+        let status = controller.statuses[portal.id]
+        let presentation = PortalPresentation(
+            portal: portal,
+            status: status,
+            reachability: controller.reachabilityStates[portal.id] ?? .unknown,
+            isStale: isStale
+        )
+        let portalActions = controller.actionAvailability(for: portal)
+        let destinationActions = controller.actionAvailability(
+            for: portal,
+            editedDestination: destinationEdit
+        )
+        Form {
+            Section("Identity") {
+                LabeledContent("Portal Name", value: presentation.portalName)
+                    .accessibilityIdentifier("selected-portal-name")
+                LabeledContent("Assigned Name", value: presentation.assignedName ?? "Not assigned")
+                    .accessibilityIdentifier("selected-assigned-name")
+                if let explanation = presentation.collisionExplanation {
+                    Text(explanation)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Section("Portal State") {
+                LabeledContent("Desired State", value: presentation.desiredState)
+                    .accessibilityIdentifier("selected-desired-state")
+                LabeledContent("Tailscale", value: presentation.tailscaleState)
+                    .accessibilityIdentifier("selected-tailscale-state")
+                if portal.localAppPort != nil {
+                    LabeledContent("Local App", value: presentation.localAppReachability)
+                        .accessibilityIdentifier("selected-local-app-state")
+                }
+            }
+            Section("Portal URL and addresses") {
+                if let portalURL = status?.portalURL {
+                    LabeledContent(presentation.portalURLLabel, value: portalURL.absoluteString)
+                        .accessibilityIdentifier("selected-portal-url")
+                    HStack {
+                        Button("Copy Portal URL") { controller.copyPortalURL(id: portal.id) }
+                            .disabled(!portalActions.copyPortalURL)
+                            .accessibilityIdentifier("selected-copy-portal-url")
+                        Button("Open Portal URL") { controller.openPortalURL(id: portal.id) }
+                            .disabled(!portalActions.openPortalURL)
+                            .accessibilityIdentifier("selected-open-portal-url")
+                    }
+                } else {
+                    LabeledContent("Portal URL", value: "Unavailable")
+                        .accessibilityIdentifier("selected-portal-url")
+                }
+                LabeledContent("Addresses", value: status?.addresses.joined(separator: ", ") ?? "Unavailable")
+                    .accessibilityIdentifier("selected-addresses")
+            }
+            Section("Portal Destination") {
+                HStack {
+                    Button("Local App") { destinationEdit.kind = .localApp }
+                        .disabled(destinationEdit.kind == .localApp)
+                        .accessibilityIdentifier("selected-edit-destination-local")
+                    Button("Remote App") { destinationEdit.kind = .remoteApp }
+                        .disabled(destinationEdit.kind == .remoteApp)
+                        .accessibilityIdentifier("selected-edit-destination-remote")
+                }
+                .buttonStyle(.bordered)
+                if destinationEdit.kind == .localApp {
+                    HStack {
+                        TextField("Local App Port", text: $destinationEdit.localAppPort)
+                            .onSubmit { updateDestination() }
+                            .accessibilityIdentifier("selected-edit-local-app-port")
+                        Button("Update Destination") { updateDestination() }
+                            .disabled(!destinationActions.editDestination)
+                            .accessibilityIdentifier("selected-update-destination")
+                    }
+                } else {
+                    Picker("Scheme", selection: $destinationEdit.remoteAppScheme) {
+                        Text("HTTP").tag(RemoteAppScheme.http)
+                        Text("HTTPS").tag(RemoteAppScheme.https)
+                    }
+                    .accessibilityIdentifier("selected-edit-remote-app-scheme")
+                    TextField("Remote App Host", text: $destinationEdit.remoteAppHost)
+                        .accessibilityIdentifier("selected-edit-remote-app-host")
+                    HStack {
+                        TextField("Remote App Port", text: $destinationEdit.remoteAppPort)
+                            .onSubmit { updateDestination() }
+                            .accessibilityIdentifier("selected-edit-remote-app-port")
+                        Button("Update Destination") { updateDestination() }
+                            .disabled(!destinationActions.editDestination)
+                            .accessibilityIdentifier("selected-update-destination")
+                    }
+                }
+            }
+            Section("Actions") {
+                if status?.state == .authenticating {
+                    Button("Authenticate") { controller.authenticate(id: portal.id) }
+                        .buttonStyle(.borderedProminent)
+                        .disabled(!portalActions.authenticate)
+                        .accessibilityIdentifier("selected-authenticate")
+                }
+                Button(portal.desiredState == .enabled ? "Stop" : "Start") {
+                    if portal.desiredState == .enabled {
+                        controller.stopPortal(id: portal.id)
+                    } else {
+                        controller.startPortal(id: portal.id)
+                    }
+                }
+                .focusable()
+                .focused($startStopFocused)
+                .disabled(portal.desiredState == .enabled ? !portalActions.stop : !portalActions.start)
+                .accessibilityIdentifier("selected-start-stop")
+                Button("Diagnostics") { openWindow(id: "diagnostics") }
+                    .accessibilityIdentifier("selected-portal-diagnostics")
+            }
+        }
+        .formStyle(.grouped)
+        .accessibilityIdentifier("selected-portal-\(portal.name)")
+        .navigationTitle(portal.name)
+        .onChange(of: portal.desiredState) { _, _ in
+            DispatchQueue.main.async {
+                startStopFocused = true
+            }
+        }
+    }
+
+    private func updateDestination() {
+        controller.updateDestination(id: portal.id, edit: destinationEdit)
     }
 }
 

--- a/Portico/PorticoApp.swift
+++ b/Portico/PorticoApp.swift
@@ -223,7 +223,6 @@ private struct SelectedPortalView: View {
     @ObservedObject var controller: PortalController
     let portal: PortalConfiguration
     @State private var destinationEdit: PortalDestinationEdit
-    @FocusState private var startStopFocused: Bool
 
     init(controller: PortalController, portal: PortalConfiguration) {
         self.controller = controller
@@ -329,17 +328,19 @@ private struct SelectedPortalView: View {
                         .disabled(!portalActions.authenticate)
                         .accessibilityIdentifier("selected-authenticate")
                 }
-                Button(portal.desiredState == .enabled ? "Stop" : "Start") {
-                    if portal.desiredState == .enabled {
-                        controller.stopPortal(id: portal.id)
-                    } else {
-                        controller.startPortal(id: portal.id)
+                HStack {
+                    FocusRestoringButton(
+                        title: portal.desiredState == .enabled ? "Stop" : "Start",
+                        isEnabled: portal.desiredState == .enabled ? portalActions.stop : portalActions.start
+                    ) {
+                        if portal.desiredState == .enabled {
+                            controller.stopPortal(id: portal.id)
+                        } else {
+                            controller.startPortal(id: portal.id)
+                        }
                     }
+                    .accessibilityIdentifier("selected-start-stop")
                 }
-                .focusable()
-                .focused($startStopFocused)
-                .disabled(portal.desiredState == .enabled ? !portalActions.stop : !portalActions.start)
-                .accessibilityIdentifier("selected-start-stop")
                 Button("Diagnostics") { openWindow(id: "diagnostics") }
                     .accessibilityIdentifier("selected-portal-diagnostics")
             }
@@ -347,15 +348,50 @@ private struct SelectedPortalView: View {
         .formStyle(.grouped)
         .accessibilityIdentifier("selected-portal-\(portal.name)")
         .navigationTitle(portal.name)
-        .onChange(of: portal.desiredState) { _, _ in
-            DispatchQueue.main.async {
-                startStopFocused = true
-            }
-        }
     }
 
     private func updateDestination() {
         controller.updateDestination(id: portal.id, edit: destinationEdit)
+    }
+}
+
+private struct FocusRestoringButton: NSViewRepresentable {
+    let title: String
+    let isEnabled: Bool
+    let action: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(action: action)
+    }
+
+    func makeNSView(context: Context) -> NSButton {
+        let button = NSButton(title: title, target: context.coordinator, action: #selector(Coordinator.performAction))
+        button.bezelStyle = .rounded
+        button.controlSize = .small
+        return button
+    }
+
+    func updateNSView(_ button: NSButton, context: Context) {
+        let titleChanged = button.title != title
+        context.coordinator.action = action
+        button.title = title
+        button.isEnabled = isEnabled
+        guard titleChanged else { return }
+        DispatchQueue.main.async {
+            button.window?.makeFirstResponder(button)
+        }
+    }
+
+    final class Coordinator: NSObject {
+        var action: () -> Void
+
+        init(action: @escaping () -> Void) {
+            self.action = action
+        }
+
+        @objc func performAction() {
+            action()
+        }
     }
 }
 

--- a/Portico/PorticoApp.swift
+++ b/Portico/PorticoApp.swift
@@ -344,10 +344,18 @@ private struct SelectedPortalView: View {
                 Button("Diagnostics") { openWindow(id: "diagnostics") }
                     .accessibilityIdentifier("selected-portal-diagnostics")
             }
+            if let message = controller.message {
+                Text(message)
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("selected-portal-message")
+            }
         }
         .formStyle(.grouped)
         .accessibilityIdentifier("selected-portal-\(portal.name)")
         .navigationTitle(portal.name)
+        .onChange(of: portal.destination) { _, destination in
+            destinationEdit = PortalDestinationEdit(destination: destination)
+        }
     }
 
     private func updateDestination() {

--- a/Portico/UITestLaunchConfiguration.swift
+++ b/Portico/UITestLaunchConfiguration.swift
@@ -5,9 +5,11 @@ import Foundation
 enum UITestScenario: String {
     case firstRun = "first-run"
     case creation
+    case management
     case online
     case remoteOnline = "remote-online"
     case authenticating
+    case awaitingApproval = "awaiting-approval"
     case stale
     case restarting
     case terminalFailure = "terminal-failure"
@@ -84,7 +86,25 @@ struct UITestLaunchConfiguration {
                 operationalLogging: .enabled,
                 launchAtLoginOffer: .declined
             ))
-        case .online, .authenticating, .stale, .restarting, .terminalFailure:
+        case .management:
+            try store.save(InstallationRecord(
+                tailnetBinding: Self.tailnetBinding,
+                portals: [
+                    Self.portal(
+                        id: Self.firstPortalID,
+                        name: "first-portal",
+                        createdAt: Date(timeIntervalSince1970: 1_700_000_000)
+                    ),
+                    Self.portal(
+                        id: Self.secondPortalID,
+                        name: "second-portal",
+                        createdAt: Date(timeIntervalSince1970: 1_700_000_001)
+                    ),
+                ],
+                operationalLogging: .enabled,
+                launchAtLoginOffer: .declined
+            ))
+        case .online, .authenticating, .awaitingApproval, .stale, .restarting, .terminalFailure:
             try store.save(InstallationRecord(
                 tailnetBinding: Self.tailnetBinding,
                 portals: [Self.portal()],
@@ -113,16 +133,22 @@ struct UITestLaunchConfiguration {
         magicDNSSuffix: "example.ts.net"
     )
 
+    private static let firstPortalID = UUID(uuidString: "22222222-2222-4222-8222-222222222222")!
+    private static let secondPortalID = UUID(uuidString: "33333333-3333-4333-8333-333333333333")!
+
     private static func portal(
+        id: UUID = portalID,
+        name: String = "portal-one",
         destination: PortalDestination = .localApp(port: 8080),
+        createdAt: Date = Date(timeIntervalSince1970: 1_700_000_000),
         lifecycle: PortalLifecycle = .active,
         removalAssignedName: String? = nil
     ) -> PortalConfiguration {
         PortalConfiguration(
-            id: portalID,
-            name: "portal-one",
+            id: id,
+            name: name,
             destination: destination,
-            createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+            createdAt: createdAt,
             desiredState: .enabled,
             lifecycle: lifecycle,
             removalAssignedName: removalAssignedName
@@ -304,19 +330,28 @@ private final class UITestHelperProcess: HelperProcess {
     }
 
     private func emitStatuses(for portals: [ReconcilePortalPayload]) {
-        guard [.online, .remoteOnline, .authenticating, .stale, .restarting, .loginOffer].contains(scenario) else { return }
+        guard [.online, .remoteOnline, .authenticating, .awaitingApproval, .stale, .restarting, .loginOffer, .management].contains(scenario) else { return }
         for portal in portals {
-            let state: PortalTailscaleState = scenario == .authenticating ? .authenticating : .online
+            let state: PortalTailscaleState
+            if scenario == .authenticating {
+                state = .authenticating
+            } else if scenario == .awaitingApproval {
+                state = .awaitingApproval
+            } else if scenario == .management, portal.portalName == "second-portal" {
+                state = .connecting
+            } else {
+                state = .online
+            }
             deliver(HelperEvent(
                 version: helperProtocolVersion,
                 event: .portalStatus,
                 portalId: portal.portalId,
                 payload: PortalStatusPayload(
                     state: state,
-                    stableNodeId: "node-1",
-                    assignedName: "portal-one-1",
-                    portalURL: URL(string: "https://portal-one-1.example.ts.net"),
-                    addresses: ["100.64.0.10"],
+                    stableNodeId: "node-\(portal.portalName)",
+                    assignedName: "\(portal.portalName)-1",
+                    portalURL: URL(string: "https://\(portal.portalName)-1.example.ts.net"),
+                    addresses: portal.portalName == "second-portal" ? ["100.64.0.11"] : ["100.64.0.10"],
                     tailnetName: "test-tailnet",
                     magicDNSSuffix: "example.ts.net"
                 )

--- a/PorticoUITests/PorticoUITests.swift
+++ b/PorticoUITests/PorticoUITests.swift
@@ -167,6 +167,48 @@ final class PorticoUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["diagnostics-heading"].waitForExistence(timeout: 3))
     }
 
+    func testSelectedPortalDetailShowsDestinationValidationErrors() {
+        let app = launch(scenario: "management")
+        app.typeKey("o", modifierFlags: [.command, .shift])
+        app.buttons["management-sidebar-portal-first-portal"].click()
+
+        let port = app.textFields["selected-edit-local-app-port"]
+        XCTAssertTrue(port.waitForExistence(timeout: 3), app.debugDescription)
+        port.click()
+        port.typeKey("a", modifierFlags: .command)
+        port.typeText("0")
+        port.typeKey(.return, modifierFlags: [])
+
+        XCTAssertTrue(
+            waitForText(
+                "Enter valid destination details.",
+                element: app.staticTexts["selected-portal-message"],
+                timeout: 3
+            ),
+            app.debugDescription
+        )
+    }
+
+    func testSelectedPortalDetailTracksDestinationChangesFromMenuBar() {
+        let app = launch(scenario: "management")
+        app.typeKey("o", modifierFlags: [.command, .shift])
+        app.buttons["management-sidebar-portal-first-portal"].click()
+
+        let selectedPort = app.textFields["selected-edit-local-app-port"]
+        XCTAssertTrue(waitForValue("8080", element: selectedPort, timeout: 3), app.debugDescription)
+
+        openMenuBarExtra(app)
+        let menuBarPort = app.textFields.matching(identifier: "edit-local-app-port").firstMatch
+        XCTAssertTrue(menuBarPort.waitForExistence(timeout: 3), app.debugDescription)
+        menuBarPort.click()
+        menuBarPort.typeKey("a", modifierFlags: .command)
+        menuBarPort.typeText("8081")
+        app.buttons.matching(identifier: "update-destination").firstMatch.click()
+
+        XCTAssertTrue(waitForValue("8081", element: selectedPort, timeout: 3), app.debugDescription)
+        XCTAssertFalse(app.buttons["selected-update-destination"].isEnabled)
+    }
+
     func testAddPortalSheetPreservesDiscoveryAndDiscardsOnlyUncommittedDrafts() {
         let root = makeRoot()
         let app = launch(scenario: "creation", root: root)

--- a/PorticoUITests/PorticoUITests.swift
+++ b/PorticoUITests/PorticoUITests.swift
@@ -55,6 +55,119 @@ final class PorticoUITests: XCTestCase {
         XCTAssertEqual(app.textFields["local-app-port-field"].value as? String, "")
     }
 
+    func testManagementSidebarOrdersAndSelectsActivePortals() {
+        let app = launch(scenario: "management")
+        app.typeKey("o", modifierFlags: [.command, .shift])
+
+        XCTAssertTrue(app.descendants(matching: .any)["management-overview"].waitForExistence(timeout: 3))
+        let firstPortal = app.buttons["management-sidebar-portal-first-portal"]
+        let secondPortal = app.buttons["management-sidebar-portal-second-portal"]
+        XCTAssertTrue(firstPortal.waitForExistence(timeout: 3), app.debugDescription)
+        XCTAssertTrue(secondPortal.waitForExistence(timeout: 3), app.debugDescription)
+        let overview = app.descendants(matching: .any)["management-sidebar-overview"]
+        XCTAssertTrue(overview.exists)
+        XCTAssertLessThan(overview.frame.minY, firstPortal.frame.minY)
+        XCTAssertLessThan(firstPortal.frame.minY, secondPortal.frame.minY)
+        XCTAssertTrue(firstPortal.label.contains("Online"))
+        XCTAssertTrue(secondPortal.label.contains("Connecting"))
+
+        firstPortal.click()
+        XCTAssertTrue(waitForValue("first-portal", element: app.staticTexts["selected-portal-name"], timeout: 3))
+        secondPortal.click()
+        XCTAssertTrue(waitForValue("second-portal", element: app.staticTexts["selected-portal-name"], timeout: 3))
+
+        app.buttons["overview-add-portal"].click()
+        XCTAssertTrue(app.descendants(matching: .any)["add-portal-sheet"].waitForExistence(timeout: 3))
+        app.buttons["add-portal-cancel"].click()
+        XCTAssertFalse(app.descendants(matching: .any)["add-portal-sheet"].waitForExistence(timeout: 1))
+    }
+
+    func testSelectedPortalDetailShowsFactsAndSafeURLActions() {
+        var app = launch(scenario: "online")
+        app.typeKey("o", modifierFlags: [.command, .shift])
+        app.buttons["management-sidebar-portal-portal-one"].click()
+        XCTAssertTrue(waitForValue("portal-one", element: app.staticTexts["selected-portal-name"], timeout: 3))
+        XCTAssertTrue(app.staticTexts["selected-assigned-name"].exists)
+        XCTAssertTrue(app.staticTexts["selected-desired-state"].exists)
+        XCTAssertTrue(app.staticTexts["selected-tailscale-state"].exists)
+        XCTAssertTrue(app.staticTexts["selected-local-app-state"].exists)
+        let currentURL = app.staticTexts["selected-portal-url"]
+        XCTAssertTrue(waitForText("https://portal-one-1.example.ts.net", element: currentURL, timeout: 3))
+        XCTAssertTrue(app.staticTexts["selected-addresses"].exists)
+        XCTAssertTrue(app.buttons["selected-copy-portal-url"].isEnabled)
+        XCTAssertTrue(app.buttons["selected-open-portal-url"].isEnabled)
+
+        app = launch(scenario: "stale")
+        app.typeKey("o", modifierFlags: [.command, .shift])
+        app.buttons["management-sidebar-portal-portal-one"].click()
+        let staleURL = app.staticTexts["selected-portal-url"]
+        XCTAssertTrue(staleURL.waitForExistence(timeout: 5))
+        XCTAssertTrue(waitForText("Last Known", element: staleURL, timeout: 5))
+        XCTAssertTrue(app.buttons["selected-copy-portal-url"].isEnabled)
+        XCTAssertFalse(app.buttons["selected-open-portal-url"].isEnabled)
+
+        app = launch(scenario: "authenticating")
+        app.typeKey("o", modifierFlags: [.command, .shift])
+        app.buttons["management-sidebar-portal-portal-one"].click()
+        XCTAssertTrue(app.buttons["selected-authenticate"].waitForExistence(timeout: 3))
+        XCTAssertTrue(app.buttons["selected-authenticate"].isEnabled)
+        XCTAssertFalse(app.buttons["selected-open-portal-url"].isEnabled)
+
+        app = launch(scenario: "awaiting-approval")
+        app.typeKey("o", modifierFlags: [.command, .shift])
+        app.buttons["management-sidebar-portal-portal-one"].click()
+        XCTAssertTrue(waitForValue("Awaiting approval", element: app.staticTexts["selected-tailscale-state"], timeout: 3))
+        XCTAssertFalse(app.buttons["selected-authenticate"].exists)
+        XCTAssertFalse(app.buttons["selected-open-portal-url"].isEnabled)
+
+        app = launch(scenario: "terminal-failure")
+        app.typeKey("o", modifierFlags: [.command, .shift])
+        let unavailablePortal = app.buttons["management-sidebar-portal-portal-one"]
+        XCTAssertTrue(unavailablePortal.waitForExistence(timeout: 3))
+        unavailablePortal.click()
+        XCTAssertFalse(app.buttons["selected-authenticate"].exists)
+        XCTAssertFalse(app.buttons["selected-open-portal-url"].exists)
+    }
+
+    func testSelectedPortalDetailDailyActionsAndIsolation() {
+        let app = launch(scenario: "management")
+        app.typeKey("o", modifierFlags: [.command, .shift])
+
+        app.buttons["management-sidebar-portal-first-portal"].click()
+        XCTAssertTrue(waitForValue("Enabled", element: app.staticTexts["selected-desired-state"], timeout: 3))
+        app.buttons["selected-edit-destination-remote"].click()
+        XCTAssertTrue(app.textFields["selected-edit-remote-app-host"].waitForExistence(timeout: 3))
+        let startStop = app.buttons["selected-start-stop"]
+        startStop.click()
+        XCTAssertTrue(waitForValue("Stopped", element: app.staticTexts["selected-desired-state"], timeout: 3))
+        app.activate()
+        let focusedStartStop = app.buttons.matching(
+            NSPredicate(format: "identifier == %@ AND hasKeyboardFocus == true", "selected-start-stop")
+        ).firstMatch
+        XCTAssertTrue(focusedStartStop.waitForExistence(timeout: 3), app.debugDescription)
+        app.typeKey(.space, modifierFlags: [])
+        XCTAssertTrue(waitForValue("Enabled", element: app.staticTexts["selected-desired-state"], timeout: 3))
+
+        app.buttons["management-sidebar-portal-second-portal"].click()
+        XCTAssertTrue(waitForValue("Enabled", element: app.staticTexts["selected-desired-state"], timeout: 3))
+        XCTAssertTrue(app.textFields["selected-edit-local-app-port"].waitForExistence(timeout: 3))
+        XCTAssertTrue(waitForValue("Connecting", element: app.staticTexts["selected-tailscale-state"], timeout: 3))
+        XCTAssertFalse(app.buttons["selected-authenticate"].exists)
+        XCTAssertFalse(app.buttons["selected-open-portal-url"].isEnabled)
+
+        app.buttons["management-sidebar-portal-first-portal"].click()
+        let port = app.textFields["selected-edit-local-app-port"]
+        XCTAssertTrue(port.waitForExistence(timeout: 3))
+        port.click()
+        port.typeKey("a", modifierFlags: .command)
+        port.typeText("8081")
+        XCTAssertTrue(app.buttons["selected-update-destination"].isEnabled)
+        app.buttons["selected-update-destination"].click()
+        XCTAssertTrue(app.buttons["selected-portal-diagnostics"].isEnabled)
+        app.buttons["selected-portal-diagnostics"].click()
+        XCTAssertTrue(app.staticTexts["diagnostics-heading"].waitForExistence(timeout: 3))
+    }
+
     func testAddPortalSheetPreservesDiscoveryAndDiscardsOnlyUncommittedDrafts() {
         let root = makeRoot()
         let app = launch(scenario: "creation", root: root)
@@ -343,6 +456,12 @@ final class PorticoUITests: XCTestCase {
 
     private func waitForValue(_ value: String, element: XCUIElement, timeout: TimeInterval) -> Bool {
         let predicate = NSPredicate(format: "value == %@", value)
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: element)
+        return XCTWaiter.wait(for: [expectation], timeout: timeout) == .completed
+    }
+
+    private func waitForText(_ text: String, element: XCUIElement, timeout: TimeInterval) -> Bool {
+        let predicate = NSPredicate(format: "label CONTAINS %@ OR value CONTAINS %@", text, text)
         let expectation = XCTNSPredicateExpectation(predicate: predicate, object: element)
         return XCTWaiter.wait(for: [expectation], timeout: timeout) == .completed
     }

--- a/PorticoUITests/PorticoUITests.swift
+++ b/PorticoUITests/PorticoUITests.swift
@@ -102,7 +102,7 @@ final class PorticoUITests: XCTestCase {
         app.buttons["management-sidebar-portal-portal-one"].click()
         let staleURL = app.staticTexts["selected-portal-url"]
         XCTAssertTrue(staleURL.waitForExistence(timeout: 5))
-        XCTAssertTrue(waitForText("Last Known", element: staleURL, timeout: 5))
+        XCTAssertTrue(app.staticTexts["Portal URL — Last Known"].exists)
         XCTAssertTrue(app.buttons["selected-copy-portal-url"].isEnabled)
         XCTAssertFalse(app.buttons["selected-open-portal-url"].isEnabled)
 
@@ -140,7 +140,6 @@ final class PorticoUITests: XCTestCase {
         let startStop = app.buttons["selected-start-stop"]
         startStop.click()
         XCTAssertTrue(waitForValue("Stopped", element: app.staticTexts["selected-desired-state"], timeout: 3))
-        app.activate()
         let focusedStartStop = app.buttons.matching(
             NSPredicate(format: "identifier == %@ AND hasKeyboardFocus == true", "selected-start-stop")
         ).firstMatch


### PR DESCRIPTION
## Summary
- add active Portal sidebar selection and controller-backed management detail
- preserve the existing Add Portal sheet and menu-bar removal/recovery paths
- cover ordering, safety states, daily actions, focus, and Portal isolation

## Validation
- xcodebuild full macOS test suite
- go build ./cmd/portico-helper
- go test ./...

Fixes #39