### PR TITLE
Build architecture-specific DMGs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,10 @@ concurrency:
 
 jobs:
   publish-release:
-    name: Build and publish release DMG
+    name: Build and publish architecture-specific release DMGs
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: macos-26
-    timeout-minutes: 90
+    timeout-minutes: 180
     environment: public-release
     env:
       DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer

--- a/README.md
+++ b/README.md
@@ -120,21 +120,23 @@ For the generated-project check and local app smoke test, see the scripts in
 
 ## Releases
 
-Each release is a universal macOS 14+ application. The helper is built for
-arm64 and x86_64, embedded in Portico.app, signed before the app, and
-distributed in one notarized DMG. The direct download and Homebrew cask use
-that same DMG; Portico does not check for, download, or install updates itself.
+Each release has two macOS 14+ DMGs: `Portico-<version>-arm64.dmg` for Apple
+Silicon and `Portico-<version>-x86_64.dmg` for Intel Macs. Each DMG contains an
+app and embedded helper built for that architecture, signed, notarized, and
+stapled independently. The direct download provides both DMGs, and the
+Homebrew cask selects the matching one; Portico does not check for, download,
+or install updates itself.
 
 The **Publish release** workflow is the only publishing path. It runs the
 Fastlane `mac release` lane and must be dispatched from `main` manually with a
 `0.x.y` version. It always releases `main`'s current commit. Before it creates a
 public GitHub Release or changes the tap, the workflow runs the Swift and Go
-suites, builds, signs, notarizes, staples, mounts, and verifies the exact DMG.
-It then verifies the uploaded draft asset and audits the generated cask before
+suites, builds, signs, notarizes, staples, mounts, and verifies both DMGs. It
+then verifies the uploaded draft assets and audits the generated cask before
 publishing the normal GitHub Release. It clean-installs the cask before
-committing its version, URL, and SHA-256 to `chrisbanes/homebrew-tap`; a retry
-for the same version and `main` commit resumes a release whose tap update did
-not complete.
+committing its version, architecture-specific URLs, and SHA-256 values to
+`chrisbanes/homebrew-tap`; a retry for the same version and `main` commit
+resumes a release whose asset or tap update did not complete.
 
 Keep these repository secrets outside the repository. The `public-release`
 environment still protects the manual publishing job:
@@ -159,11 +161,11 @@ bundle exec fastlane mac build version:0.1.0
 ```
 
 Keep the Developer ID certificate and App Store Connect team API key outside
-the repository. Before configuring credentials, the universal helper build can
-be verified locally with:
+the repository. Before configuring credentials, the architecture-specific
+helper builds can be verified locally with:
 
 ```shell
