### PR TITLE
Make headless tests the default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,15 @@ jobs:
       - name: Generate Xcode project
         run: ./Scripts/generate-xcode-project.sh
 
-      - name: Test Swift application
+      - name: Test headless Swift unit suite
         run: >
           xcodebuild -project Portico.xcodeproj -scheme Portico
-          -destination 'platform=macOS' -derivedDataPath .build/xcode test
+          -destination 'platform=macOS' -derivedDataPath .build/xcode-unit test
+
+      - name: Test native Swift UI suite
+        run: >
+          xcodebuild -project Portico.xcodeproj -scheme 'Portico UI Tests'
+          -destination 'platform=macOS' -derivedDataPath .build/xcode-ui test
 
   go:
     name: Go

--- a/README.md
+++ b/README.md
@@ -40,15 +40,27 @@ Launch the result:
 open .build/xcode/Build/Products/Debug/Portico.app
 ```
 
-Run the unit tests:
+Run the routine headless Swift unit tests:
 
 ```shell
-(cd helper && go test ./...)
 xcodebuild \
   -project Portico.xcodeproj \
   -scheme Portico \
   -destination 'platform=macOS' \
-  -derivedDataPath .build/xcode \
+  -derivedDataPath .build/xcode-unit \
+  test
+```
+
+Run the native UI tests when changing menu-bar content, windows, commands,
+accessibility interactions, focus, or other native UI behavior. This command
+launches the real app, opens native windows, and takes the foreground:
+
+```shell
+xcodebuild \
+  -project Portico.xcodeproj \
+  -scheme 'Portico UI Tests' \
+  -destination 'platform=macOS' \
+  -derivedDataPath .build/xcode-ui \
   test
 ```
 
@@ -61,7 +73,13 @@ xcodebuild \
   -project Portico.xcodeproj \
   -scheme Portico \
   -destination 'platform=macOS' \
-  -derivedDataPath .build/xcode \
+  -derivedDataPath .build/xcode-unit \
+  test
+xcodebuild \
+  -project Portico.xcodeproj \
+  -scheme 'Portico UI Tests' \
+  -destination 'platform=macOS' \
+  -derivedDataPath .build/xcode-ui \
   test
 (cd helper && go build ./cmd/portico-helper && go test ./...)
 ```
@@ -79,6 +97,11 @@ bundled helper process, and confirms that both stop cleanly:
 ```shell
 ./Scripts/smoke-test-local-app.sh
 ```
+
+At the current baseline, this script can finish its build and helper checks,
+then report `Portico did not quit` even though neither the app nor its helper
+process remains. Treat only that exact final signature as the known limitation;
+any build, helper, launch, or residual-process failure needs investigation.
 
 ## Documentation
 

--- a/Scripts/verify-xcode-project-generation.sh
+++ b/Scripts/verify-xcode-project-generation.sh
@@ -79,7 +79,35 @@ if awk '/^[[:space:]]*(TEST_HOST|BUNDLE_LOADER)[[:space:]]*=/ { found = 1 } END 
   exit 1
 fi
 
-if ! awk '/^[[:space:]]*Schemes:/ { in_schemes = 1; next } in_schemes && /^[[:space:]]*Portico[[:space:]]*$/ { found = 1 } END { exit !found }' <<<"$project_listing"; then
-  echo "Generated project is missing the Portico scheme" >&2
+ui_test_settings="$(xcodebuild -showBuildSettings -project "$project_path" -target PorticoUITests -configuration Debug)"
+if ! awk '/^[[:space:]]*TEST_TARGET_NAME[[:space:]]*=[[:space:]]*Portico$/ { found = 1 } END { exit !found }' <<<"$ui_test_settings"; then
+  echo "PorticoUITests must target the Portico application" >&2
+  exit 1
+fi
+
+for scheme in Portico "Portico UI Tests"; do
+  if ! awk -v scheme="$scheme" '/^[[:space:]]*Schemes:/ { in_schemes = 1; next } in_schemes && $0 ~ "^[[:space:]]*" scheme "[[:space:]]*$" { found = 1 } END { exit !found }' <<<"$project_listing"; then
+    echo "Generated project is missing the $scheme scheme" >&2
+    exit 1
+  fi
+done
+
+scheme_dir="$project_path/xcshareddata/xcschemes"
+scheme_test_action() {
+  awk 'index($0, "<TestAction") { in_test_action = 1 } in_test_action { print } index($0, "</TestAction>") { exit }' "$1"
+}
+
+headless_test_action="$(scheme_test_action "$scheme_dir/Portico.xcscheme")"
+ui_test_action="$(scheme_test_action "$scheme_dir/Portico UI Tests.xcscheme")"
+headless_testable_count="$(awk 'index($0, "<TestableReference") { count++ } END { print count + 0 }' <<<"$headless_test_action")"
+ui_testable_count="$(awk 'index($0, "<TestableReference") { count++ } END { print count + 0 }' <<<"$ui_test_action")"
+
+if [[ "$headless_testable_count" != 1 ]] || ! grep -Fq 'BlueprintName = "PorticoTests"' <<<"$headless_test_action"; then
+  echo "Portico scheme must select only PorticoTests" >&2
+  exit 1
+fi
+
+if [[ "$ui_testable_count" != 1 ]] || ! grep -Fq 'BlueprintName = "PorticoUITests"' <<<"$ui_test_action"; then
+  echo "Portico UI Tests scheme must select only PorticoUITests" >&2
   exit 1
 fi

--- a/project.yml
+++ b/project.yml
@@ -114,4 +114,13 @@ schemes:
       config: Debug
       targets:
         - PorticoTests
+
+  Portico UI Tests:
+    build:
+      targets:
+        Portico: all
+        PorticoUITests: [test]
+    test:
+      config: Debug
+      targets:
         - PorticoUITests


### PR DESCRIPTION
## Summary
- make `Portico` the shared headless-unit scheme and add the explicit `Portico UI Tests` scheme
- verify exclusive generated TestAction membership, unhosted units, and the UI bundle app target
- document foreground UI validation and split the existing Swift CI job into named unit/UI steps

## Validation
- `./Scripts/verify-xcode-project-generation.sh`
- `xcodebuild -project Portico.xcodeproj -scheme Portico -destination platform=macOS,arch=arm64 -derivedDataPath .build/xcode-unit test`
- `xcodebuild -project Portico.xcodeproj -scheme Portico UI Tests -destination platform=macOS,arch=arm64 -derivedDataPath .build/xcode-ui test`
- `cd helper && go build ./cmd/portico-helper && go test ./...`
- smoke baseline: after successful build/helper checks, it ended only with `Portico did not quit`; no scoped app/helper process remained

Closes #51