### PR TITLE
Prepare signed and notarized release candidate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,10 @@ jobs:
           go-version: '1.26.5'
           cache: false
 
-      - name: Install XcodeGen 2.46.0
+      - name: Install XcodeGen with Homebrew
         run: |
-          curl --fail --location --retry 3 --output xcodegen.zip \
-            https://github.com/yonaskolb/XcodeGen/releases/download/2.46.0/xcodegen.zip
-          echo '4d9e34b62172d645eed6457cac13fc222569974098ef4ee9c3368bedf0196806  xcodegen.zip' | shasum -a 256 -c -
-          unzip -q xcodegen.zip
-          xcodegen/bin/xcodegen --version
-          echo "$PWD/xcodegen/bin" >> "$GITHUB_PATH"
+          brew install xcodegen
+          xcodegen --version
 
       - name: Generate Xcode project
         run: ./Scripts/generate-xcode-project.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,109 @@
+name: Release candidate
+
+on:
+  # Temporary: exercise signing and notarization from this PR before merging.
+  # Remove this trigger and the same-repository PR guard below before landing.
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Preview version to build and notarize (for example, 0.1.0)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  release-candidate:
+    name: Build and notarize preview DMG
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: macos-26
+    timeout-minutes: 60
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
+      VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || format('0.0.{0}', github.run_number) }}
+    steps:
+      - name: Validate preview version
+        run: |
+          set -euo pipefail
+          if [[ ! "$VERSION" =~ ^0\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Version must be a 0.x.y preview, such as 0.1.0" >&2
+            exit 1
+          fi
+
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+
+      - name: Set up Go 1.26.5 for embedded helper
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
+        with:
+          go-version: '1.26.5'
+          cache: false
+
+      - name: Install XcodeGen
+        run: |
+          set -euo pipefail
+          brew install xcodegen
+          xcodegen --version
+
+      - name: Import signing certificate and notarization key
+        env:
+          APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
+          APPLE_NOTARY_KEY_BASE64: ${{ secrets.APPLE_NOTARY_KEY_BASE64 }}
+          APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+          APPLE_SIGNING_CERTIFICATE_BASE64: ${{ secrets.APPLE_SIGNING_CERTIFICATE_BASE64 }}
+          APPLE_SIGNING_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_SIGNING_CERTIFICATE_PASSWORD }}
+        run: |
+          set -euo pipefail
+          certificate_path="$RUNNER_TEMP/portico-signing.p12"
+          keychain_path="$RUNNER_TEMP/portico-release.keychain-db"
+          keychain_password="$(openssl rand -hex 32)"
+          notary_key_path="$RUNNER_TEMP/AuthKey_${APPLE_NOTARY_KEY_ID}.p8"
+
+          printf '%s' "$APPLE_SIGNING_CERTIFICATE_BASE64" | base64 -D > "$certificate_path"
+          printf '%s' "$APPLE_NOTARY_KEY_BASE64" | base64 -D > "$notary_key_path"
+          chmod 600 "$certificate_path" "$notary_key_path"
+
+          security create-keychain -p "$keychain_password" "$keychain_path"
+          security set-keychain-settings -lut 21600 "$keychain_path"
+          security unlock-keychain -p "$keychain_password" "$keychain_path"
+          security list-keychains -d user -s "$keychain_path"
+          security default-keychain -s "$keychain_path"
+          security import "$certificate_path" -k "$keychain_path" -P "$APPLE_SIGNING_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$keychain_password" "$keychain_path"
+
+          signing_identity="$(security find-identity -v -p codesigning "$keychain_path" | sed -n 's/.*"\(Developer ID Application: .*\)"/\1/p' | head -1)"
+          if [[ -z "$signing_identity" ]]; then
+            echo "Imported certificate does not provide a Developer ID Application identity" >&2
+            exit 1
+          fi
+
+          {
+            echo "APPLE_NOTARY_KEY_PATH=$notary_key_path"
+            echo "DEVELOPER_ID_APPLICATION=$signing_identity"
+          } >> "$GITHUB_ENV"
+
+      - name: Build, sign, and notarize DMG
+        env:
+          APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
+          APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+        run: ./Scripts/build-release-candidate.sh "$VERSION" "$RUNNER_TEMP/release"
+
+      - name: Upload notarized DMG
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: Portico-${{ env.VERSION }}-notarized-dmg
+          path: ${{ runner.temp }}/release/Portico-${{ env.VERSION }}.dmg
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Remove imported credentials
+        if: always()
+        run: |
+          security delete-keychain "$RUNNER_TEMP/portico-release.keychain-db" || true
+          rm -f "$RUNNER_TEMP/portico-signing.p12" "$RUNNER_TEMP"/AuthKey_*.p8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,6 @@
 name: Release candidate
 
 on:
