### PR TITLE
Run unit tests without an application host

### DIFF
--- a/Portico/PorticoApp.swift
+++ b/Portico/PorticoApp.swift
@@ -1,7 +1,6 @@
 import AppKit
 import SwiftUI
 
-@main
 struct PorticoApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @Environment(\.openWindow) private var openWindow
@@ -47,6 +46,12 @@ struct PorticoApp: App {
         DispatchQueue.main.async {
             openWindow(id: "management")
         }
+    }
+}
+
+public enum PorticoApplication {
+    public static func launch() {
+        PorticoApp.main()
     }
 }
 

--- a/PorticoLauncher/PorticoLauncher.swift
+++ b/PorticoLauncher/PorticoLauncher.swift
@@ -1,0 +1,8 @@
+import PorticoApplication
+
+@main
+struct PorticoLauncher {
+    static func main() {
+        PorticoApplication.launch()
+    }
+}

--- a/PorticoTests/DiagnosticsTests.swift
+++ b/PorticoTests/DiagnosticsTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import Portico
+@testable import PorticoApplication
 
 final class DiagnosticsTests: XCTestCase {
     func testHistoryEvictsOldestAndReportContainsOnlyAllowlistedFacts() {

--- a/PorticoTests/HelperProtocolTests.swift
+++ b/PorticoTests/HelperProtocolTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import Portico
+@testable import PorticoApplication
 
 final class HelperProtocolTests: XCTestCase {
     func testVersionFourReconciliationFixturesRoundTrip() throws {

--- a/PorticoTests/HelperShutdownTests.swift
+++ b/PorticoTests/HelperShutdownTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-@testable import Portico
+@testable import PorticoApplication
 
 @MainActor
 final class HelperShutdownTests: XCTestCase {

--- a/PorticoTests/HelperSupervisorTests.swift
+++ b/PorticoTests/HelperSupervisorTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-@testable import Portico
+@testable import PorticoApplication
 
 @MainActor
 final class HelperSupervisorTests: XCTestCase {

--- a/PorticoTests/LaunchAtLoginTests.swift
+++ b/PorticoTests/LaunchAtLoginTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import Portico
+@testable import PorticoApplication
 
 @MainActor
 final class LaunchAtLoginTests: XCTestCase {

--- a/PorticoTests/LocalAppReachabilityTests.swift
+++ b/PorticoTests/LocalAppReachabilityTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import Portico
+@testable import PorticoApplication
 
 @MainActor
 final class LocalAppReachabilityTests: XCTestCase {

--- a/PorticoTests/PortalActionAvailabilityTests.swift
+++ b/PorticoTests/PortalActionAvailabilityTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import Portico
+@testable import PorticoApplication
 
 final class PortalActionAvailabilityTests: XCTestCase {
     func testAuthoritativeActionMatrix() {

--- a/PorticoTests/PortalConfigurationTests.swift
+++ b/PorticoTests/PortalConfigurationTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import Portico
+@testable import PorticoApplication
 
 final class PortalConfigurationTests: XCTestCase {
     func testRemoteAppDestinationCanonicalizesAndRejectsLoopback() throws {

--- a/PorticoTests/PortalControllerTests.swift
+++ b/PorticoTests/PortalControllerTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-@testable import Portico
+@testable import PorticoApplication
 
 @MainActor
 final class PortalControllerTests: XCTestCase {

--- a/PorticoTests/PortalPresentationTests.swift
+++ b/PorticoTests/PortalPresentationTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import Portico
+@testable import PorticoApplication
 
 final class PortalPresentationTests: XCTestCase {
     func testFirstRunGuidance() {

--- a/PorticoTests/PortalStoreTests.swift
+++ b/PorticoTests/PortalStoreTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-@testable import Portico
+@testable import PorticoApplication
 
 final class PortalStoreTests: XCTestCase {
     func testPrepareForStartupPersistsOnlyGenuinelyNewInstallations() throws {

--- a/PorticoTests/ProcessHelperLauncherTests.swift
+++ b/PorticoTests/ProcessHelperLauncherTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-@testable import Portico
+@testable import PorticoApplication
 
 final class ProcessHelperLauncherTests: XCTestCase {
     func testEnabledLoggingRemovesInheritedOptOutWithoutChangingOtherVariables() throws {

--- a/Scripts/verify-xcode-project-generation.sh
+++ b/Scripts/verify-xcode-project-generation.sh
@@ -38,8 +38,44 @@ diff -ru "$snapshot_dir/Portico.xcodeproj" "$project_path"
 project_listing="$(xcodebuild -list -project "$project_path")"
 printf '%s\n' "$project_listing"
 
-if ! awk '/^[[:space:]]*Targets:/ { in_targets = 1; next } in_targets && /^[[:space:]]*Schemes:/ { exit } in_targets && /^[[:space:]]*Portico[[:space:]]*$/ { found = 1 } END { exit !found }' <<<"$project_listing"; then
-  echo "Generated project is missing the Portico target" >&2
+for target in PorticoApplication Portico PorticoTests PorticoUITests; do
+  if ! awk -v target="$target" '/^[[:space:]]*Targets:/ { in_targets = 1; next } in_targets && /^[[:space:]]*Schemes:/ { exit } in_targets && $0 ~ "^[[:space:]]*" target "[[:space:]]*$" { found = 1 } END { exit !found }' <<<"$project_listing"; then
+    echo "Generated project is missing the $target target" >&2
+    exit 1
+  fi
+done
+
+application_settings="$(xcodebuild -showBuildSettings -project "$project_path" -target PorticoApplication -configuration Debug)"
+if ! awk '/^[[:space:]]*PRODUCT_TYPE[[:space:]]*=[[:space:]]*com\.apple\.product-type\.library\.static$/ { found = 1 } END { exit !found }' <<<"$application_settings"; then
+  echo "PorticoApplication must be a static library" >&2
+  exit 1
+fi
+
+project_metadata="$project_path/project.pbxproj"
+library_target_id="$(awk '
+  /\/\* PorticoApplication \*\/ = \{$/ { candidate = $1; in_target = 1; next }
+  in_target && /isa = PBXNativeTarget;/ { native_target = 1 }
+  in_target && native_target && /name = PorticoApplication;/ { print candidate; exit }
+  in_target && /^\t\t};$/ { in_target = 0; native_target = 0 }
+' "$project_metadata")"
+library_dependency_id="$(awk -v target="$library_target_id" '
+  /\/\* PBXTargetDependency \*\/ = \{$/ { candidate = $1; in_dependency = 1; next }
+  in_dependency && $0 ~ "target = " target " /\\* PorticoApplication \\*/;" { print candidate; exit }
+  in_dependency && /^\t\t};$/ { in_dependency = 0 }
+' "$project_metadata")"
+if [[ -z "$library_target_id" || -z "$library_dependency_id" ]] || ! awk -v dependency="$library_dependency_id" '
+  /\/\* PorticoTests \*\/ = \{$/ { in_target = 1; next }
+  in_target && $1 == dependency { found = 1; next }
+  in_target && /name = PorticoTests;/ { exit }
+  END { exit !found }
+' "$project_metadata"; then
+  echo "PorticoTests must directly depend on PorticoApplication" >&2
+  exit 1
+fi
+
+unit_test_settings="$(xcodebuild -showBuildSettings -project "$project_path" -target PorticoTests -configuration Debug)"
+if awk '/^[[:space:]]*(TEST_HOST|BUNDLE_LOADER)[[:space:]]*=/ { found = 1 } END { exit !found }' <<<"$unit_test_settings"; then
+  echo "PorticoTests must not use an application host or bundle loader" >&2
   exit 1
 fi
 

--- a/project.yml
+++ b/project.yml
@@ -14,12 +14,21 @@ settings:
       SWIFT_COMPILATION_MODE: wholemodule
 
 targets:
+  PorticoApplication:
+    type: library.static
+    platform: macOS
+    deploymentTarget: "14.0"
+    sources:
+      - path: Portico
+
   Portico:
     type: application
     platform: macOS
     deploymentTarget: "14.0"
     sources:
-      - path: Portico
+      - path: PorticoLauncher
+    dependencies:
+      - target: PorticoApplication
     settings:
       base:
         ARCHS: arm64
@@ -61,11 +70,10 @@ targets:
     sources:
       - path: PorticoTests
     dependencies:
-      - target: Portico
+      - target: PorticoApplication
     settings:
       base:
         ARCHS: arm64
-        BUNDLE_LOADER: "$(TEST_HOST)"
         CODE_SIGNING_ALLOWED: "NO"
         GENERATE_INFOPLIST_FILE: "YES"
         MACOSX_DEPLOYMENT_TARGET: "14.0"
@@ -73,7 +81,6 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: dev.chrisbanes.PorticoTests
         PRODUCT_NAME: "$(TARGET_NAME)"
         SWIFT_VERSION: "5.0"
-        TEST_HOST: "$(BUILT_PRODUCTS_DIR)/Portico.app/Contents/MacOS/Portico"
 
   PorticoUITests:
     type: bundle.ui-testing


### PR DESCRIPTION
## Summary

- Move all Portico implementation sources into a static `PorticoApplication` library.
- Keep `Portico` as a minimal executable launcher with the existing product settings and helper embedding.
- Make `PorticoTests` directly depend on the library without a test host or bundle loader, and verify the generated topology.

## Verification

- `./Scripts/verify-xcode-project-generation.sh`
- `xcodebuild -quiet -project Portico.xcodeproj -scheme Portico -destination 'platform=macOS,arch=arm64' -derivedDataPath .build/xcode-unit -only-testing:PorticoTests test`\n- `xcodebuild -quiet -project Portico.xcodeproj -scheme Portico -destination 'platform=macOS,arch=arm64' -derivedDataPath .build/xcode-ui -only-testing:PorticoUITests test` (17 passed)\n- `cd helper && go build ./cmd/portico-helper && go test ./...`\n\n## Residual risk\n\n`./Scripts/smoke-test-local-app.sh` builds successfully and verifies the bundled helper, but its final AppleScript quit assertion fails with `Portico did not quit`. The identical script reproduces that failure on clean base `d44e836` with the original one-target graph, a clean worktree, and no remaining app/helper process, so this is recorded as a pre-existing environment/baseline limitation rather than a change regression.\n\nFixes #50