-./Scripts/verify-universal-helper.sh
+./Scripts/verify-helper-architectures.sh
 ```
 
 ## Learn more

--- a/Scripts/test-release.py
+++ b/Scripts/test-release.py
@@ -11,12 +11,15 @@ RELEASE = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")
 FASTFILE = (ROOT / "fastlane" / "Fastfile").read_text(encoding="utf-8")
 HOMEBREW_TAP = (ROOT / "fastlane" / "homebrew_tap.rb").read_text(encoding="utf-8")
 SMOKE_TEST = (ROOT / "Scripts" / "smoke-test-local-app.sh").read_text(encoding="utf-8")
+ARTIFACT_VERIFIER = (ROOT / "Scripts" / "verify-release-artifact.sh").read_text(encoding="utf-8")
+HELPER_VERIFIER = (ROOT / "Scripts" / "verify-helper-architectures.sh").read_text(encoding="utf-8")
 
 assert "workflow_dispatch:" in RELEASE
 assert not any(f"  {trigger}:" in RELEASE for trigger in ("pull_request", "push"))
 assert "environment: public-release" in RELEASE
 assert "github.ref == 'refs/heads/main'" in RELEASE
 assert "ref: main" in RELEASE
+assert "timeout-minutes: 180" in RELEASE
 assert "source_commit:" not in RELEASE
 assert "SOURCE_COMMIT" not in RELEASE
 assert "bundle exec fastlane mac release" in RELEASE
@@ -35,6 +38,9 @@ for required in (
     "run_tests(",
     "set_github_release(",
     'script("verify-release-artifact.sh")',
+    'ARCHITECTURES = %w[arm64 x86_64].freeze',
+    '"Portico-#{version}-#{architecture}.dmg"',
+    "architectures: missing_architectures",
 ):
     assert required in FASTFILE, required
 
@@ -49,7 +55,9 @@ positions = [FASTFILE.index(marker, FASTFILE.index('lane :release')) for marker 
 assert positions == sorted(positions)
 
 for required in (
-    "https://github.com/chrisbanes/portico/releases/download/v\\#{version}/Portico-\\#{version}.dmg",
+    'arch arm: "arm64", intel: "x86_64"',
+    "sha256 arm:",
+    "https://github.com/chrisbanes/portico/releases/download/v\\#{version}/Portico-\\#{version}-\\#{arch}.dmg",
     '"brew", "audit", "--cask", "--strict"',
     '"operationalLogging":"disabled"',
     '"push", "origin", "HEAD:main"',
@@ -65,5 +73,9 @@ tap_ordered = (
 tap_positions = [HOMEBREW_TAP.index(marker) for marker in tap_ordered]
 assert tap_positions == sorted(tap_positions)
 assert 'pgrep -P "$app_pid" -x portico-helper' in SMOKE_TEST
+assert "Usage: $0 <version> <architecture> <dmg-path>" in ARTIFACT_VERIFIER
+assert '[[ "$architectures" == "$architecture" ]]' in ARTIFACT_VERIFIER
+assert 'ARCHS="$architecture"' in HELPER_VERIFIER
+assert '[[ "$architectures" == "$architecture" ]]' in HELPER_VERIFIER
 
 print("Portico release contract passed")

--- a/Scripts/verify-helper-architectures.sh
+++ b/Scripts/verify-helper-architectures.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
+# Verifies the helper binaries shipped in the two architecture-specific releases.
+
 set -euo pipefail
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd -- "$script_dir/.." && pwd)"
 temporary_directory="$(mktemp -d)"
-helper_path="$temporary_directory/portico-helper"
 
 cleanup() {
   rm -rf "$temporary_directory"
@@ -13,17 +14,17 @@ cleanup() {
 trap cleanup EXIT
 
 cd "$repo_root"
-PORTICO_GO_BUILD_CACHE="$repo_root/.build/verify-go-build-cache/macos-14" \
-  ARCHS='arm64 x86_64' \
-  ./Scripts/build-helper.sh "$helper_path"
-
-architectures="$(lipo -archs "$helper_path")"
-[[ "$architectures" == *arm64* && "$architectures" == *x86_64* ]] || {
-  echo "Expected universal helper, found: $architectures" >&2
-  exit 1
-}
-
 for architecture in arm64 x86_64; do
+  helper_path="$temporary_directory/portico-helper-$architecture"
+  PORTICO_GO_BUILD_CACHE="$repo_root/.build/verify-go-build-cache/macos-14" \
+    ARCHS="$architecture" \
+    ./Scripts/build-helper.sh "$helper_path"
+
+  architectures="$(lipo -archs "$helper_path")"
+  [[ "$architectures" == "$architecture" ]] || {
+    echo "Expected $architecture helper, found: $architectures" >&2
+    exit 1
+  }
   if ! vtool -arch "$architecture" -show-build "$helper_path" | awk '
     /minos/ { found = 1; if ($2 != "14.0") exit 1 }
     END { exit !found }
@@ -38,4 +39,4 @@ if ARCHS='arm64 unsupported' ./Scripts/build-helper.sh "$temporary_directory/inv
   exit 1
 fi
 
-echo "Portico universal helper verification passed"
+echo "Portico architecture-specific helper verification passed"

--- a/Scripts/verify-release-artifact.sh
+++ b/Scripts/verify-release-artifact.sh
@@ -2,13 +2,14 @@
 
 set -euo pipefail
 
-if [[ $# -ne 2 ]]; then
-  echo "Usage: $0 <version> <dmg-path>" >&2
+if [[ $# -ne 3 ]]; then
+  echo "Usage: $0 <version> <architecture> <dmg-path>" >&2
   exit 64
 fi
 
 version="$1"
-dmg_path="$2"
+architecture="$2"
+dmg_path="$3"
 mounted_volume=""
 
 cleanup() {
@@ -22,6 +23,10 @@ if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   echo "Version must be numeric semantic versioning, such as 0.1.0" >&2
   exit 1
 fi
+case "$architecture" in
+  arm64|x86_64) ;;
+  *) echo "Unsupported architecture: $architecture" >&2; exit 1 ;;
+esac
 [[ -f "$dmg_path" ]] || { echo "DMG is missing: $dmg_path" >&2; exit 1; }
 
 hdiutil verify "$dmg_path"
@@ -47,8 +52,8 @@ packaged_version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionStrin
 
 for binary in "$app_executable" "$helper_path"; do
   architectures="$(lipo -archs "$binary")"
-  [[ "$architectures" == *arm64* && "$architectures" == *x86_64* ]] || {
-    echo "Expected universal binary at $binary, found: $architectures" >&2
+  [[ "$architectures" == "$architecture" ]] || {
+    echo "Expected $architecture binary at $binary, found: $architectures" >&2
     exit 1
   }
   codesign --verify --strict --verbose=2 "$binary"

--- a/docs/adr/0004-ship-a-direct-download-first.md
+++ b/docs/adr/0004-ship-a-direct-download-first.md
@@ -1,6 +1,6 @@
 # Ship a direct-download macOS app first
 
-The first release targets macOS 14 and later as a universal, hardened,
-signed, and notarized direct-download app. Mac App Store sandbox feasibility
-will be assessed separately so sandbox and review constraints do not distort
-the tsnet lifecycle spike or MVP architecture.
+The first release targets macOS 14 and later as separate arm64 and x86_64,
+hardened, signed, and notarized direct-download apps. Mac App Store sandbox
+feasibility will be assessed separately so sandbox and review constraints do
+not distort the tsnet lifecycle spike or MVP architecture.

--- a/docs/portico-mvp-spec.md
+++ b/docs/portico-mvp-spec.md
@@ -538,7 +538,7 @@ registers a login item, or opens an external URL.
 
 ### Packaging
 
-- arm64 and x86_64 helper slices combine into a universal binary;
+- arm64 and x86_64 builds each embed a helper with the matching architecture;
 - helper and app signatures verify strictly with the hardened runtime;
 - the helper is present at the expected bundle path; and
 - a packaged app starts and shuts down without leaving a helper process.
@@ -589,20 +589,20 @@ stable test identities.
 
 ## Distribution
 
-The first supported artifact is a macOS 14+ universal app distributed outside
-the Mac App Store. Build arm64 and x86_64 helper binaries, combine them,
-embed and sign the helper before signing the outer app, enable the hardened
-runtime, verify both signatures, notarize the final ZIP or DMG, and staple the
-ticket where supported. Issue #11 owns this signed-app work, including the
-production `SMAppService.mainApp` registration smoke check.
+The first supported artifacts are macOS 14+ arm64 and x86_64 apps distributed
+outside the Mac App Store in separate DMGs. Build each helper for its matching
+app architecture, embed and sign the helper before signing the outer app,
+enable the hardened runtime, verify both signatures, notarize each DMG, and
+staple its ticket where supported. Issue #11 owns this signed-app work,
+including the production `SMAppService.mainApp` registration smoke check.
 
 The initial Homebrew cask will live in
 [`chrisbanes/homebrew-tap`](https://github.com/chrisbanes/homebrew-tap) and
-consume the same notarized versioned artifact. It must retain a concrete
-version and SHA-256 checksum; the tap is an installation channel, not a second
-build or release pipeline. Mac App Store sandbox feasibility is a separate
-investigation; it must not change the MVP process boundary until proven
-practical.
+consume the matching notarized versioned artifact. It must retain a concrete
+version, architecture-specific URL, and SHA-256 checksum; the tap is an
+installation channel, not a second build or release pipeline. Mac App Store
+sandbox feasibility is a separate investigation; it must not change the MVP
+process boundary until proven practical.
 
 ## Unresolved risks
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -28,8 +28,8 @@
   validation.
 - Complete accessibility, keyboard navigation, VoiceOver, localization
   readiness, and polished error recovery.
-- Automate universal helper builds, inside-out signing, notarization, release
-  verification, and versioned DMG or ZIP publication.
+- Automate architecture-specific helper builds, inside-out signing,
+  notarization, release verification, and versioned DMG or ZIP publication.
 - Publish the initial Homebrew cask in
   [`chrisbanes/homebrew-tap`](https://github.com/chrisbanes/homebrew-tap) and a
   support/troubleshooting guide.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -8,6 +8,7 @@ opt_out_usage
 REPOSITORY = "chrisbanes/portico"
 ROOT = File.expand_path("..", __dir__)
 PROJECT = File.join(ROOT, "Portico.xcodeproj")
+ARCHITECTURES = %w[arm64 x86_64].freeze
 ENV["HOMEBREW_NO_AUTO_UPDATE"] ||= "1"
 
 def script(name)
@@ -22,6 +23,65 @@ end
 
 def validate_version(version)
   UI.user_error!("Version must be a 0.x.y release, such as 0.1.0") unless version.match?(/\A0\.(0|[1-9]\d*)\.(0|[1-9]\d*)\z/)
+end
+
+def validate_architectures(architectures)
+  requested = Array(architectures).map(&:to_s).uniq
+  UI.user_error!("Build at least one supported architecture: #{ARCHITECTURES.join(", ")}") if requested.empty? || (requested - ARCHITECTURES).any?
+  requested
+end
+
+def release_asset_name(version, architecture)
+  "Portico-#{version}-#{architecture}.dmg"
+end
+
+def build_release_dmg(version:, architecture:, output_directory:, signing_identity:, api_key:)
+  architecture_output_directory = File.join(output_directory, architecture)
+  archive_path = File.join(architecture_output_directory, "Portico.xcarchive")
+  app_path = File.join(archive_path, "Products/Applications/Portico.app")
+  app_executable = File.join(app_path, "Contents/MacOS/Portico")
+  helper_path = File.join(app_path, "Contents/Helpers/portico-helper")
+  derived_data_path = File.join(architecture_output_directory, "DerivedData")
+  staging_directory = File.join(architecture_output_directory, "dmg-root")
+  dmg_path = File.join(output_directory, release_asset_name(version, architecture))
+
+  FileUtils.rm_rf([archive_path, derived_data_path, staging_directory])
+  FileUtils.rm_f(dmg_path)
+  FileUtils.mkdir_p(staging_directory)
+
+  build_mac_app(
+    project: PROJECT,
+    scheme: "Portico",
+    configuration: "Release",
+    destination: "generic/platform=macOS",
+    archive_path: archive_path,
+    derived_data_path: derived_data_path,
+    output_directory: File.join(architecture_output_directory, "gym-output"),
+    skip_codesigning: true,
+    skip_package_pkg: true,
+    xcargs: "ARCHS=#{architecture} MARKETING_VERSION=#{version} CURRENT_PROJECT_VERSION=1 ONLY_ACTIVE_ARCH=NO"
+  )
+
+  UI.user_error!("Packaged app executable is missing") unless File.executable?(app_executable)
+  UI.user_error!("Packaged helper is missing") unless File.executable?(helper_path)
+  packaged_version = sh("/usr/libexec/PlistBuddy", "-c", "Print :CFBundleShortVersionString", File.join(app_path, "Contents/Info.plist")).strip
+  UI.user_error!("Expected app version #{version}, found #{packaged_version}") unless packaged_version == version
+
+  [app_executable, helper_path].each do |binary|
+    binary_architecture = sh("lipo", "-archs", binary).strip
+    UI.user_error!("Expected #{architecture} binary at #{binary}, found: #{binary_architecture}") unless binary_architecture == architecture
+  end
+
+  sh("codesign", "--force", "--options", "runtime", "--timestamp", "--sign", signing_identity, helper_path)
+  sh("codesign", "--force", "--options", "runtime", "--timestamp", "--sign", signing_identity, app_path)
+  sh("codesign", "--verify", "--deep", "--strict", "--verbose=2", app_path)
+
+  FileUtils.cp_r(app_path, File.join(staging_directory, "Portico.app"))
+  sh("hdiutil", "create", "-volname", "Portico", "-srcfolder", staging_directory, "-ov", "-format", "UDZO", dmg_path)
+  sh("hdiutil", "verify", dmg_path)
+  notarize(package: dmg_path, bundle_id: "dev.chrisbanes.Portico", api_key: api_key, print_log: true)
+  sh(script("verify-release-artifact.sh"), version, architecture, dmg_path)
+  dmg_path
 end
 
 platform :mac do
@@ -43,7 +103,7 @@ platform :mac do
     end
   end
 
-  desc "Build, sign, notarize, and verify a release DMG"
+  desc "Build, sign, notarize, and verify architecture-specific release DMGs"
   lane :build do |options|
     version = options[:version] || ENV["VERSION"]
     UI.user_error!("Pass version:<0.x.y> or set VERSION") if version.nil?
@@ -57,50 +117,7 @@ platform :mac do
     signing_identity = identity_output[/"(Developer ID Application: [^"]+)"/, 1]
     UI.user_error!("No Developer ID Application signing identity is available") if signing_identity.nil?
 
-    FileUtils.mkdir_p(output_directory)
-    archive_path = File.join(output_directory, "Portico.xcarchive")
-    app_path = File.join(archive_path, "Products/Applications/Portico.app")
-    app_executable = File.join(app_path, "Contents/MacOS/Portico")
-    helper_path = File.join(app_path, "Contents/Helpers/portico-helper")
-    derived_data_path = File.join(output_directory, "DerivedData")
-    staging_directory = File.join(output_directory, "dmg-root")
-    dmg_path = File.join(output_directory, "Portico-#{version}.dmg")
-
-    FileUtils.rm_rf([archive_path, derived_data_path, staging_directory])
-    FileUtils.rm_f(dmg_path)
-    FileUtils.mkdir_p(staging_directory)
-
     sh(script("generate-xcode-project.sh"))
-    build_mac_app(
-      project: PROJECT,
-      scheme: "Portico",
-      configuration: "Release",
-      destination: "generic/platform=macOS",
-      archive_path: archive_path,
-      derived_data_path: derived_data_path,
-      output_directory: File.join(output_directory, "gym-output"),
-      skip_codesigning: true,
-      skip_package_pkg: true,
-      xcargs: "ARCHS='arm64 x86_64' MARKETING_VERSION=#{version} CURRENT_PROJECT_VERSION=1 ONLY_ACTIVE_ARCH=NO"
-    )
-
-    UI.user_error!("Packaged app executable is missing") unless File.executable?(app_executable)
-    UI.user_error!("Packaged helper is missing") unless File.executable?(helper_path)
-    packaged_version = sh("/usr/libexec/PlistBuddy", "-c", "Print :CFBundleShortVersionString", File.join(app_path, "Contents/Info.plist")).strip
-    UI.user_error!("Expected app version #{version}, found #{packaged_version}") unless packaged_version == version
-
-    [app_executable, helper_path].each do |binary|
-      architectures = sh("lipo", "-archs", binary)
-      UI.user_error!("Expected universal binary at #{binary}, found: #{architectures.strip}") unless architectures.include?("arm64") && architectures.include?("x86_64")
-    end
-
-    sh("codesign", "--force", "--options", "runtime", "--timestamp", "--sign", signing_identity, helper_path)
-    sh("codesign", "--force", "--options", "runtime", "--timestamp", "--sign", signing_identity, app_path)
-    sh("codesign", "--verify", "--deep", "--strict", "--verbose=2", app_path)
-
-    FileUtils.cp_r(app_path, File.join(staging_directory, "Portico.app"))
-    sh("hdiutil", "create", "-volname", "Portico", "-srcfolder", staging_directory, "-ov", "-format", "UDZO", dmg_path)
-    sh("hdiutil", "verify", dmg_path)
 
     api_key = app_store_connect_api_key(
       key_id: key_id,
@@ -109,9 +126,19 @@ platform :mac do
       is_key_content_base64: true,
       set_spaceship_token: false
     )
-    notarize(package: dmg_path, bundle_id: "dev.chrisbanes.Portico", api_key: api_key, print_log: true)
-    sh(script("verify-release-artifact.sh"), version, dmg_path)
-    dmg_path
+    FileUtils.mkdir_p(output_directory)
+    validate_architectures(options[:architectures] || ARCHITECTURES).to_h do |architecture|
+      [
+        architecture,
+        build_release_dmg(
+          version: version,
+          architecture: architecture,
+          output_directory: output_directory,
+          signing_identity: signing_identity,
+          api_key: api_key
+        )
+      ]
+    end
   end
 
   desc "Publish a GitHub release and its Homebrew cask"
@@ -124,7 +151,7 @@ platform :mac do
     github_token = require_environment("GH_TOKEN")
     tap_token = require_environment("HOMEBREW_TAP_TOKEN")
     tag = "v#{version}"
-    asset_name = "Portico-#{version}.dmg"
+    asset_names = ARCHITECTURES.to_h { |architecture| [architecture, release_asset_name(version, architecture)] }
     output_directory = File.join(require_environment("RUNNER_TEMP"), "release")
     download_directory = File.join(require_environment("RUNNER_TEMP"), "release-download")
 
@@ -145,13 +172,15 @@ platform :mac do
       UI.user_error!("Release tag exists without a GitHub Release and cannot be resumed safely: #{tag}") if tag_response[:status] == 200
     end
 
-    has_asset = !release.nil? && release.fetch("assets", []).any? { |asset| asset["name"] == asset_name }
-    dmg_path = if has_asset
-                 FileUtils.mkdir_p(output_directory)
-                 File.join(output_directory, asset_name)
-               else
-                 build(version: version, output_directory: output_directory)
-               end
+    existing_asset_names = release.nil? ? [] : release.fetch("assets", []).map { |asset| asset.fetch("name") }
+    missing_architectures = asset_names.filter_map do |architecture, asset_name|
+      architecture unless existing_asset_names.include?(asset_name)
+    end
+    built_dmgs = if missing_architectures.empty?
+                   {}
+                 else
+                   build(version: version, output_directory: output_directory, architectures: missing_architectures)
+                 end
 
     if release.nil?
       release = set_github_release(
@@ -164,25 +193,26 @@ platform :mac do
         is_draft: true
       )
     end
-    sh("gh", "release", "upload", tag, dmg_path, "--repo", REPOSITORY) unless has_asset
+    built_dmgs.each_value do |dmg_path|
+      sh("gh", "release", "upload", tag, dmg_path, "--repo", REPOSITORY)
+    end
 
     FileUtils.rm_rf(download_directory)
     FileUtils.mkdir_p(download_directory)
-    sh("gh", "release", "download", tag, "--repo", REPOSITORY, "--pattern", asset_name, "--dir", download_directory)
-    downloaded_dmg = File.join(download_directory, asset_name)
-    if has_asset
-      FileUtils.cp(downloaded_dmg, dmg_path)
-    else
-      sh("cmp", "--silent", dmg_path, downloaded_dmg)
+    downloaded_dmgs = asset_names.to_h do |architecture, asset_name|
+      sh("gh", "release", "download", tag, "--repo", REPOSITORY, "--pattern", asset_name, "--dir", download_directory)
+      downloaded_dmg = File.join(download_directory, asset_name)
+      built_dmg = built_dmgs[architecture]
+      sh("cmp", "--silent", built_dmg, downloaded_dmg) unless built_dmg.nil?
+      sh(script("verify-release-artifact.sh"), version, architecture, downloaded_dmg)
+      [architecture, downloaded_dmg]
     end
-    sh(script("verify-release-artifact.sh"), version, dmg_path)
-
-    checksum = Digest::SHA256.file(dmg_path).hexdigest
+    checksums = downloaded_dmgs.transform_values { |dmg_path| Digest::SHA256.file(dmg_path).hexdigest }
     begin
       app_directory = File.join(require_environment("RUNNER_TEMP"), "Applications")
       update_homebrew_tap(
         version: version,
-        checksum: checksum,
+        checksums: checksums,
         tap_token: tap_token,
         app_directory: app_directory
       ) do

--- a/fastlane/homebrew_tap.rb
+++ b/fastlane/homebrew_tap.rb
@@ -3,8 +3,11 @@ require "fileutils"
 HOMEBREW_TAP = "chrisbanes/tap"
 PORTICO_ROOT = File.expand_path("..", __dir__)
 
-def update_homebrew_tap(version:, checksum:, tap_token:, app_directory:, &publish_release)
+def update_homebrew_tap(version:, checksums:, tap_token:, app_directory:, &publish_release)
   UI.user_error!("Homebrew tap update requires a release publication block") if publish_release.nil?
+
+  arm64_checksum = checksums.fetch("arm64")
+  x86_64_checksum = checksums.fetch("x86_64")
 
   installed = false
   state_root = File.expand_path("~/Library/Application Support/Portico")
@@ -14,10 +17,13 @@ def update_homebrew_tap(version:, checksum:, tap_token:, app_directory:, &publis
   FileUtils.mkdir_p(File.dirname(cask_path))
   File.write(cask_path, <<~CASK)
     cask "portico" do
-      version "#{version}"
-      sha256 "#{checksum}"
+      arch arm: "arm64", intel: "x86_64"
 
-      url "https://github.com/chrisbanes/portico/releases/download/v\#{version}/Portico-\#{version}.dmg"
+      version "#{version}"
+      sha256 arm:   "#{arm64_checksum}",
+             intel: "#{x86_64_checksum}"
+
+      url "https://github.com/chrisbanes/portico/releases/download/v\#{version}/Portico-\#{version}-\#{arch}.dmg"
       name "Portico"
       desc "Make a web service on your Mac reachable on your tailnet"
       homepage "https://github.com/chrisbanes/portico"


### PR DESCRIPTION
## Summary

- Publish separate signed and notarized Apple Silicon and Intel DMGs.
- Verify that each packaged app and helper contains only its intended architecture.
- Generate a Homebrew cask that selects the matching artifact and checksum.

## Why

Universal DMGs are no longer the shipping format, so each release needs an architecture-specific artifact throughout build, verification, publication, and installation.

## Validation

- `python3 Scripts/test-release.py`
- `ruby -c fastlane/Fastfile`
- `ruby -c fastlane/homebrew_tap.rb`
- `bash -n Scripts/verify-release-artifact.sh Scripts/verify-helper-architectures.sh`
- `./Scripts/verify-helper-architectures.sh`
- `bundle exec fastlane lanes`