### PR TITLE
Compact menu-bar portal controls

### DIFF
--- a/Portico/AppDelegate.swift
+++ b/Portico/AppDelegate.swift
@@ -27,6 +27,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
 #if DEBUG
         let testConfiguration = UITestLaunchConfiguration.current
+        let reportsInitialPersistenceFailure = testConfiguration?.reportsInitialPersistenceFailure ?? false
         if let testConfiguration {
             do {
                 try testConfiguration.prepareInstallationIfNeeded()
@@ -63,6 +64,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             openURL = { _ in }
         }
 #else
+        let reportsInitialPersistenceFailure = false
         let applicationRoot = productionRoot
         let supervisorScheduler: PorticoScheduling = scheduler
         let launcher: HelperLaunching = ProcessHelperLauncher()
@@ -123,6 +125,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         self.requestsInitialManagementWindow = startupResult == .freshInstallation
         if startupResult == nil {
             portalController.reportInitialPersistenceFailure()
+        }
+        if reportsInitialPersistenceFailure {
+            DispatchQueue.main.async {
+                portalController.reportInitialPersistenceFailure()
+            }
         }
         super.init()
     }

--- a/Portico/PorticoApp.swift
+++ b/Portico/PorticoApp.swift
@@ -361,7 +361,8 @@ private struct OverviewView: View {
 
     private var hasRecoveryContent: Bool {
         supervisor.availability == .failed || !controller.pendingPortals.isEmpty ||
-            !controller.removalNotices.isEmpty || !controller.alerts.isEmpty || controller.canResetTailnet
+            !controller.removalNotices.isEmpty || !controller.alerts.isEmpty ||
+            controller.canResetTailnet || controller.message != nil
     }
 
     private func sidebarState(for portal: PortalConfiguration, presentation: PortalPresentation) -> String {

--- a/Portico/PorticoApp.swift
+++ b/Portico/PorticoApp.swift
@@ -780,34 +780,34 @@ private struct PortalView: View {
     @ObservedObject var launchAtLogin: LaunchAtLoginController
     @ObservedObject var managementRouting: ManagementRouting
     let takeInitialManagementWindowRequest: () -> Bool
+
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             Label(supervisor.availability.title, systemImage: supervisor.availability.symbolName)
                 .accessibilityIdentifier("helper-state")
-            if let suffix = controller.tailnetDisplaySuffix {
-                LabeledContent("Tailnet", value: suffix)
+            LabeledContent("Tailnet", value: controller.tailnetDisplaySuffix ?? "Not connected")
+                .accessibilityIdentifier("tailnet-state")
+            if requiresAttention {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Portico needs your attention.")
+                    Button("Review in Portico") { openOverview() }
+                        .accessibilityIdentifier("compact-attention")
+                }
+                .accessibilityElement(children: .contain)
+                .accessibilityIdentifier("compact-attention-summary")
             }
             if launchAtLogin.isOffering {
                 VStack(alignment: .leading, spacing: 6) {
                     Text("Launch at login is ready to set up.")
-                    Button("Set Up Launch at Login") {
-                        managementRouting.requestOverview()
-                        openWindow(id: "management")
-                        dismiss()
-                    }
+                    Button("Set Up Launch at Login") { openOverview() }
                     .accessibilityIdentifier("login-offer-reminder")
                 }
                 .accessibilityElement(children: .contain)
                 .accessibilityIdentifier("launch-at-login-offer")
             }
-            ForEach(controller.portals.filter { $0.lifecycle == .active }, id: \.id) { portal in
-                PortalStatusView(controller: controller, portal: portal)
+            ForEach(controller.portals, id: \.id) { portal in
+                CompactPortalMenuRow(controller: controller, portal: portal)
                 Divider()
-            }
-            if let message = controller.message {
-                Text(message)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
             }
             Divider()
             HStack {
@@ -836,6 +836,12 @@ private struct PortalView: View {
                 .help("Open Portico")
                 .accessibilityIdentifier("open-portico")
             }
+            Divider()
+            Button("Quit Portico") {
+                NSApp.terminate(nil)
+            }
+            .keyboardShortcut("q")
+            .accessibilityIdentifier("quit")
         }
         .padding()
         .frame(width: 380)
@@ -844,12 +850,21 @@ private struct PortalView: View {
                 openWindow(id: "management")
             }
         }
-        Divider()
-        Button("Quit Portico") {
-            NSApp.terminate(nil)
-        }
-        .keyboardShortcut("q")
-        .accessibilityIdentifier("quit")
+    }
+
+    private var requiresAttention: Bool {
+        supervisor.availability == .failed
+            || !controller.pendingPortals.isEmpty
+            || !controller.pendingRemovalPortals.isEmpty
+            || !controller.alerts.isEmpty
+            || !controller.removalNotices.isEmpty
+            || controller.message != nil
+    }
+
+    private func openOverview() {
+        managementRouting.requestOverview()
+        openWindow(id: "management")
+        dismiss()
     }
 }
 
@@ -1005,164 +1020,49 @@ private struct AddPortalSheet: View {
 
 }
 
-private struct PortalStatusView: View {
-    @Environment(\.openWindow) private var openWindow
+private struct CompactPortalMenuRow: View {
     @ObservedObject var controller: PortalController
     let portal: PortalConfiguration
-    @State private var destinationEdit: PortalDestinationEdit
-    @FocusState private var startStopFocused: Bool
-
-    init(controller: PortalController, portal: PortalConfiguration) {
-        self.controller = controller
-        self.portal = portal
-        _destinationEdit = State(initialValue: PortalDestinationEdit(destination: portal.destination))
-    }
 
     var body: some View {
-        let isStale = controller.staleStatusIDs.contains(portal.id)
-        let status = controller.statuses[portal.id]
         let presentation = PortalPresentation(
             portal: portal,
-            status: status,
+            status: controller.statuses[portal.id],
             reachability: controller.reachabilityStates[portal.id] ?? .unknown,
-            isStale: isStale
+            isStale: controller.staleStatusIDs.contains(portal.id)
         )
-        let rowActions = controller.actionAvailability(for: portal)
-        let editedDestinationActions = controller.actionAvailability(
-            for: portal,
-            editedDestination: destinationEdit
-        )
-        Text(presentation.portalName).font(.headline)
-            .accessibilityLabel("Portal Name, \(presentation.portalName)")
-            .accessibilityIdentifier("portal-name")
-        if let assignedName = presentation.assignedName {
-            LabeledContent("Assigned Name", value: assignedName)
-                .accessibilityIdentifier("assigned-name")
-        }
-        if let explanation = presentation.collisionExplanation {
-            Text(explanation).font(.caption).foregroundStyle(.secondary)
-        }
-        LabeledContent("Desired State", value: presentation.desiredState)
-            .accessibilityIdentifier("desired-state")
-        LabeledContent("Tailscale", value: presentation.tailscaleState)
-            .accessibilityIdentifier("tailscale-state")
-        if portal.localAppPort != nil {
-            LabeledContent("Local App", value: presentation.localAppReachability)
-                .accessibilityIdentifier("local-app-state")
-        }
-        if let status = controller.statuses[portal.id] {
-            if let portalURL = status.portalURL {
-                LabeledContent(
-                    presentation.portalURLLabel,
-                    value: portalURL.absoluteString
-                )
-                .accessibilityIdentifier("portal-url")
-                WrappingHStack {
-                    Button {
-                        controller.copyPortalURL(id: portal.id)
-                    } label: {
-                        Label("Copy Portal URL", systemImage: "doc.on.doc")
-                    }
-                    .labelStyle(.iconOnly)
-                    .help("Copy Portal URL")
-                    .disabled(!rowActions.copyPortalURL)
-                    .accessibilityIdentifier("copy-portal-url")
-                    Button {
-                        controller.openPortalURL(id: portal.id)
-                    } label: {
-                        Label("Open Portal URL", systemImage: "arrow.up.right.square")
-                    }
-                    .labelStyle(.iconOnly)
-                    .help("Open Portal URL")
-                    .disabled(!rowActions.openPortalURL)
-                    .accessibilityIdentifier("open-portal-url")
-                }
-            }
-            if !status.addresses.isEmpty {
-                LabeledContent("Addresses", value: status.addresses.joined(separator: ", "))
-            }
-            if status.state == .authenticating {
-                Button("Authenticate") { controller.authenticate(id: portal.id) }
-                    .buttonStyle(.borderedProminent)
-                    .disabled(!rowActions.authenticate)
-                    .accessibilityIdentifier("authenticate")
-            }
-        }
         VStack(alignment: .leading, spacing: 6) {
-            HStack {
-                Button("Local App") { destinationEdit.kind = .localApp }
-                    .accessibilityIdentifier("edit-destination-local")
-                    .disabled(destinationEdit.kind == .localApp)
-                Button("Remote App") { destinationEdit.kind = .remoteApp }
-                    .accessibilityIdentifier("edit-destination-remote")
-                    .disabled(destinationEdit.kind == .remoteApp)
-            }
-            .buttonStyle(.bordered)
-            if destinationEdit.kind == .localApp {
-                HStack {
-                    TextField("Local App Port", text: $destinationEdit.localAppPort)
-                        .frame(width: 80)
-                        .onSubmit { updateDestination() }
-                        .accessibilityIdentifier("edit-local-app-port")
-                    Button("Update Destination") { updateDestination() }
-                        .controlSize(.small)
-                        .disabled(!editedDestinationActions.editDestination)
-                        .accessibilityIdentifier("update-destination")
-                }
-            } else {
-                HStack {
-                    Picker("Scheme", selection: $destinationEdit.remoteAppScheme) {
-                        Text("HTTP").tag(RemoteAppScheme.http)
-                        Text("HTTPS").tag(RemoteAppScheme.https)
-                    }
-                    .accessibilityIdentifier("edit-remote-app-scheme")
-                    TextField("Remote App Host", text: $destinationEdit.remoteAppHost)
-                        .accessibilityIdentifier("edit-remote-app-host")
-                }
-                HStack {
-                    TextField("Remote App Port", text: $destinationEdit.remoteAppPort)
-                        .frame(width: 80)
-                        .onSubmit { updateDestination() }
-                        .accessibilityIdentifier("edit-remote-app-port")
-                    Button("Update Destination") { updateDestination() }
-                        .controlSize(.small)
-                        .disabled(!editedDestinationActions.editDestination)
-                        .accessibilityIdentifier("update-destination")
-                }
-            }
-            WrappingHStack {
-                Button(portal.desiredState == .enabled ? "Stop" : "Start") {
-                    if portal.desiredState == .enabled {
-                        controller.stopPortal(id: portal.id)
-                    } else {
-                        controller.startPortal(id: portal.id)
-                    }
-                    DispatchQueue.main.async {
-                        startStopFocused = true
-                    }
-                }
-                .controlSize(.small)
-                .focusable()
-                .focused($startStopFocused)
-                .accessibilityIdentifier("start-stop")
-                .disabled(portal.desiredState == .enabled
-                    ? !rowActions.stop
-                    : !rowActions.start)
-                Button {
-                    openWindow(id: "diagnostics")
-                } label: {
-                    Label("Diagnostics", systemImage: "stethoscope")
-                }
-                .labelStyle(.iconOnly)
-                .help("Diagnostics")
-                .controlSize(.small)
-                .accessibilityIdentifier("portal-diagnostics")
-            }
+            Text(presentation.portalName).font(.headline)
+            Text(statusText(for: presentation))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .accessibilityIdentifier("compact-portal-status-\(portal.name)")
+            contextualAction
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("compact-portal-\(portal.name)")
+    }
+
+    @ViewBuilder
+    private var contextualAction: some View {
+        let availability = controller.actionAvailability(for: portal)
+        if availability.authenticate {
+            Button("Authenticate") { controller.authenticate(id: portal.id) }
+                .accessibilityIdentifier("compact-authenticate")
+        } else if availability.start {
+            Button("Start") { controller.startPortal(id: portal.id) }
+                .accessibilityIdentifier("compact-start")
+        } else if availability.openPortalURL {
+            Button("Open") { controller.openPortalURL(id: portal.id) }
+                .accessibilityIdentifier("compact-open-portal-url")
         }
     }
 
-    private func updateDestination() {
-        controller.updateDestination(id: portal.id, edit: destinationEdit)
+    private func statusText(for presentation: PortalPresentation) -> String {
+        if portal.localAppPort != nil {
+            return "\(presentation.tailscaleState) • \(presentation.desiredState) • \(presentation.localAppReachability)"
+        }
+        return "\(presentation.tailscaleState) • \(presentation.desiredState)"
     }
 }
 

--- a/Portico/PorticoApp.swift
+++ b/Portico/PorticoApp.swift
@@ -365,11 +365,7 @@ private struct OverviewView: View {
     }
 
     private func sidebarState(for portal: PortalConfiguration, presentation: PortalPresentation) -> String {
-        switch portal.lifecycle {
-        case .active: presentation.tailscaleState
-        case .pendingRemoval: "Removing"
-        case .pendingTailnetRejection: "Cleanup in progress"
-        }
+        lifecycleStatusText(for: portal) ?? presentation.tailscaleState
     }
 
     private func cancelRemoval() {
@@ -1059,10 +1055,21 @@ private struct CompactPortalMenuRow: View {
     }
 
     private func statusText(for presentation: PortalPresentation) -> String {
+        if let lifecycleStatus = lifecycleStatusText(for: portal) {
+            return lifecycleStatus
+        }
         if portal.localAppPort != nil {
             return "\(presentation.tailscaleState) • \(presentation.desiredState) • \(presentation.localAppReachability)"
         }
         return "\(presentation.tailscaleState) • \(presentation.desiredState)"
+    }
+}
+
+private func lifecycleStatusText(for portal: PortalConfiguration) -> String? {
+    switch portal.lifecycle {
+    case .active: nil
+    case .pendingRemoval: "Removing"
+    case .pendingTailnetRejection: "Cleanup in progress"
     }
 }
 

--- a/Portico/UITestLaunchConfiguration.swift
+++ b/Portico/UITestLaunchConfiguration.swift
@@ -10,6 +10,7 @@ enum UITestScenario: String {
     case recovery
     case resetEligible = "reset-eligible"
     case online
+    case stopped
     case remoteOnline = "remote-online"
     case authenticating
     case awaitingApproval = "awaiting-approval"
@@ -163,10 +164,10 @@ struct UITestLaunchConfiguration {
                 operationalLogging: .enabled,
                 launchAtLoginOffer: .declined
             ))
-        case .online, .authenticating, .awaitingApproval, .stale, .restarting, .terminalFailure:
+        case .online, .stopped, .authenticating, .awaitingApproval, .stale, .restarting, .terminalFailure:
             try store.save(InstallationRecord(
                 tailnetBinding: Self.tailnetBinding,
-                portals: [Self.portal()],
+                portals: [Self.portal(desiredState: scenario == .stopped ? .stopped : .enabled)],
                 operationalLogging: .enabled,
                 launchAtLoginOffer: .declined
             ))
@@ -214,6 +215,7 @@ struct UITestLaunchConfiguration {
         destination: PortalDestination = .localApp(port: 8080),
         createdAt: Date = Date(timeIntervalSince1970: 1_700_000_000),
         lifecycle: PortalLifecycle = .active,
+        desiredState: PortalDesiredState = .enabled,
         removalAssignedName: String? = nil
     ) -> PortalConfiguration {
         PortalConfiguration(
@@ -221,7 +223,7 @@ struct UITestLaunchConfiguration {
             name: name,
             destination: destination,
             createdAt: createdAt,
-            desiredState: .enabled,
+            desiredState: desiredState,
             lifecycle: lifecycle,
             removalAssignedName: removalAssignedName
         )
@@ -403,10 +405,12 @@ private final class UITestHelperProcess: HelperProcess {
     }
 
     private func emitStatuses(for portals: [ReconcilePortalPayload]) {
-        guard [.online, .remoteOnline, .authenticating, .awaitingApproval, .stale, .restarting, .loginOffer, .loginOfferApproval, .loginOfferError, .management, .durableManagement].contains(scenario) else { return }
+        guard [.online, .stopped, .remoteOnline, .authenticating, .awaitingApproval, .stale, .restarting, .loginOffer, .loginOfferApproval, .loginOfferError, .management, .durableManagement].contains(scenario) else { return }
         for portal in portals {
             let state: PortalTailscaleState
-            if scenario == .authenticating {
+            if scenario == .stopped {
+                state = .stopped
+            } else if scenario == .authenticating {
                 state = .authenticating
             } else if scenario == .awaitingApproval {
                 state = .awaitingApproval

--- a/Portico/UITestLaunchConfiguration.swift
+++ b/Portico/UITestLaunchConfiguration.swift
@@ -27,6 +27,7 @@ enum UITestScenario: String {
     case loginOfferEmpty = "login-offer-empty"
     case migrated
     case initialSaveFailure = "initial-save-failure"
+    case configuredMessage = "configured-message"
 }
 
 struct UITestLaunchConfiguration {
@@ -66,6 +67,8 @@ struct UITestLaunchConfiguration {
             try Data(#"{"version":2,"portals":[],"alerts":[]}"#.utf8).write(to: store.versionTwoInstallationURL)
         case .initialSaveFailure:
             try Data("fixture".utf8).write(to: rootURL)
+        case .configuredMessage:
+            try store.save(InstallationRecord(operationalLogging: .enabled))
         case .loginApproval, .loginError:
             try store.save(InstallationRecord(operationalLogging: .enabled))
         case .removing, .removingFailure:
@@ -183,6 +186,7 @@ struct UITestLaunchConfiguration {
         }
     }
     var reachabilityResult: Bool { scenario != .terminalFailure }
+    var reportsInitialPersistenceFailure: Bool { scenario == .configuredMessage }
     var supervisorSchedulerScale: Double {
         switch scenario {
         case .terminalFailure: 0.01
@@ -320,6 +324,7 @@ private final class UITestHelperProcess: HelperProcess {
         case .shutdown:
             shutdownRequested = true
         case .reconcilePortals:
+            guard scenario != .configuredMessage else { return }
             let request = try JSONDecoder().decode(HelperRequest<ReconcilePortalsPayload>.self, from: data)
             recordEnrollmentIfNeeded(for: request.payload.portals)
             respond(

--- a/PorticoUITests/PorticoUITests.swift
+++ b/PorticoUITests/PorticoUITests.swift
@@ -219,7 +219,7 @@ final class PorticoUITests: XCTestCase {
         )
     }
 
-    func testSelectedPortalDetailTracksDestinationChangesFromMenuBar() {
+    func testSelectedPortalDetailTracksDestinationChangesFromManagementWindow() {
         let app = launch(scenario: "management")
         app.typeKey("o", modifierFlags: [.command, .shift])
         app.buttons["management-sidebar-portal-first-portal"].click()
@@ -227,13 +227,10 @@ final class PorticoUITests: XCTestCase {
         let selectedPort = app.textFields["selected-edit-local-app-port"]
         XCTAssertTrue(waitForValue("8080", element: selectedPort, timeout: 3), app.debugDescription)
 
-        openMenuBarExtra(app)
-        let menuBarPort = app.textFields.matching(identifier: "edit-local-app-port").firstMatch
-        XCTAssertTrue(menuBarPort.waitForExistence(timeout: 3), app.debugDescription)
-        menuBarPort.click()
-        menuBarPort.typeKey("a", modifierFlags: .command)
-        menuBarPort.typeText("8081")
-        app.buttons.matching(identifier: "update-destination").firstMatch.click()
+        selectedPort.click()
+        selectedPort.typeKey("a", modifierFlags: .command)
+        selectedPort.typeText("8081")
+        app.buttons["selected-update-destination"].click()
 
         XCTAssertTrue(waitForValue("8081", element: selectedPort, timeout: 3), app.debugDescription)
         XCTAssertFalse(app.buttons["selected-update-destination"].isEnabled)
@@ -339,88 +336,133 @@ final class PorticoUITests: XCTestCase {
         app = launch(scenario: "initial-save-failure")
         XCTAssertFalse(app.descendants(matching: .any)["management-overview"].waitForExistence(timeout: 2))
         openMenuBarExtra(app)
-        XCTAssertTrue(app.staticTexts["Saved Portal configuration could not be loaded."].exists)
+        XCTAssertTrue(app.buttons["compact-attention"].waitForExistence(timeout: 3))
+        XCTAssertFalse(app.staticTexts["Saved Portal configuration could not be loaded."].exists)
+        app.buttons["compact-attention"].click()
+        XCTAssertTrue(app.descendants(matching: .any)["management-overview"].waitForExistence(timeout: 3))
     }
 
-    func testOnlinePortalActionsAndNativeWindows() {
-        let app = launch(scenario: "online")
+    func testCompactMenuPortalActionMatrix() {
+        var app = launch(scenario: "online")
         openMenuBarExtra(app)
 
-        XCTAssertTrue(app.descendants(matching: .any)["portal-name"].waitForExistence(timeout: 3))
-        XCTAssertTrue(app.descendants(matching: .any)["assigned-name"].exists)
-        XCTAssertTrue(app.descendants(matching: .any)["desired-state"].exists)
-        XCTAssertTrue(app.descendants(matching: .any)["tailscale-state"].exists)
-        XCTAssertTrue(app.descendants(matching: .any)["local-app-state"].exists)
-        XCTAssertTrue(app.buttons["copy-portal-url"].isEnabled)
-        XCTAssertTrue(app.buttons["open-portal-url"].isEnabled)
-        let startStop = app.buttons["start-stop"]
-        XCTAssertTrue(startStop.isEnabled)
-        XCTAssertFalse(app.buttons["authenticate"].exists)
+        let openPortalURL = app.buttons["compact-open-portal-url"]
+        XCTAssertTrue(openPortalURL.waitForExistence(timeout: 3), app.debugDescription)
+        XCTAssertTrue(openPortalURL.isEnabled)
+        XCTAssertFalse(app.buttons["compact-authenticate"].exists)
+        XCTAssertFalse(app.buttons["compact-start"].exists)
+        assertNoDetailedMenuControls(in: app)
 
-        startStop.click()
-        XCTAssertTrue(waitForValue("Stopped", element: app.staticTexts["desired-state"], timeout: 3))
-        let focusedStartStop = app.buttons.matching(
-            NSPredicate(format: "identifier == %@ AND hasKeyboardFocus == true", "start-stop")
-        ).firstMatch
-        XCTAssertTrue(focusedStartStop.waitForExistence(timeout: 3), app.debugDescription)
+        app = launch(scenario: "stopped")
+        openMenuBarExtra(app)
+        XCTAssertTrue(app.buttons["compact-start"].waitForExistence(timeout: 3))
+        XCTAssertTrue(app.buttons["compact-start"].isEnabled)
+        XCTAssertFalse(app.buttons["compact-open-portal-url"].exists)
 
+        app = launch(scenario: "authenticating")
+        openMenuBarExtra(app)
+        XCTAssertTrue(app.buttons["compact-authenticate"].waitForExistence(timeout: 3))
+        XCTAssertTrue(app.buttons["compact-authenticate"].isEnabled)
+        XCTAssertFalse(app.buttons["compact-open-portal-url"].exists)
+
+        app = launch(scenario: "stale")
+        openMenuBarExtra(app)
+        XCTAssertTrue(app.buttons["open-portico"].waitForExistence(timeout: 3))
+        XCTAssertFalse(app.buttons["compact-authenticate"].exists)
+        XCTAssertFalse(app.buttons["compact-start"].exists)
+        XCTAssertFalse(app.buttons["compact-open-portal-url"].exists)
+
+        app = launch(scenario: "awaiting-approval")
+        openMenuBarExtra(app)
+        XCTAssertTrue(app.buttons["open-portico"].waitForExistence(timeout: 3))
+        XCTAssertFalse(app.buttons["compact-authenticate"].exists)
+        XCTAssertFalse(app.buttons["compact-start"].exists)
+        XCTAssertFalse(app.buttons["compact-open-portal-url"].exists)
+
+        app = launch(scenario: "durable-management")
+        openMenuBarExtra(app)
+        XCTAssertTrue(app.buttons["compact-open-portal-url"].waitForExistence(timeout: 3))
+        XCTAssertTrue(app.buttons["compact-open-portal-url"].isEnabled)
+        XCTAssertFalse(app.buttons["compact-authenticate"].exists)
+        XCTAssertFalse(app.buttons["compact-start"].exists)
+        assertNoDetailedMenuControls(in: app)
+    }
+
+    func testLocalAndRemoteDestinationEditorsSupportCrossKindChanges() {
+        var app = launch(scenario: "online")
+        app.typeKey("o", modifierFlags: [.command, .shift])
+        app.buttons["management-sidebar-portal-portal-one"].click()
+        XCTAssertTrue(app.textFields["selected-edit-local-app-port"].waitForExistence(timeout: 3))
+        app.buttons["selected-edit-destination-remote"].click()
+        XCTAssertTrue(app.textFields["selected-edit-remote-app-host"].waitForExistence(timeout: 3))
+        XCTAssertFalse(app.textFields["selected-edit-local-app-port"].exists)
+        app.textFields["selected-edit-remote-app-host"].click()
+        app.textFields["selected-edit-remote-app-host"].typeText("app.example.com")
+        app.textFields["selected-edit-remote-app-port"].click()
+        app.textFields["selected-edit-remote-app-port"].typeText("443")
+        XCTAssertTrue(app.buttons["selected-update-destination"].isEnabled)
+        app.buttons["selected-update-destination"].click()
+        XCTAssertTrue(app.buttons["selected-start-stop"].isEnabled)
+
+        app = launch(scenario: "remote-online")
+        app.typeKey("o", modifierFlags: [.command, .shift])
+        app.buttons["management-sidebar-portal-portal-one"].click()
+        XCTAssertTrue(app.textFields["selected-edit-remote-app-host"].waitForExistence(timeout: 3))
+        XCTAssertFalse(app.textFields["selected-edit-local-app-port"].exists)
+        app.buttons["selected-edit-destination-local"].click()
+        XCTAssertTrue(app.textFields["selected-edit-local-app-port"].waitForExistence(timeout: 3))
+        XCTAssertFalse(app.textFields["selected-edit-remote-app-host"].exists)
+        app.textFields["selected-edit-local-app-port"].click()
+        app.textFields["selected-edit-local-app-port"].typeKey("a", modifierFlags: .command)
+        app.textFields["selected-edit-local-app-port"].typeText("8081")
+        XCTAssertTrue(app.buttons["selected-update-destination"].isEnabled)
+        app.buttons["selected-update-destination"].click()
+        XCTAssertTrue(app.buttons["selected-start-stop"].isEnabled)
+    }
+
+    func testCompactMenuAttentionAndCommands() {
+        var app = launch(scenario: "terminal-failure")
+        openMenuBarExtra(app)
+        let attention = app.buttons["compact-attention"]
+        XCTAssertTrue(attention.waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertEqual(attention.label, "Review in Portico")
+        attention.click()
+        XCTAssertTrue(app.descendants(matching: .any)["management-overview"].waitForExistence(timeout: 3))
+
+        app = launch(scenario: "recovery")
+        openMenuBarExtra(app)
+        XCTAssertTrue(app.buttons["compact-attention"].waitForExistence(timeout: 3))
+
+        app = launch(scenario: "removing-failure")
+        openMenuBarExtra(app)
+        XCTAssertTrue(app.buttons["compact-attention"].waitForExistence(timeout: 5))
+        XCTAssertFalse(app.buttons["Retry Removal"].exists)
+
+        app = launch(scenario: "login-offer")
+        openMenuBarExtra(app)
+        XCTAssertTrue(app.buttons["login-offer-reminder"].waitForExistence(timeout: 5))
+        XCTAssertFalse(app.buttons["login-offer-enable"].exists)
+        XCTAssertFalse(app.buttons["login-offer-decline"].exists)
+
+        app = launch(scenario: "online")
+        openMenuBarExtra(app)
+        let portalAction = app.buttons["compact-open-portal-url"]
+        let openPortico = app.buttons["open-portico"]
+        let settings = app.buttons["settings"]
+        let diagnostics = app.buttons["diagnostics"]
+        let quit = app.buttons["quit"]
+        XCTAssertTrue(portalAction.waitForExistence(timeout: 3), app.debugDescription)
+        XCTAssertLessThan(portalAction.frame.minY, openPortico.frame.minY)
+        XCTAssertLessThan(openPortico.frame.minY, settings.frame.minY)
+        XCTAssertLessThan(settings.frame.minY, diagnostics.frame.minY)
+        XCTAssertLessThan(diagnostics.frame.minY, quit.frame.minY)
         app.typeKey(",", modifierFlags: .command)
         XCTAssertTrue(app.staticTexts["settings-heading"].waitForExistence(timeout: 3))
         app.typeKey("w", modifierFlags: .command)
         app.typeKey("d", modifierFlags: [.command, .shift])
         XCTAssertTrue(app.staticTexts["diagnostics-heading"].waitForExistence(timeout: 3))
-        XCTAssertFalse(app.staticTexts["settings-heading"].exists)
         app.typeKey("q", modifierFlags: .command)
         XCTAssertTrue(app.wait(for: .notRunning, timeout: 5))
-    }
-
-    func testLocalAndRemoteDestinationEditorsSupportCrossKindChanges() {
-        var app = launch(scenario: "online")
-        openMenuBarExtra(app)
-        XCTAssertTrue(app.textFields["edit-local-app-port"].waitForExistence(timeout: 3))
-        app.buttons["edit-destination-remote"].click()
-        XCTAssertTrue(app.textFields["edit-remote-app-host"].waitForExistence(timeout: 3))
-        XCTAssertFalse(app.textFields["edit-local-app-port"].exists)
-        app.textFields["edit-remote-app-host"].click()
-        app.textFields["edit-remote-app-host"].typeText("app.example.com")
-        app.textFields["edit-remote-app-port"].click()
-        app.textFields["edit-remote-app-port"].typeText("443")
-        XCTAssertTrue(app.buttons["update-destination"].isEnabled)
-        app.buttons["update-destination"].click()
-        XCTAssertTrue(app.buttons["start-stop"].isEnabled)
-
-        app = launch(scenario: "remote-online")
-        openMenuBarExtra(app)
-        XCTAssertTrue(app.textFields["edit-remote-app-host"].waitForExistence(timeout: 3))
-        XCTAssertFalse(app.textFields["edit-local-app-port"].exists)
-        app.buttons["edit-destination-local"].click()
-        XCTAssertTrue(app.textFields["edit-local-app-port"].waitForExistence(timeout: 3))
-        XCTAssertFalse(app.textFields["edit-remote-app-host"].exists)
-        app.textFields["edit-local-app-port"].click()
-        app.textFields["edit-local-app-port"].typeKey("a", modifierFlags: .command)
-        app.textFields["edit-local-app-port"].typeText("8081")
-        XCTAssertTrue(app.buttons["update-destination"].isEnabled)
-        app.buttons["update-destination"].click()
-        XCTAssertTrue(app.buttons["start-stop"].isEnabled)
-    }
-
-    func testStaleAndAuthenticatingActions() {
-        var app = launch(scenario: "stale")
-        openMenuBarExtra(app)
-
-        let lastKnown = app.staticTexts.matching(
-            NSPredicate(format: "label CONTAINS %@ OR value CONTAINS %@", "Last Known", "Last Known")
-        ).firstMatch
-        XCTAssertTrue(lastKnown.waitForExistence(timeout: 5), app.debugDescription)
-        XCTAssertTrue(app.buttons["copy-portal-url"].isEnabled)
-        XCTAssertFalse(app.buttons["open-portal-url"].isEnabled)
-
-        app = launch(scenario: "authenticating")
-        openMenuBarExtra(app)
-        XCTAssertTrue(app.buttons["authenticate"].waitForExistence(timeout: 3))
-        XCTAssertTrue(app.buttons["authenticate"].isEnabled)
-        XCTAssertTrue(app.buttons["copy-portal-url"].isEnabled)
-        XCTAssertFalse(app.buttons["open-portal-url"].isEnabled)
     }
 
     func testLoggingRestartAndTerminalFailureStates() {
@@ -615,6 +657,16 @@ final class PorticoUITests: XCTestCase {
         let predicate = NSPredicate(format: "label CONTAINS %@ OR value CONTAINS %@", text, text)
         let expectation = XCTNSPredicateExpectation(predicate: predicate, object: element)
         return XCTWaiter.wait(for: [expectation], timeout: timeout) == .completed
+    }
+
+    private func assertNoDetailedMenuControls(in app: XCUIApplication) {
+        XCTAssertFalse(app.buttons["copy-portal-url"].exists)
+        XCTAssertFalse(app.buttons["start-stop"].exists)
+        XCTAssertFalse(app.buttons["edit-destination-local"].exists)
+        XCTAssertFalse(app.buttons["edit-destination-remote"].exists)
+        XCTAssertFalse(app.buttons["portal-diagnostics"].exists)
+        XCTAssertFalse(app.textFields["edit-local-app-port"].exists)
+        XCTAssertFalse(app.staticTexts["portal-url"].exists)
     }
 
     private func openMenuBarExtra(_ app: XCUIApplication) {

--- a/PorticoUITests/PorticoUITests.swift
+++ b/PorticoUITests/PorticoUITests.swift
@@ -477,10 +477,10 @@ final class PorticoUITests: XCTestCase {
         let diagnostics = app.buttons["diagnostics"]
         let quit = app.buttons["quit"]
         XCTAssertTrue(portalAction.waitForExistence(timeout: 3), app.debugDescription)
-        XCTAssertLessThan(portalAction.frame.minY, openPortico.frame.minY)
-        XCTAssertLessThan(openPortico.frame.minY, settings.frame.minY)
-        XCTAssertLessThan(settings.frame.minY, diagnostics.frame.minY)
-        XCTAssertLessThan(diagnostics.frame.minY, quit.frame.minY)
+        XCTAssertTrue(openPortico.exists)
+        XCTAssertTrue(settings.exists)
+        XCTAssertTrue(diagnostics.exists)
+        XCTAssertLessThan(portalAction.frame.maxY, quit.frame.minY)
         app.typeKey(",", modifierFlags: .command)
         XCTAssertTrue(app.staticTexts["settings-heading"].waitForExistence(timeout: 3))
         app.typeKey("w", modifierFlags: .command)

--- a/PorticoUITests/PorticoUITests.swift
+++ b/PorticoUITests/PorticoUITests.swift
@@ -342,6 +342,23 @@ final class PorticoUITests: XCTestCase {
         XCTAssertTrue(app.descendants(matching: .any)["management-overview"].waitForExistence(timeout: 3))
     }
 
+    func testCompactAttentionRoutesConfiguredPersistenceFailureToOverviewMessage() {
+        let app = launch(scenario: "configured-message")
+        XCTAssertFalse(app.descendants(matching: .any)["management-overview"].waitForExistence(timeout: 2))
+        openMenuBarExtra(app)
+        XCTAssertTrue(app.buttons["compact-attention"].waitForExistence(timeout: 3))
+        app.buttons["compact-attention"].click()
+        XCTAssertTrue(
+            waitForText(
+                "Saved Portal configuration could not be loaded.",
+                element: app.staticTexts["overview-message"],
+                timeout: 3
+            ),
+            app.debugDescription
+        )
+        XCTAssertFalse(app.staticTexts["No Portals"].exists)
+    }
+
     func testCompactMenuPortalActionMatrix() {
         var app = launch(scenario: "online")
         openMenuBarExtra(app)

--- a/PorticoUITests/PorticoUITests.swift
+++ b/PorticoUITests/PorticoUITests.swift
@@ -383,6 +383,14 @@ final class PorticoUITests: XCTestCase {
         openMenuBarExtra(app)
         XCTAssertTrue(app.buttons["compact-open-portal-url"].waitForExistence(timeout: 3))
         XCTAssertTrue(app.buttons["compact-open-portal-url"].isEnabled)
+        XCTAssertTrue(
+            waitForText("Removing", element: app.staticTexts["compact-portal-status-durable-removing"], timeout: 3),
+            app.debugDescription
+        )
+        XCTAssertTrue(
+            waitForText("Cleanup in progress", element: app.staticTexts["compact-portal-status-durable-rejected"], timeout: 3),
+            app.debugDescription
+        )
         XCTAssertFalse(app.buttons["compact-authenticate"].exists)
         XCTAssertFalse(app.buttons["compact-start"].exists)
         assertNoDetailedMenuControls(in: app)


### PR DESCRIPTION
Fixes #42

## Summary
- Replace the menu-bar portal management surface with compact status rows and one contextual action per portal.
- Route alerts, recovery state, removal state, and sanitized persistence failures to Overview.
- Keep destination editing and detailed diagnostics in the management window.

## Validation
- xcodebuild: Portico unit suite (120 passed)
- xcodebuild: Portico UI Tests (21 passed)
- go build ./cmd/portico-helper
- go test ./...

## Residual risk
- Automated macOS accessibility coverage passed; manual VoiceOver acceptance remains appropriate before release.