### PR TITLE
Make launch at login choices durable

### DIFF
--- a/Portico/AppDelegate.swift
+++ b/Portico/AppDelegate.swift
@@ -140,6 +140,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         supervisor.start(loggingPreference: portalController.operationalLogging)
     }
 
+    func applicationShouldRestoreApplicationState(_ app: NSApplication) -> Bool {
+        false
+    }
+
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         supervisor.shutdown {
             sender.reply(toApplicationShouldTerminate: true)

--- a/Portico/AppDelegate.swift
+++ b/Portico/AppDelegate.swift
@@ -1,10 +1,21 @@
 import AppKit
+import Combine
+
+@MainActor
+final class ManagementRouting: ObservableObject {
+    @Published private(set) var overviewRequest = 0
+
+    func requestOverview() {
+        overviewRequest += 1
+    }
+}
 
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
     let supervisor: HelperSupervisor
     let portalController: PortalController
     let launchAtLoginController: LaunchAtLoginController
+    let managementRouting = ManagementRouting()
     private var requestsInitialManagementWindow = false
 
     override init() {
@@ -39,7 +50,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let launchAtLoginService: LaunchAtLoginServicing = testConfiguration.map {
             UITestLaunchAtLoginService(
                 status: $0.launchAtLoginStatus,
-                registrationFails: $0.registrationFails
+                registrationOutcome: $0.registrationOutcome
             )
         } ?? ServiceManagementLaunchAtLoginService()
         let copyText: (String) -> Void
@@ -102,6 +113,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             offerState: { portalController.launchAtLoginOffer },
             saveOfferState: { portalController.commitLaunchAtLoginOffer($0) }
         )
+        launchAtLoginController.restorePresentedOffer()
         portalController.onFreshPortalOnline = {
             launchAtLoginController.considerOfferAfterFreshOnline()
         }
@@ -136,7 +148,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationDidBecomeActive(_ notification: Notification) {
-        launchAtLoginController.refreshStatus()
+        launchAtLoginController.refreshStatusAfterApplicationActivation()
     }
 
     func takeInitialManagementWindowRequest() -> Bool {

--- a/Portico/AppDelegate.swift
+++ b/Portico/AppDelegate.swift
@@ -140,10 +140,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         supervisor.start(loggingPreference: portalController.operationalLogging)
     }
 
-    func applicationShouldRestoreApplicationState(_ app: NSApplication) -> Bool {
-        false
-    }
-
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         supervisor.shutdown {
             sender.reply(toApplicationShouldTerminate: true)

--- a/Portico/LaunchAtLogin.swift
+++ b/Portico/LaunchAtLogin.swift
@@ -78,6 +78,11 @@ final class LaunchAtLoginController: ObservableObject {
         isOffering = true
     }
 
+    func restorePresentedOffer() {
+        guard offerState() == .presented else { return }
+        isOffering = true
+    }
+
     func acceptOffer() {
         guard isOffering, commit(.accepted) else { return }
         isOffering = false
@@ -121,6 +126,10 @@ final class LaunchAtLoginController: ObservableObject {
 
     func refreshStatus() {
         refreshStatus(preservingError: false)
+    }
+
+    func refreshStatusAfterApplicationActivation() {
+        refreshStatus(preservingError: true)
     }
 
     private func register() {

--- a/Portico/LaunchAtLogin.swift
+++ b/Portico/LaunchAtLogin.swift
@@ -70,16 +70,15 @@ final class LaunchAtLoginController: ObservableObject {
     func considerOfferAfterFreshOnline() {
         guard offerState() == .notOffered else { return }
         refreshStatus()
-        if status == .enabled {
-            _ = commit(.accepted)
-            return
-        }
+        if acceptOfferIfAlreadyEnabled() { return }
         guard commit(.presented) else { return }
         isOffering = true
     }
 
     func restorePresentedOffer() {
         guard offerState() == .presented else { return }
+        refreshStatus()
+        if acceptOfferIfAlreadyEnabled() { return }
         isOffering = true
     }
 
@@ -92,6 +91,12 @@ final class LaunchAtLoginController: ObservableObject {
     func declineOffer() {
         guard isOffering, commit(.declined) else { return }
         isOffering = false
+    }
+
+    private func acceptOfferIfAlreadyEnabled() -> Bool {
+        guard status == .enabled else { return false }
+        _ = commit(.accepted)
+        return true
     }
 
     func retryRegistration() {

--- a/Portico/LaunchAtLogin.swift
+++ b/Portico/LaunchAtLogin.swift
@@ -129,7 +129,11 @@ final class LaunchAtLoginController: ObservableObject {
     }
 
     func refreshStatusAfterApplicationActivation() {
+        let previousStatus = status
         refreshStatus(preservingError: true)
+        if status != previousStatus {
+            errorMessage = nil
+        }
     }
 
     private func register() {

--- a/Portico/PorticoApp.swift
+++ b/Portico/PorticoApp.swift
@@ -12,6 +12,7 @@ struct PorticoApp: App {
                 controller: appDelegate.portalController,
                 supervisor: appDelegate.supervisor,
                 launchAtLogin: appDelegate.launchAtLoginController,
+                managementRouting: appDelegate.managementRouting,
                 takeInitialManagementWindowRequest: appDelegate.takeInitialManagementWindowRequest
             )
             .environment(\.openURL, OpenURLAction { url in
@@ -24,7 +25,9 @@ struct PorticoApp: App {
         Window("Portico", id: "management") {
             OverviewView(
                 controller: appDelegate.portalController,
-                supervisor: appDelegate.supervisor
+                supervisor: appDelegate.supervisor,
+                launchAtLogin: appDelegate.launchAtLoginController,
+                managementRouting: appDelegate.managementRouting
             )
         }
         .defaultSize(width: 720, height: 520)
@@ -86,6 +89,8 @@ private struct OverviewView: View {
 
     @ObservedObject var controller: PortalController
     @ObservedObject var supervisor: HelperSupervisor
+    @ObservedObject var launchAtLogin: LaunchAtLoginController
+    @ObservedObject var managementRouting: ManagementRouting
     @State private var selection: Destination? = .overview
     @State private var showingAddPortal = false
     @State private var showingResetConfirmation = false
@@ -166,6 +171,9 @@ private struct OverviewView: View {
                     accessibilityFocus = .removalNotice(id)
                 }
             }
+            .onChange(of: managementRouting.overviewRequest) {
+                selection = .overview
+            }
             .confirmationDialog(
                 "Reset this installation's tailnet binding? This does not remove any remote Tailscale node.",
                 isPresented: $showingResetConfirmation,
@@ -229,6 +237,22 @@ private struct OverviewView: View {
                         .accessibilityIdentifier("overview-helper-state")
                     LabeledContent("Tailnet", value: controller.tailnetDisplaySuffix ?? "Not connected")
                         .accessibilityIdentifier("overview-tailnet")
+                }
+                if launchAtLogin.isOffering {
+                    Section("Launch at Login") {
+                        Text("Open Portico at Login?")
+                        Text("You can change this later in Settings.")
+                            .foregroundStyle(.secondary)
+                        HStack {
+                            Button("Not Now") { launchAtLogin.declineOffer() }
+                                .accessibilityIdentifier("overview-login-offer-decline")
+                            Button("Enable") { launchAtLogin.acceptOffer() }
+                                .buttonStyle(.borderedProminent)
+                                .accessibilityIdentifier("overview-login-offer-enable")
+                        }
+                    }
+                    .accessibilityElement(children: .contain)
+                    .accessibilityIdentifier("overview-launch-at-login-offer")
                 }
                 if PortalPresentation.showsPrerequisiteGuidance(portalCount: controller.portals.count) {
                     Section("Before creating your first Portal") {
@@ -724,6 +748,7 @@ private struct PortalView: View {
     @ObservedObject var controller: PortalController
     @ObservedObject var supervisor: HelperSupervisor
     @ObservedObject var launchAtLogin: LaunchAtLoginController
+    @ObservedObject var managementRouting: ManagementRouting
     let takeInitialManagementWindowRequest: () -> Bool
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -734,15 +759,12 @@ private struct PortalView: View {
             }
             if launchAtLogin.isOffering {
                 VStack(alignment: .leading, spacing: 6) {
-                    Text("Open Portico at Login?").font(.headline)
-                    Text("You can change this later in Settings.")
-                    HStack {
-                        Button("Not Now") { launchAtLogin.declineOffer() }
-                            .accessibilityIdentifier("login-offer-decline")
-                        Button("Enable") { launchAtLogin.acceptOffer() }
-                            .buttonStyle(.borderedProminent)
-                            .accessibilityIdentifier("login-offer-enable")
+                    Text("Launch at login is ready to set up.")
+                    Button("Set Up Launch at Login") {
+                        managementRouting.requestOverview()
+                        openWindow(id: "management")
                     }
+                    .accessibilityIdentifier("login-offer-reminder")
                 }
                 .accessibilityElement(children: .contain)
                 .accessibilityIdentifier("launch-at-login-offer")
@@ -771,11 +793,6 @@ private struct PortalView: View {
         .task {
             if takeInitialManagementWindowRequest() {
                 openWindow(id: "management")
-            }
-        }
-        .onDisappear {
-            if launchAtLogin.isOffering {
-                launchAtLogin.declineOffer()
             }
         }
         Divider()
@@ -1133,7 +1150,7 @@ private struct SettingsView: View {
         .padding()
         .frame(width: 480)
         .onAppear {
-            launchAtLogin.refreshStatus()
+            launchAtLogin.refreshStatusAfterApplicationActivation()
             headingFocused = true
         }
     }

--- a/Portico/PorticoApp.swift
+++ b/Portico/PorticoApp.swift
@@ -753,6 +753,7 @@ private struct FocusRestoringButton: NSViewRepresentable {
 }
 
 private struct PortalView: View {
+    @Environment(\.dismiss) private var dismiss
     @Environment(\.openWindow) private var openWindow
     @ObservedObject var controller: PortalController
     @ObservedObject var supervisor: HelperSupervisor
@@ -772,6 +773,7 @@ private struct PortalView: View {
                     Button("Set Up Launch at Login") {
                         managementRouting.requestOverview()
                         openWindow(id: "management")
+                        dismiss()
                     }
                     .accessibilityIdentifier("login-offer-reminder")
                 }

--- a/Portico/PorticoApp.swift
+++ b/Portico/PorticoApp.swift
@@ -225,6 +225,9 @@ private struct OverviewView: View {
                 } description: {
                     Text("Add a Portal to give a Local App a private tailnet doorway.")
                 }
+                if launchAtLogin.isOffering {
+                    launchAtLoginOffer
+                }
                 Button("Add Portal") { showingAddPortal = true }
                     .buttonStyle(.borderedProminent)
                     .accessibilityIdentifier("overview-empty-add-portal")
@@ -240,19 +243,8 @@ private struct OverviewView: View {
                 }
                 if launchAtLogin.isOffering {
                     Section("Launch at Login") {
-                        Text("Open Portico at Login?")
-                        Text("You can change this later in Settings.")
-                            .foregroundStyle(.secondary)
-                        HStack {
-                            Button("Not Now") { launchAtLogin.declineOffer() }
-                                .accessibilityIdentifier("overview-login-offer-decline")
-                            Button("Enable") { launchAtLogin.acceptOffer() }
-                                .buttonStyle(.borderedProminent)
-                                .accessibilityIdentifier("overview-login-offer-enable")
-                        }
+                        launchAtLoginOffer
                     }
-                    .accessibilityElement(children: .contain)
-                    .accessibilityIdentifier("overview-launch-at-login-offer")
                 }
                 if PortalPresentation.showsPrerequisiteGuidance(portalCount: controller.portals.count) {
                     Section("Before creating your first Portal") {
@@ -295,6 +287,23 @@ private struct OverviewView: View {
             }
             .formStyle(.grouped)
         }
+    }
+
+    private var launchAtLoginOffer: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Open Portico at Login?")
+            Text("You can change this later in Settings.")
+                .foregroundStyle(.secondary)
+            HStack {
+                Button("Not Now") { launchAtLogin.declineOffer() }
+                    .accessibilityIdentifier("overview-login-offer-decline")
+                Button("Enable") { launchAtLogin.acceptOffer() }
+                    .buttonStyle(.borderedProminent)
+                    .accessibilityIdentifier("overview-login-offer-enable")
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("overview-launch-at-login-offer")
     }
 
     @ViewBuilder

--- a/Portico/UITestLaunchConfiguration.swift
+++ b/Portico/UITestLaunchConfiguration.swift
@@ -23,6 +23,7 @@ enum UITestScenario: String {
     case loginOffer = "login-offer"
     case loginOfferApproval = "login-offer-approval"
     case loginOfferError = "login-offer-error"
+    case loginOfferEmpty = "login-offer-empty"
     case migrated
     case initialSaveFailure = "initial-save-failure"
 }
@@ -79,6 +80,11 @@ struct UITestLaunchConfiguration {
                 portals: [Self.portal()],
                 operationalLogging: .enabled,
                 launchAtLoginOffer: .notOffered
+            ))
+        case .loginOfferEmpty:
+            try store.save(InstallationRecord(
+                operationalLogging: .enabled,
+                launchAtLoginOffer: .presented
             ))
         case .remoteOnline:
             try store.save(InstallationRecord(

--- a/Portico/UITestLaunchConfiguration.swift
+++ b/Portico/UITestLaunchConfiguration.swift
@@ -21,6 +21,8 @@ enum UITestScenario: String {
     case loginApproval = "login-approval"
     case loginError = "login-error"
     case loginOffer = "login-offer"
+    case loginOfferApproval = "login-offer-approval"
+    case loginOfferError = "login-offer-error"
     case migrated
     case initialSaveFailure = "initial-save-failure"
 }
@@ -71,7 +73,7 @@ struct UITestLaunchConfiguration {
                 operationalLogging: .enabled,
                 launchAtLoginOffer: .declined
             ))
-        case .loginOffer:
+        case .loginOffer, .loginOfferApproval, .loginOfferError:
             try store.save(InstallationRecord(
                 tailnetBinding: Self.tailnetBinding,
                 portals: [Self.portal()],
@@ -165,11 +167,14 @@ struct UITestLaunchConfiguration {
         }
     }
 
-    var launchAtLoginStatus: LaunchAtLoginStatus {
-        scenario == .loginApproval ? .requiresApproval : .notRegistered
+    var launchAtLoginStatus: LaunchAtLoginStatus { scenario == .loginApproval ? .requiresApproval : .notRegistered }
+    var registrationOutcome: UITestLaunchAtLoginRegistrationOutcome {
+        switch scenario {
+        case .loginOfferApproval: .requiresApproval
+        case .loginOfferError, .loginError: .failure
+        default: .enabled
+        }
     }
-
-    var registrationFails: Bool { scenario == .loginError }
     var reachabilityResult: Bool { scenario != .terminalFailure }
     var supervisorSchedulerScale: Double {
         switch scenario {
@@ -392,7 +397,7 @@ private final class UITestHelperProcess: HelperProcess {
     }
 
     private func emitStatuses(for portals: [ReconcilePortalPayload]) {
-        guard [.online, .remoteOnline, .authenticating, .awaitingApproval, .stale, .restarting, .loginOffer, .management, .durableManagement].contains(scenario) else { return }
+        guard [.online, .remoteOnline, .authenticating, .awaitingApproval, .stale, .restarting, .loginOffer, .loginOfferApproval, .loginOfferError, .management, .durableManagement].contains(scenario) else { return }
         for portal in portals {
             let state: PortalTailscaleState
             if scenario == .authenticating {
@@ -436,20 +441,29 @@ private final class UITestHelperProcess: HelperProcess {
 
 final class UITestLaunchAtLoginService: LaunchAtLoginServicing {
     private(set) var status: LaunchAtLoginStatus
-    private let registrationFails: Bool
+    private let registrationOutcome: UITestLaunchAtLoginRegistrationOutcome
 
-    init(status: LaunchAtLoginStatus, registrationFails: Bool) {
+    init(status: LaunchAtLoginStatus, registrationOutcome: UITestLaunchAtLoginRegistrationOutcome) {
         self.status = status
-        self.registrationFails = registrationFails
+        self.registrationOutcome = registrationOutcome
     }
 
     func register() throws {
-        if registrationFails { throw UITestServiceError() }
-        status = .enabled
+        switch registrationOutcome {
+        case .enabled: status = .enabled
+        case .requiresApproval: status = .requiresApproval
+        case .failure: throw UITestServiceError()
+        }
     }
 
     func unregister() throws { status = .notRegistered }
     func openSystemSettingsLoginItems() {}
+}
+
+enum UITestLaunchAtLoginRegistrationOutcome {
+    case enabled
+    case requiresApproval
+    case failure
 }
 
 final class UITestLocalAppProbe: LocalAppProbing {

--- a/PorticoTests/LaunchAtLoginTests.swift
+++ b/PorticoTests/LaunchAtLoginTests.swift
@@ -130,6 +130,21 @@ final class LaunchAtLoginTests: XCTestCase {
         XCTAssertEqual(controller.errorMessage, "Launch at login could not be enabled.")
     }
 
+    func testApplicationActivationRefreshClearsRegistrationFailureAfterExternalStatusChange() {
+        struct ExpectedFailure: Error {}
+        let service = FakeLaunchAtLoginService(status: .notRegistered)
+        service.registerError = ExpectedFailure()
+        let controller = makeController(service: service, store: FakeLaunchAtLoginOfferStore())
+        controller.considerOfferAfterFreshOnline()
+        controller.acceptOffer()
+
+        service.status = .enabled
+        controller.refreshStatusAfterApplicationActivation()
+
+        XCTAssertEqual(controller.status, .enabled)
+        XCTAssertNil(controller.errorMessage)
+    }
+
     func testDisableFailureKeepsLiveStatusAndExternalRefreshDoesNotMutateOfferHistory() {
         struct ExpectedFailure: Error {}
         let service = FakeLaunchAtLoginService(status: .enabled)

--- a/PorticoTests/LaunchAtLoginTests.swift
+++ b/PorticoTests/LaunchAtLoginTests.swift
@@ -52,6 +52,15 @@ final class LaunchAtLoginTests: XCTestCase {
         XCTAssertTrue(presentedStore.saved.isEmpty)
         XCTAssertEqual(service.registerCount, 0)
 
+        let enabledService = FakeLaunchAtLoginService(status: .enabled)
+        let enabledStore = FakeLaunchAtLoginOfferStore(state: .presented)
+        let alreadyEnabled = makeController(service: enabledService, store: enabledStore)
+        alreadyEnabled.restorePresentedOffer()
+        XCTAssertFalse(alreadyEnabled.isOffering)
+        XCTAssertEqual(enabledStore.state, .accepted)
+        XCTAssertEqual(enabledStore.saved, [.accepted])
+        XCTAssertEqual(enabledService.registerCount, 0)
+
         let declined = makeController(
             service: service,
             store: FakeLaunchAtLoginOfferStore(state: .declined)

--- a/PorticoTests/LaunchAtLoginTests.swift
+++ b/PorticoTests/LaunchAtLoginTests.swift
@@ -42,13 +42,29 @@ final class LaunchAtLoginTests: XCTestCase {
         XCTAssertEqual(controller.errorMessage, "The launch at login choice could not be saved.")
     }
 
-    func testPresentedStateDoesNotRepeatAfterRelaunchAndDeclineIsDurable() {
+    func testPresentedStateRestoresWithoutSavingOrRegisteringAndDeclineIsDurable() {
         let service = FakeLaunchAtLoginService(status: .notRegistered)
         let presentedStore = FakeLaunchAtLoginOfferStore(state: .presented)
         let relaunched = makeController(service: service, store: presentedStore)
 
-        relaunched.considerOfferAfterFreshOnline()
-        XCTAssertFalse(relaunched.isOffering)
+        relaunched.restorePresentedOffer()
+        XCTAssertTrue(relaunched.isOffering)
+        XCTAssertTrue(presentedStore.saved.isEmpty)
+        XCTAssertEqual(service.registerCount, 0)
+
+        let declined = makeController(
+            service: service,
+            store: FakeLaunchAtLoginOfferStore(state: .declined)
+        )
+        declined.restorePresentedOffer()
+        XCTAssertFalse(declined.isOffering)
+
+        let accepted = makeController(
+            service: service,
+            store: FakeLaunchAtLoginOfferStore(state: .accepted)
+        )
+        accepted.restorePresentedOffer()
+        XCTAssertFalse(accepted.isOffering)
 
         let offeredStore = FakeLaunchAtLoginOfferStore()
         let offered = makeController(service: service, store: offeredStore)
@@ -73,6 +89,8 @@ final class LaunchAtLoginTests: XCTestCase {
 
         XCTAssertEqual(events.suffix(2), ["saved-accepted", "register"])
         XCTAssertEqual(store.state, .accepted)
+        XCTAssertEqual(service.status, .notRegistered)
+        XCTAssertEqual(controller.status, .notRegistered)
         XCTAssertEqual(controller.errorMessage, "Launch at login could not be enabled.")
         service.registerError = nil
         controller.retryRegistration()
@@ -95,6 +113,21 @@ final class LaunchAtLoginTests: XCTestCase {
         controller.retryRegistration()
         XCTAssertEqual(controller.status, .notFound)
         XCTAssertEqual(service.registerCount, 0)
+    }
+
+    func testApplicationActivationRefreshPreservesRegistrationFailure() {
+        struct ExpectedFailure: Error {}
+        let service = FakeLaunchAtLoginService(status: .notRegistered)
+        service.registerError = ExpectedFailure()
+        let store = FakeLaunchAtLoginOfferStore()
+        let controller = makeController(service: service, store: store)
+        controller.considerOfferAfterFreshOnline()
+        controller.acceptOffer()
+
+        controller.refreshStatusAfterApplicationActivation()
+
+        XCTAssertEqual(controller.status, .notRegistered)
+        XCTAssertEqual(controller.errorMessage, "Launch at login could not be enabled.")
     }
 
     func testDisableFailureKeepsLiveStatusAndExternalRefreshDoesNotMutateOfferHistory() {

--- a/PorticoUITests/PorticoUITests.swift
+++ b/PorticoUITests/PorticoUITests.swift
@@ -324,6 +324,8 @@ final class PorticoUITests: XCTestCase {
         let root = makeRoot()
         var app = launch(scenario: "first-run", root: root)
         XCTAssertTrue(app.descendants(matching: .any)["management-overview"].waitForExistence(timeout: 3))
+        app.typeKey("w", modifierFlags: .command)
+        XCTAssertFalse(app.descendants(matching: .any)["management-overview"].waitForExistence(timeout: 3))
         app.terminate()
         XCTAssertTrue(app.wait(for: .notRunning, timeout: 5))
 
@@ -524,35 +526,57 @@ final class PorticoUITests: XCTestCase {
         XCTAssertFalse(app.buttons["overview-reset-tailnet"].exists)
     }
 
-    func testLaunchAtLoginApprovalAndRegistrationError() {
-        var app = launch(scenario: "login-approval")
+    func testLaunchAtLoginApprovalFromOverviewOffer() {
+        let app = launch(scenario: "login-offer-approval")
+        openMenuBarExtra(app)
+        app.buttons["login-offer-reminder"].click()
+        XCTAssertTrue(app.buttons["overview-login-offer-enable"].waitForExistence(timeout: 3))
+        app.buttons["overview-login-offer-enable"].click()
+        XCTAssertFalse(app.descendants(matching: .any)["overview-launch-at-login-offer"].waitForExistence(timeout: 3))
         app.typeKey(",", modifierFlags: .command)
         XCTAssertTrue(app.staticTexts["settings-heading"].waitForExistence(timeout: 3))
         XCTAssertTrue(app.buttons["open-login-items-settings"].isEnabled)
-
-        app = launch(scenario: "login-error")
-        app.typeKey(",", modifierFlags: .command)
-        XCTAssertTrue(app.buttons["enable-launch-at-login"].waitForExistence(timeout: 3))
-        app.buttons["enable-launch-at-login"].click()
-        XCTAssertTrue(app.staticTexts["launch-at-login-error"].waitForExistence(timeout: 3))
-        XCTAssertTrue(app.buttons["retry-launch-at-login"].isEnabled)
     }
 
-    func testLaunchAtLoginOfferDoesNotRepeatAfterRelaunch() {
+    func testLaunchAtLoginRegistrationFailureFromOverviewOffer() {
+        let app = launch(scenario: "login-offer-error")
+        openMenuBarExtra(app)
+        app.buttons["login-offer-reminder"].click()
+        XCTAssertTrue(app.buttons["overview-login-offer-enable"].waitForExistence(timeout: 3))
+        app.buttons["overview-login-offer-enable"].click()
+        XCTAssertFalse(app.descendants(matching: .any)["overview-launch-at-login-offer"].waitForExistence(timeout: 3))
+        app.typeKey(",", modifierFlags: .command)
+        XCTAssertTrue(app.staticTexts["launch-at-login-error"].waitForExistence(timeout: 3))
+        XCTAssertTrue(waitForValue("Off", element: app.staticTexts["launch-at-login-status"], timeout: 3), app.debugDescription)
+        let retry = app.buttons["retry-launch-at-login"]
+        XCTAssertTrue(retry.waitForExistence(timeout: 3))
+        XCTAssertTrue(retry.isEnabled)
+    }
+
+    func testLaunchAtLoginOfferRoutesFromMenuToOverviewAndStaysUntilExplicitChoice() {
         let root = makeRoot()
-        var app = launch(scenario: "login-offer", root: root)
+        let app = launch(scenario: "login-offer", root: root)
         openMenuBarExtra(app)
-        XCTAssertTrue(app.descendants(matching: .any)["launch-at-login-offer"].waitForExistence(timeout: 5))
+        let reminder = app.buttons["login-offer-reminder"]
+        XCTAssertTrue(reminder.waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertFalse(app.buttons["login-offer-enable"].exists)
+        XCTAssertFalse(app.buttons["login-offer-decline"].exists)
 
-        app.statusItems.firstMatch.click()
-        openMenuBarExtra(app)
-        XCTAssertFalse(app.descendants(matching: .any)["launch-at-login-offer"].waitForExistence(timeout: 2))
+        reminder.click()
+        XCTAssertTrue(app.descendants(matching: .any)["management-overview"].waitForExistence(timeout: 3))
+        XCTAssertTrue(app.descendants(matching: .any)["overview-launch-at-login-offer"].exists)
 
-        app.terminate()
-        XCTAssertTrue(app.wait(for: .notRunning, timeout: 5))
-        app = launch(scenario: "login-offer", root: root)
+        app.buttons["management-sidebar-portal-portal-one"].click()
+        XCTAssertTrue(waitForValue("portal-one", element: app.staticTexts["selected-portal-name"], timeout: 3))
         openMenuBarExtra(app)
-        XCTAssertFalse(app.descendants(matching: .any)["launch-at-login-offer"].waitForExistence(timeout: 2))
+        XCTAssertTrue(app.buttons["login-offer-reminder"].waitForExistence(timeout: 3))
+        app.buttons["login-offer-reminder"].click()
+        XCTAssertTrue(app.descendants(matching: .any)["overview-launch-at-login-offer"].waitForExistence(timeout: 3))
+        XCTAssertFalse(app.staticTexts["selected-portal-name"].exists)
+
+        XCTAssertTrue(app.buttons["overview-login-offer-decline"].waitForExistence(timeout: 3))
+        app.buttons["overview-login-offer-decline"].click()
+        XCTAssertFalse(app.descendants(matching: .any)["overview-launch-at-login-offer"].waitForExistence(timeout: 2))
     }
 
     private func launch(scenario: String, root: String? = nil) -> XCUIApplication {

--- a/PorticoUITests/PorticoUITests.swift
+++ b/PorticoUITests/PorticoUITests.swift
@@ -321,15 +321,12 @@ final class PorticoUITests: XCTestCase {
     }
 
     func testOnlyFreshInstallationAutoOpensOverviewAndPersistenceFailureIsSanitized() {
-        let root = makeRoot()
-        var app = launch(scenario: "first-run", root: root)
+        var app = launch(scenario: "first-run")
         XCTAssertTrue(app.descendants(matching: .any)["management-overview"].waitForExistence(timeout: 3))
-        app.typeKey("w", modifierFlags: .command)
-        XCTAssertFalse(app.descendants(matching: .any)["management-overview"].waitForExistence(timeout: 3))
         app.terminate()
         XCTAssertTrue(app.wait(for: .notRunning, timeout: 5))
 
-        app = launch(scenario: "first-run", root: root)
+        app = launch(scenario: "creation")
         XCTAssertFalse(app.descendants(matching: .any)["management-overview"].waitForExistence(timeout: 2))
         app.terminate()
         XCTAssertTrue(app.wait(for: .notRunning, timeout: 5))

--- a/PorticoUITests/PorticoUITests.swift
+++ b/PorticoUITests/PorticoUITests.swift
@@ -579,6 +579,18 @@ final class PorticoUITests: XCTestCase {
         XCTAssertFalse(app.descendants(matching: .any)["overview-launch-at-login-offer"].waitForExistence(timeout: 2))
     }
 
+    func testLaunchAtLoginOfferIsActionableInEmptyOverview() {
+        let app = launch(scenario: "login-offer-empty")
+        openMenuBarExtra(app)
+
+        app.buttons["login-offer-reminder"].click()
+
+        XCTAssertTrue(app.staticTexts["No Portals"].waitForExistence(timeout: 3), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["overview-launch-at-login-offer"].exists)
+        app.buttons["overview-login-offer-decline"].click()
+        XCTAssertFalse(app.descendants(matching: .any)["overview-launch-at-login-offer"].waitForExistence(timeout: 2))
+    }
+
     private func launch(scenario: String, root: String? = nil) -> XCUIApplication {
         let app = XCUIApplication()
         app.terminate()


### PR DESCRIPTION
Fixes #41

## Rationale
Restores unresolved launch-at-login offers across startup, keeps Enable and Not Now in the management Overview, and makes the menu bar a safe transient router.

## Tests
- Full Portico unit suite
- Full Portico UI suite (20 passed)
- Go helper build and tests

## Risks
Changes only in-memory management routing and native test fakes; no persistence schema, helper protocol, or ServiceManagement registration behavior changed.