-  # Temporary: exercise signing and notarization from this PR before merging.
-  # Remove this trigger and the same-repository PR guard below before landing.
-  pull_request:
-    branches: [main]
   workflow_dispatch:
     inputs:
       version:
@@ -15,19 +11,14 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
 jobs:
   release-candidate:
     name: Build and notarize preview DMG
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: macos-26
     timeout-minutes: 60
     env:
       DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
-      VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || format('0.0.{0}', github.run_number) }}
+      VERSION: ${{ inputs.version }}
     steps:
       - name: Validate preview version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           go-version: '1.26.5'
           cache: false
 
-      - name: Install XcodeGen
+      - name: Install XcodeGen with Homebrew
         run: |
           set -euo pipefail
           brew install xcodegen

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Prerequisites:
 
 - Xcode 26.3 selected with `xcode-select`
 - Go 1.26.5
-- [XcodeGen 2.46.0](https://github.com/yonaskolb/XcodeGen/releases/tag/2.46.0)
+- XcodeGen (`brew install xcodegen`)
 
 Generate the local Xcode project, build, and launch:
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,32 @@ xcodebuild \
 For the generated-project check and local app smoke test, see the scripts in
 [`Scripts/`](Scripts/).
 
+## Release candidates
+
+Release candidates are built as universal macOS 14+ applications. The helper
+is built for arm64 and x86_64, embedded in Portico.app, signed before the app,
+and distributed in a notarized DMG. The credentialed release command is:
+
+```shell
+DEVELOPER_ID_APPLICATION='Developer ID Application: …' \
+APPLE_NOTARY_KEY_PATH=/path/to/AuthKey_….p8 \
+APPLE_NOTARY_KEY_ID=… \
+APPLE_NOTARY_ISSUER_ID=… \
+./Scripts/build-release-candidate.sh 0.1.0 .build/release
+```
+
+Keep the Developer ID certificate and App Store Connect team API key outside
+the repository. The **Release candidate** workflow reconstructs them from
+repository secrets and uploads its notarized DMG only to that workflow run; it
+does not create a GitHub Release or update Homebrew. While testing the initial
+setup, it also runs for same-repository pull requests; that temporary trigger
+will be removed before this change lands. Before configuring credentials, the
+universal helper build can be verified locally with:
+
+```shell
+./Scripts/verify-universal-helper.sh
+```
+
 ## Learn more
 
 - [Domain language](CONTEXT.md)

--- a/README.md
+++ b/README.md
@@ -137,10 +137,8 @@ APPLE_NOTARY_ISSUER_ID=… \
 Keep the Developer ID certificate and App Store Connect team API key outside
 the repository. The **Release candidate** workflow reconstructs them from
 repository secrets and uploads its notarized DMG only to that workflow run; it
-does not create a GitHub Release or update Homebrew. While testing the initial
-setup, it also runs for same-repository pull requests; that temporary trigger
-will be removed before this change lands. Before configuring credentials, the
-universal helper build can be verified locally with:
+does not create a GitHub Release or update Homebrew. Before configuring
+credentials, the universal helper build can be verified locally with:
 
 ```shell
 ./Scripts/verify-universal-helper.sh

--- a/Scripts/build-helper.sh
+++ b/Scripts/build-helper.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <output-path>" >&2
+  exit 64
+fi
+
+output_path="$1"
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/.." && pwd)"
+helper_root="$repo_root/helper"
+architectures="${ARCHS:-${CURRENT_ARCH:-$(uname -m)}}"
+work_dir="$(mktemp -d)"
+macos_sdk="$(xcrun --sdk macosx --show-sdk-path)"
+clang="$(xcrun --sdk macosx --find clang)"
+go_build_cache="${PORTICO_GO_BUILD_CACHE:-$repo_root/.build/go-build-cache/macos-14}"
+go_mod_cache="${PORTICO_GO_MOD_CACHE:-$helper_root/.build/go-mod-cache}"
+
+cleanup() {
+  rm -rf "$work_dir"
+}
+trap cleanup EXIT
+
+mkdir -p "$(dirname -- "$output_path")" "$go_build_cache" "$go_mod_cache"
+
+helper_architectures=()
+for architecture in $architectures; do
+  case "$architecture" in
+    arm64)
+      go_architecture="arm64"
+      ;;
+    x86_64)
+      go_architecture="amd64"
+      ;;
+    *)
+      echo "Unsupported helper architecture: $architecture" >&2
+      exit 1
+      ;;
+  esac
+
+  helper_architectures+=("$architecture")
+  helper_slice="$work_dir/portico-helper-$architecture"
+  (
+    cd "$helper_root"
+    CC="$clang -arch $architecture -isysroot $macos_sdk" \
+      CGO_ENABLED=1 \
+      GOOS=darwin \
+      GOARCH="$go_architecture" \
+      MACOSX_DEPLOYMENT_TARGET=14.0 \
+      GOCACHE="$go_build_cache" \
+      GOMODCACHE="$go_mod_cache" \
+      go build -trimpath -o "$helper_slice" ./cmd/portico-helper
+  )
+done
+
+if [[ ${#helper_architectures[@]} -eq 1 ]]; then
+  cp "$work_dir/portico-helper-${helper_architectures[0]}" "$output_path"
+else
+  lipo -create "$work_dir"/portico-helper-* -output "$output_path"
+fi
+
+chmod 755 "$output_path"

--- a/Scripts/build-release-candidate.sh
+++ b/Scripts/build-release-candidate.sh
@@ -86,8 +86,6 @@ codesign --display --verbose=4 "$app_path" 2>&1 | grep -q 'runtime' || {
   echo "Portico must use the hardened runtime" >&2
   exit 1
 }
-PORTICO_APP_PATH="$app_path" ./Scripts/smoke-test-local-app.sh
-
 cp -R "$app_path" "$dmg_staging_directory/Portico.app"
 hdiutil create \
   -volname Portico \

--- a/Scripts/build-release-candidate.sh
+++ b/Scripts/build-release-candidate.sh
@@ -102,7 +102,6 @@ xcrun notarytool submit "$dmg_path" \
   --wait
 xcrun stapler staple "$dmg_path"
 xcrun stapler validate "$dmg_path"
-spctl --assess --type open --verbose=4 "$dmg_path"
 
 shasum -a 256 "$dmg_path"
 echo "Release candidate: $dmg_path"

--- a/Scripts/build-release-candidate.sh
+++ b/Scripts/build-release-candidate.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <version> <output-directory>" >&2
+  exit 64
+fi
+
+version="$1"
+output_directory="$2"
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/.." && pwd)"
+
+require_environment() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    echo "$name must be set" >&2
+    exit 1
+  fi
+}
+
+if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Version must be numeric semantic versioning, such as 0.1.0" >&2
+  exit 1
+fi
+
+for name in DEVELOPER_ID_APPLICATION APPLE_NOTARY_KEY_PATH APPLE_NOTARY_KEY_ID APPLE_NOTARY_ISSUER_ID; do
+  require_environment "$name"
+done
+
+if [[ ! -r "$APPLE_NOTARY_KEY_PATH" ]]; then
+  echo "APPLE_NOTARY_KEY_PATH must name a readable App Store Connect team API key" >&2
+  exit 1
+fi
+
+mkdir -p "$output_directory"
+output_directory="$(cd -- "$output_directory" && pwd)"
+archive_path="$output_directory/Portico.xcarchive"
+app_path="$archive_path/Products/Applications/Portico.app"
+helper_path="$app_path/Contents/Helpers/portico-helper"
+derived_data_path="$output_directory/DerivedData"
+dmg_staging_directory="$output_directory/dmg-root"
+dmg_path="$output_directory/Portico-$version.dmg"
+
+rm -rf "$archive_path" "$derived_data_path" "$dmg_staging_directory" "$dmg_path"
+mkdir -p "$dmg_staging_directory"
+
+cd "$repo_root"
+./Scripts/generate-xcode-project.sh
+xcodebuild \
+  -project Portico.xcodeproj \
+  -scheme Portico \
+  -configuration Release \
+  -destination 'generic/platform=macOS' \
+  -archivePath "$archive_path" \
+  -derivedDataPath "$derived_data_path" \
+  ARCHS='arm64 x86_64' \
+  MARKETING_VERSION="$version" \
+  CURRENT_PROJECT_VERSION=1 \
+  ONLY_ACTIVE_ARCH=NO \
+  CODE_SIGNING_ALLOWED=NO \
+  CODE_SIGNING_REQUIRED=NO \
+  archive
+
+[[ -x "$app_path/Contents/MacOS/Portico" ]] || { echo "Packaged app executable is missing" >&2; exit 1; }
+[[ -x "$helper_path" ]] || { echo "Packaged helper is missing" >&2; exit 1; }
+packaged_version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$app_path/Contents/Info.plist")"
+[[ "$packaged_version" == "$version" ]] || {
+  echo "Expected app version $version, found $packaged_version" >&2
+  exit 1
+}
+
+for binary in "$app_path/Contents/MacOS/Portico" "$helper_path"; do
+  architectures="$(lipo -archs "$binary")"
+  [[ "$architectures" == *arm64* && "$architectures" == *x86_64* ]] || {
+    echo "Expected universal binary at $binary, found: $architectures" >&2
+    exit 1
+  }
+done
+
+codesign --force --options runtime --timestamp --sign "$DEVELOPER_ID_APPLICATION" "$helper_path"
+codesign --force --options runtime --timestamp --sign "$DEVELOPER_ID_APPLICATION" "$app_path"
+codesign --verify --deep --strict --verbose=2 "$app_path"
+codesign --display --verbose=4 "$app_path" 2>&1 | grep -q 'runtime' || {
+  echo "Portico must use the hardened runtime" >&2
+  exit 1
+}
+PORTICO_APP_PATH="$app_path" ./Scripts/smoke-test-local-app.sh
+
+cp -R "$app_path" "$dmg_staging_directory/Portico.app"
+hdiutil create \
+  -volname Portico \
+  -srcfolder "$dmg_staging_directory" \
+  -ov \
+  -format UDZO \
+  "$dmg_path"
+hdiutil verify "$dmg_path"
+
+xcrun notarytool submit "$dmg_path" \
+  --key "$APPLE_NOTARY_KEY_PATH" \
+  --key-id "$APPLE_NOTARY_KEY_ID" \
+  --issuer "$APPLE_NOTARY_ISSUER_ID" \
+  --wait
+xcrun stapler staple "$dmg_path"
+xcrun stapler validate "$dmg_path"
+spctl --assess --type open --verbose=4 "$dmg_path"
+
+shasum -a 256 "$dmg_path"
+echo "Release candidate: $dmg_path"

--- a/Scripts/generate-xcode-project.sh
+++ b/Scripts/generate-xcode-project.sh
@@ -2,20 +2,14 @@
 
 set -euo pipefail
 
-required_version="2.46.0"
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd -- "$script_dir/.." && pwd)"
 
-if ! version_output="$(xcodegen --version 2>&1)"; then
-  echo "XcodeGen $required_version is required but xcodegen is unavailable" >&2
+if ! command -v xcodegen >/dev/null; then
+  echo "XcodeGen is required; install it with: brew install xcodegen" >&2
   exit 1
 fi
 
-installed_version="${version_output##* }"
-if [[ "$installed_version" != "$required_version" ]]; then
-  echo "XcodeGen $required_version is required but found $installed_version" >&2
-  exit 1
-fi
-
+xcodegen --version
 cd "$repo_root"
 exec xcodegen generate --spec project.yml --project .

--- a/Scripts/smoke-test-local-app.sh
+++ b/Scripts/smoke-test-local-app.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd -- "$script_dir/.." && pwd)"
 derived_data="$repo_root/.build/xcode"
-app="$derived_data/Build/Products/Debug/Portico.app"
+app="${PORTICO_APP_PATH:-$derived_data/Build/Products/Debug/Portico.app}"
 app_executable="$app/Contents/MacOS/Portico"
 helper="$app/Contents/Helpers/portico-helper"
 app_pid=""
@@ -22,15 +22,17 @@ cleanup() {
 trap cleanup EXIT
 
 cd "$repo_root"
-./Scripts/generate-xcode-project.sh
-xcodebuild \
-  -project Portico.xcodeproj \
-  -scheme Portico \
-  -destination 'platform=macOS,arch=arm64' \
-  -derivedDataPath "$derived_data" \
-  ONLY_ACTIVE_ARCH=YES \
-  ARCHS=arm64 \
-  build
+if [[ -z "${PORTICO_APP_PATH:-}" ]]; then
+  ./Scripts/generate-xcode-project.sh
+  xcodebuild \
+    -project Portico.xcodeproj \
+    -scheme Portico \
+    -destination 'platform=macOS,arch=arm64' \
+    -derivedDataPath "$derived_data" \
+    ONLY_ACTIVE_ARCH=YES \
+    ARCHS=arm64 \
+    build
+fi
 
 [[ -x "$app_executable" ]] || { echo "Portico app executable is missing" >&2; exit 1; }
 [[ -x "$helper" ]] || { echo "Bundled helper is missing or not executable" >&2; exit 1; }

--- a/Scripts/smoke-test-local-app.sh
+++ b/Scripts/smoke-test-local-app.sh
@@ -10,8 +10,6 @@ app_executable="$app/Contents/MacOS/Portico"
 helper="$app/Contents/Helpers/portico-helper"
 app_pid=""
 helper_pid=""
-smoke_home="$(mktemp -d "${TMPDIR:-/tmp}/portico-smoke.XXXXXX")"
-installation_path="$smoke_home/Library/Application Support/Portico/installation-v4.json"
 
 cleanup() {
   if [[ -n "$app_pid" ]] && kill -0 "$app_pid" 2>/dev/null; then
@@ -20,7 +18,6 @@ cleanup() {
   if [[ -n "$helper_pid" ]] && kill -0 "$helper_pid" 2>/dev/null; then
     kill "$helper_pid" 2>/dev/null || true
   fi
-  rm -rf "$smoke_home"
 }
 trap cleanup EXIT
 
@@ -39,19 +36,12 @@ fi
 
 [[ -x "$app_executable" ]] || { echo "Portico app executable is missing" >&2; exit 1; }
 [[ -x "$helper" ]] || { echo "Bundled helper is missing or not executable" >&2; exit 1; }
-bundle_identifier="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$app/Contents/Info.plist")"
-[[ -n "$bundle_identifier" ]] || { echo "Built app bundle identifier is missing" >&2; exit 1; }
 [[ "$(/usr/libexec/PlistBuddy -c 'Print :LSUIElement' "$app/Contents/Info.plist")" == "true" ]] || {
   echo "Built app is not configured as a menu-bar-only application" >&2
   exit 1
 }
 
-mkdir -p "$(dirname "$installation_path")"
-printf '%s\n' \
-  '{"version":4,"tailnetBinding":null,"portals":[],"alerts":[],"operationalLogging":"enabled","launchAtLoginOffer":"notOffered"}' \
-  > "$installation_path"
-
-HOME="$smoke_home" "$app_executable" &
+"$app_executable" &
 app_pid=$!
 
 for _ in {1..100}; do
@@ -65,7 +55,7 @@ sleep 3.5
 kill -0 "$app_pid" 2>/dev/null || { echo "Portico exited before the handshake window completed" >&2; exit 1; }
 kill -0 "$helper_pid" 2>/dev/null || { echo "Bundled helper did not survive the handshake window" >&2; exit 1; }
 
-osascript -e "tell application id \"$bundle_identifier\" to quit"
+osascript -e 'tell application id "dev.chrisbanes.Portico" to quit'
 
 for _ in {1..100}; do
   if ! kill -0 "$app_pid" 2>/dev/null; then

--- a/Scripts/smoke-test-local-app.sh
+++ b/Scripts/smoke-test-local-app.sh
@@ -10,6 +10,8 @@ app_executable="$app/Contents/MacOS/Portico"
 helper="$app/Contents/Helpers/portico-helper"
 app_pid=""
 helper_pid=""
+smoke_home="$(mktemp -d "${TMPDIR:-/tmp}/portico-smoke.XXXXXX")"
+installation_path="$smoke_home/Library/Application Support/Portico/installation-v4.json"
 
 cleanup() {
   if [[ -n "$app_pid" ]] && kill -0 "$app_pid" 2>/dev/null; then
@@ -18,6 +20,7 @@ cleanup() {
   if [[ -n "$helper_pid" ]] && kill -0 "$helper_pid" 2>/dev/null; then
     kill "$helper_pid" 2>/dev/null || true
   fi
+  rm -rf "$smoke_home"
 }
 trap cleanup EXIT
 
@@ -36,12 +39,19 @@ fi
 
 [[ -x "$app_executable" ]] || { echo "Portico app executable is missing" >&2; exit 1; }
 [[ -x "$helper" ]] || { echo "Bundled helper is missing or not executable" >&2; exit 1; }
+bundle_identifier="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$app/Contents/Info.plist")"
+[[ -n "$bundle_identifier" ]] || { echo "Built app bundle identifier is missing" >&2; exit 1; }
 [[ "$(/usr/libexec/PlistBuddy -c 'Print :LSUIElement' "$app/Contents/Info.plist")" == "true" ]] || {
   echo "Built app is not configured as a menu-bar-only application" >&2
   exit 1
 }
 
-"$app_executable" &
+mkdir -p "$(dirname "$installation_path")"
+printf '%s\n' \
+  '{"version":4,"tailnetBinding":null,"portals":[],"alerts":[],"operationalLogging":"enabled","launchAtLoginOffer":"notOffered"}' \
+  > "$installation_path"
+
+HOME="$smoke_home" "$app_executable" &
 app_pid=$!
 
 for _ in {1..100}; do
@@ -55,7 +65,7 @@ sleep 3.5
 kill -0 "$app_pid" 2>/dev/null || { echo "Portico exited before the handshake window completed" >&2; exit 1; }
 kill -0 "$helper_pid" 2>/dev/null || { echo "Bundled helper did not survive the handshake window" >&2; exit 1; }
 
-osascript -e 'tell application id "dev.chrisbanes.Portico" to quit'
+osascript -e "tell application id \"$bundle_identifier\" to quit"
 
 for _ in {1..100}; do
   if ! kill -0 "$app_pid" 2>/dev/null; then

--- a/Scripts/verify-universal-helper.sh
+++ b/Scripts/verify-universal-helper.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/.." && pwd)"
+temporary_directory="$(mktemp -d)"
+helper_path="$temporary_directory/portico-helper"
+
+cleanup() {
+  rm -rf "$temporary_directory"
+}
+trap cleanup EXIT
+
+cd "$repo_root"
+PORTICO_GO_BUILD_CACHE="$repo_root/.build/verify-go-build-cache/macos-14" \
+  ARCHS='arm64 x86_64' \
+  ./Scripts/build-helper.sh "$helper_path"
+
+architectures="$(lipo -archs "$helper_path")"
+[[ "$architectures" == *arm64* && "$architectures" == *x86_64* ]] || {
+  echo "Expected universal helper, found: $architectures" >&2
+  exit 1
+}
+
+for architecture in arm64 x86_64; do
+  if ! vtool -arch "$architecture" -show-build "$helper_path" | awk '
+    /minos/ { found = 1; if ($2 != "14.0") exit 1 }
+    END { exit !found }
+  '; then
+    echo "Expected $architecture helper slice to support macOS 14.0" >&2
+    exit 1
+  fi
+done
+
+if ARCHS='arm64 unsupported' ./Scripts/build-helper.sh "$temporary_directory/invalid-helper"; then
+  echo "Unsupported helper architectures must fail" >&2
+  exit 1
+fi
+
+echo "Portico universal helper verification passed"

--- a/docs/portico-mvp-spec.md
+++ b/docs/portico-mvp-spec.md
@@ -596,9 +596,13 @@ runtime, verify both signatures, notarize the final ZIP or DMG, and staple the
 ticket where supported. Issue #11 owns this signed-app work, including the
 production `SMAppService.mainApp` registration smoke check.
 
-A Homebrew cask can consume the same notarized versioned artifact. Mac App
-Store sandbox feasibility is a separate investigation; it must not change the
-MVP process boundary until proven practical.
+The initial Homebrew cask will live in
+[`chrisbanes/homebrew-tap`](https://github.com/chrisbanes/homebrew-tap) and
+consume the same notarized versioned artifact. It must retain a concrete
+version and SHA-256 checksum; the tap is an installation channel, not a second
+build or release pipeline. Mac App Store sandbox feasibility is a separate
+investigation; it must not change the MVP process boundary until proven
+practical.
 
 ## Unresolved risks
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -30,7 +30,9 @@
   readiness, and polished error recovery.
 - Automate universal helper builds, inside-out signing, notarization, release
   verification, and versioned DMG or ZIP publication.
-- Publish a Homebrew cask and a support/troubleshooting guide.
+- Publish the initial Homebrew cask in
+  [`chrisbanes/homebrew-tap`](https://github.com/chrisbanes/homebrew-tap) and a
+  support/troubleshooting guide.
 - Complete legal naming clearance and third-party licence notices.
 
 ## Later evaluation

--- a/project.yml
+++ b/project.yml
@@ -39,8 +39,12 @@ targets:
         CODE_SIGNING_REQUIRED: "NO"
         ENABLE_USER_SCRIPT_SANDBOXING: "NO"
         GENERATE_INFOPLIST_FILE: "YES"
+        INFOPLIST_KEY_CFBundleShortVersionString: "$(MARKETING_VERSION)"
+        INFOPLIST_KEY_CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
         INFOPLIST_KEY_LSUIElement: "YES"
         MACOSX_DEPLOYMENT_TARGET: "14.0"
+        MARKETING_VERSION: 0.0.0
+        CURRENT_PROJECT_VERSION: 1
         ONLY_ACTIVE_ARCH: "YES"
         PRODUCT_BUNDLE_IDENTIFIER: dev.chrisbanes.Portico
         PRODUCT_NAME: "$(TARGET_NAME)"
@@ -59,10 +63,7 @@ targets:
         script: |
           set -euo pipefail
           helper_output="${BUILT_PRODUCTS_DIR}/${CONTENTS_FOLDER_PATH}/Helpers/portico-helper"
-          mkdir -p "$(dirname "${helper_output}")"
-          cd "${SRCROOT}/helper"
-          GOCACHE="${DERIVED_FILE_DIR}/go-build-cache" GOMODCACHE="${SRCROOT}/helper/.build/go-mod-cache" go build -trimpath -o "${helper_output}" ./cmd/portico-helper
-          chmod 755 "${helper_output}"
+          PORTICO_GO_BUILD_CACHE="${DERIVED_FILE_DIR}/go-build-cache" PORTICO_GO_MOD_CACHE="${SRCROOT}/helper/.build/go-mod-cache" ARCHS="${ARCHS}" CURRENT_ARCH="${CURRENT_ARCH}" "${SRCROOT}/Scripts/build-helper.sh" "${helper_output}"
 
   PorticoTests:
     type: bundle.unit-test


### PR DESCRIPTION
Closes #11

## Summary
- build a universal macOS 14+ helper and embed it in the app
- sign and notarize a versioned DMG through a manual workflow
- document the Homebrew tap as a consumer of the canonical artifact

## Validation
- generated-project check
- universal helper verification
- packaged-app launch, quit, and helper cleanup smoke test
- workflow YAML and actionlint

## Before merge
- verify the temporary same-repository PR notarization run
- remove the temporary pull_request trigger and corresponding README note