### PR TITLE
Clarify Portal authentication setup

### DIFF
--- a/Portico/PorticoApp.swift
+++ b/Portico/PorticoApp.swift
@@ -375,6 +375,14 @@ private struct OverviewView: View {
                 removalFocusRequestID: removalCancelFocusPortalID == portal.id
                     ? portal.id
                     : nil,
+                onFocusRestored: { id in
+                    if authenticationFocusPortalID == id {
+                        authenticationFocusPortalID = nil
+                    }
+                    if removalCancelFocusPortalID == id {
+                        removalCancelFocusPortalID = nil
+                    }
+                },
                 onRemove: {
                     removalCancelFocusPortalID = nil
                     removalCandidate = portal
@@ -447,6 +455,7 @@ private struct SelectedPortalView: View {
     let portal: PortalConfiguration
     let authenticationFocusRequestID: UUID?
     let removalFocusRequestID: UUID?
+    let onFocusRestored: (UUID) -> Void
     let onRemove: () -> Void
     @State private var destinationEdit: PortalDestinationEdit
 
@@ -455,12 +464,14 @@ private struct SelectedPortalView: View {
         portal: PortalConfiguration,
         authenticationFocusRequestID: UUID?,
         removalFocusRequestID: UUID?,
+        onFocusRestored: @escaping (UUID) -> Void,
         onRemove: @escaping () -> Void
     ) {
         self.controller = controller
         self.portal = portal
         self.authenticationFocusRequestID = authenticationFocusRequestID
         self.removalFocusRequestID = removalFocusRequestID
+        self.onFocusRestored = onFocusRestored
         self.onRemove = onRemove
         _destinationEdit = State(initialValue: PortalDestinationEdit(destination: portal.destination))
     }
@@ -583,7 +594,8 @@ private struct SelectedPortalView: View {
                             title: "Authenticate",
                             isEnabled: portalActions.authenticate,
                             isProminent: true,
-                            focusRequestID: authenticationFocusRequestID
+                            focusRequestID: authenticationFocusRequestID,
+                            onFocusRestored: onFocusRestored
                         ) {
                             controller.authenticate(id: portal.id)
                         }
@@ -613,6 +625,7 @@ private struct SelectedPortalView: View {
                         isEnabled: portalActions.remove,
                         isDestructive: true,
                         focusRequestID: removalFocusRequestID,
+                        onFocusRestored: onFocusRestored,
                         action: onRemove
                     )
                         .accessibilityIdentifier("selected-remove-portal")
@@ -775,10 +788,15 @@ private struct FocusRestoringButton: NSViewRepresentable {
     var isDestructive = false
     var isProminent = false
     var focusRequestID: UUID?
+    var onFocusRestored: ((UUID) -> Void)?
     let action: () -> Void
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(action: action, focusRequestID: focusRequestID)
+        Coordinator(
+            action: action,
+            focusRequestID: focusRequestID,
+            onFocusRestored: onFocusRestored
+        )
     }
 
     func makeNSView(context: Context) -> NSButton {
@@ -795,6 +813,7 @@ private struct FocusRestoringButton: NSViewRepresentable {
     func updateNSView(_ button: NSButton, context: Context) {
         let titleChanged = button.title != title
         context.coordinator.action = action
+        context.coordinator.onFocusRestored = onFocusRestored
         button.title = title
         button.isEnabled = isEnabled
         button.contentTintColor = isDestructive ? .systemRed : nil
@@ -812,11 +831,17 @@ private struct FocusRestoringButton: NSViewRepresentable {
     final class Coordinator: NSObject {
         var action: () -> Void
         var focusRequestID: UUID?
+        var onFocusRestored: ((UUID) -> Void)?
         private var sheetObserver: NSObjectProtocol?
 
-        init(action: @escaping () -> Void, focusRequestID: UUID?) {
+        init(
+            action: @escaping () -> Void,
+            focusRequestID: UUID?,
+            onFocusRestored: ((UUID) -> Void)?
+        ) {
             self.action = action
             self.focusRequestID = focusRequestID
+            self.onFocusRestored = onFocusRestored
         }
 
         deinit {
@@ -824,12 +849,12 @@ private struct FocusRestoringButton: NSViewRepresentable {
         }
 
         func restoreFocus(afterSheetDismissal button: NSButton) {
+            let requestedFocusID = focusRequestID
             DispatchQueue.main.async { [weak self, weak button] in
                 guard let self, let button, let window = button.window else { return }
                 self.removeSheetObserver()
                 guard window.attachedSheet != nil else {
-                    button.scrollToVisible(button.bounds)
-                    window.makeFirstResponder(button)
+                    self.focus(button, in: window, for: requestedFocusID)
                     return
                 }
                 self.sheetObserver = NotificationCenter.default.addObserver(
@@ -837,11 +862,19 @@ private struct FocusRestoringButton: NSViewRepresentable {
                     object: window,
                     queue: .main
                 ) { [weak self, weak button, weak window] _ in
-                    self?.removeSheetObserver()
-                    guard let button, let window else { return }
-                    button.scrollToVisible(button.bounds)
-                    window.makeFirstResponder(button)
+                    guard let self, let button, let window else { return }
+                    self.removeSheetObserver()
+                    self.focus(button, in: window, for: requestedFocusID)
                 }
+            }
+        }
+
+        private func focus(_ button: NSButton, in window: NSWindow, for focusRequestID: UUID?) {
+            guard focusRequestID == nil || self.focusRequestID == focusRequestID else { return }
+            button.scrollToVisible(button.bounds)
+            window.makeFirstResponder(button)
+            if let focusRequestID {
+                onFocusRestored?(focusRequestID)
             }
         }
 

--- a/Portico/PorticoApp.swift
+++ b/Portico/PorticoApp.swift
@@ -180,7 +180,10 @@ private struct OverviewView: View {
                         controller.discardPortalDraft()
                         showingAddPortal = false
                     },
-                    dismissAfterPersistence: { showingAddPortal = false }
+                    didPersistPortal: { portal in
+                        selection = .portal(portal.id)
+                        showingAddPortal = false
+                    }
                 )
             }
             .onChange(of: controller.portals) { _, portals in
@@ -270,14 +273,15 @@ private struct OverviewView: View {
                   !hasRecoveryContent {
             VStack(spacing: 16) {
                 ContentUnavailableView {
-                    Label("No Portals", systemImage: "door.left.hand.open")
+                    Label("Connect Your Tailnet", systemImage: "door.left.hand.open")
                 } description: {
-                    Text("Add a Portal to give a Local App a private tailnet doorway.")
+                    Text("Create your first Portal. Next, you’ll sign in with Tailscale in your browser.")
+                        .accessibilityIdentifier("overview-first-portal-authentication-guidance")
                 }
                 if launchAtLogin.isOffering {
                     launchAtLoginOffer
                 }
-                Button("Add Portal") { showingAddPortal = true }
+                Button("Create Your First Portal") { showingAddPortal = true }
                     .buttonStyle(.borderedProminent)
                     .accessibilityIdentifier("overview-empty-add-portal")
             }
@@ -557,6 +561,14 @@ private struct SelectedPortalView: View {
                 }
             }
             Section("Actions") {
+                if status?.state == .authenticating {
+                    Label("Next, sign in with Tailscale in your browser.", systemImage: "key.fill")
+                        .font(.headline)
+                        .padding(8)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(.tint.opacity(0.12), in: RoundedRectangle(cornerRadius: 8))
+                        .accessibilityIdentifier("selected-authentication-guidance")
+                }
                 WrappingHStack {
                     if status?.state == .authenticating {
                         Button("Authenticate") { controller.authenticate(id: portal.id) }
@@ -966,7 +978,7 @@ private struct AddPortalSheet: View {
 
     @ObservedObject var controller: PortalController
     let cancel: () -> Void
-    let dismissAfterPersistence: () -> Void
+    let didPersistPortal: (PortalConfiguration) -> Void
     @FocusState private var inputFocus: FocusTarget?
     @AccessibilityFocusState private var accessibilityFocus: FocusTarget?
     @State private var step = Step.destination
@@ -1149,8 +1161,8 @@ private struct AddPortalSheet: View {
         case .validationError(.invalidRemoteHost):
             inputFocus = .remoteAppHost
             accessibilityFocus = .remoteAppHost
-        case .persisted:
-            dismissAfterPersistence()
+        case let .persisted(portal):
+            didPersistPortal(portal)
         case .persistenceFailure, nil:
             break
         }

--- a/Portico/PorticoApp.swift
+++ b/Portico/PorticoApp.swift
@@ -114,6 +114,7 @@ private struct OverviewView: View {
     @State private var removalCandidate: PortalConfiguration?
     @State private var removalCompletionFocusID: UUID?
     @State private var removalCancelFocusPortalID: UUID?
+    @State private var authenticationFocusPortalID: UUID?
     @AccessibilityFocusState private var accessibilityFocus: AccessibilityFocusTarget?
 
     var body: some View {
@@ -182,6 +183,7 @@ private struct OverviewView: View {
                     },
                     didPersistPortal: { portal in
                         selection = .portal(portal.id)
+                        authenticationFocusPortalID = portal.id
                         showingAddPortal = false
                     }
                 )
@@ -368,13 +370,16 @@ private struct OverviewView: View {
             SelectedPortalView(
                 controller: controller,
                 portal: portal,
+                authenticationFocusRequestID: authenticationFocusPortalID == portal.id &&
+                    controller.actionAvailability(for: portal).authenticate ? portal.id : nil,
                 removalFocusRequestID: removalCancelFocusPortalID == portal.id
                     ? portal.id
-                    : nil
-            ) {
-                removalCancelFocusPortalID = nil
-                removalCandidate = portal
-            }
+                    : nil,
+                onRemove: {
+                    removalCancelFocusPortalID = nil
+                    removalCandidate = portal
+                }
+            )
         case .pendingRemoval:
             RemovingPortalView(controller: controller, portal: portal)
         case .pendingTailnetRejection:
@@ -440,6 +445,7 @@ private struct SelectedPortalView: View {
     @Environment(\.openWindow) private var openWindow
     @ObservedObject var controller: PortalController
     let portal: PortalConfiguration
+    let authenticationFocusRequestID: UUID?
     let removalFocusRequestID: UUID?
     let onRemove: () -> Void
     @State private var destinationEdit: PortalDestinationEdit
@@ -447,11 +453,13 @@ private struct SelectedPortalView: View {
     init(
         controller: PortalController,
         portal: PortalConfiguration,
+        authenticationFocusRequestID: UUID?,
         removalFocusRequestID: UUID?,
         onRemove: @escaping () -> Void
     ) {
         self.controller = controller
         self.portal = portal
+        self.authenticationFocusRequestID = authenticationFocusRequestID
         self.removalFocusRequestID = removalFocusRequestID
         self.onRemove = onRemove
         _destinationEdit = State(initialValue: PortalDestinationEdit(destination: portal.destination))
@@ -561,7 +569,7 @@ private struct SelectedPortalView: View {
                 }
             }
             Section("Actions") {
-                if status?.state == .authenticating {
+                if portalActions.authenticate {
                     Label("Next, sign in with Tailscale in your browser.", systemImage: "key.fill")
                         .font(.headline)
                         .padding(8)
@@ -571,9 +579,14 @@ private struct SelectedPortalView: View {
                 }
                 WrappingHStack {
                     if status?.state == .authenticating {
-                        Button("Authenticate") { controller.authenticate(id: portal.id) }
-                            .buttonStyle(.borderedProminent)
-                            .disabled(!portalActions.authenticate)
+                        FocusRestoringButton(
+                            title: "Authenticate",
+                            isEnabled: portalActions.authenticate,
+                            isProminent: true,
+                            focusRequestID: authenticationFocusRequestID
+                        ) {
+                            controller.authenticate(id: portal.id)
+                        }
                             .accessibilityIdentifier("selected-authenticate")
                     }
                     FocusRestoringButton(
@@ -760,6 +773,7 @@ private struct FocusRestoringButton: NSViewRepresentable {
     let title: String
     let isEnabled: Bool
     var isDestructive = false
+    var isProminent = false
     var focusRequestID: UUID?
     let action: () -> Void
 
@@ -771,6 +785,10 @@ private struct FocusRestoringButton: NSViewRepresentable {
         let button = NSButton(title: title, target: context.coordinator, action: #selector(Coordinator.performAction))
         button.bezelStyle = .rounded
         button.controlSize = .small
+        button.bezelColor = isProminent ? .controlAccentColor : nil
+        if context.coordinator.focusRequestID != nil {
+            context.coordinator.restoreFocus(afterSheetDismissal: button)
+        }
         return button
     }
 
@@ -780,6 +798,7 @@ private struct FocusRestoringButton: NSViewRepresentable {
         button.title = title
         button.isEnabled = isEnabled
         button.contentTintColor = isDestructive ? .systemRed : nil
+        button.bezelColor = isProminent ? .controlAccentColor : nil
         let focusRequested = context.coordinator.focusRequestID != focusRequestID
         context.coordinator.focusRequestID = focusRequestID
         guard titleChanged || (focusRequested && focusRequestID != nil) else { return }
@@ -809,6 +828,7 @@ private struct FocusRestoringButton: NSViewRepresentable {
                 guard let self, let button, let window = button.window else { return }
                 self.removeSheetObserver()
                 guard window.attachedSheet != nil else {
+                    button.scrollToVisible(button.bounds)
                     window.makeFirstResponder(button)
                     return
                 }
@@ -819,6 +839,7 @@ private struct FocusRestoringButton: NSViewRepresentable {
                 ) { [weak self, weak button, weak window] _ in
                     self?.removeSheetObserver()
                     guard let button, let window else { return }
+                    button.scrollToVisible(button.bounds)
                     window.makeFirstResponder(button)
                 }
             }

--- a/Portico/UITestLaunchConfiguration.swift
+++ b/Portico/UITestLaunchConfiguration.swift
@@ -15,6 +15,7 @@ enum UITestScenario: String {
     case authenticating
     case awaitingApproval = "awaiting-approval"
     case stale
+    case staleAuthenticating = "stale-authenticating"
     case restarting
     case terminalFailure = "terminal-failure"
     case removing
@@ -167,7 +168,7 @@ struct UITestLaunchConfiguration {
                 operationalLogging: .enabled,
                 launchAtLoginOffer: .declined
             ))
-        case .online, .stopped, .authenticating, .awaitingApproval, .stale, .restarting, .terminalFailure:
+        case .online, .stopped, .authenticating, .awaitingApproval, .stale, .staleAuthenticating, .restarting, .terminalFailure:
             try store.save(InstallationRecord(
                 tailnetBinding: Self.tailnetBinding,
                 portals: [Self.portal(desiredState: scenario == .stopped ? .stopped : .enabled)],
@@ -273,7 +274,7 @@ final class UITestHelperLauncher: HelperLaunching {
         onEOF: @escaping () -> Void,
         onExit: @escaping (Int32) -> Void
     ) throws -> HelperProcess {
-        if scenario == .terminalFailure || (scenario == .stale && launchCount > 0) {
+        if scenario == .terminalFailure || ([.stale, .staleAuthenticating].contains(scenario) && launchCount > 0) {
             throw UITestHelperLaunchBlocked()
         }
         launchCount += 1
@@ -410,12 +411,12 @@ private final class UITestHelperProcess: HelperProcess {
     }
 
     private func emitStatuses(for portals: [ReconcilePortalPayload]) {
-        guard [.online, .stopped, .remoteOnline, .authenticating, .awaitingApproval, .stale, .restarting, .loginOffer, .loginOfferApproval, .loginOfferError, .management, .durableManagement, .creation].contains(scenario) else { return }
+        guard [.online, .stopped, .remoteOnline, .authenticating, .awaitingApproval, .stale, .staleAuthenticating, .restarting, .loginOffer, .loginOfferApproval, .loginOfferError, .management, .durableManagement, .creation].contains(scenario) else { return }
         for portal in portals {
             let state: PortalTailscaleState
             if scenario == .stopped {
                 state = .stopped
-            } else if scenario == .authenticating || scenario == .creation {
+            } else if [.authenticating, .creation, .staleAuthenticating].contains(scenario) {
                 state = .authenticating
             } else if scenario == .awaitingApproval {
                 state = .awaitingApproval
@@ -439,7 +440,7 @@ private final class UITestHelperProcess: HelperProcess {
                 )
             ), delay: 0.01)
         }
-        guard scenario == .stale, !staleFailureScheduled else { return }
+        guard [.stale, .staleAuthenticating].contains(scenario), !staleFailureScheduled else { return }
         staleFailureScheduled = true
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.02) { [weak self] in
             guard self?.isRunning == true else { return }

--- a/Portico/UITestLaunchConfiguration.swift
+++ b/Portico/UITestLaunchConfiguration.swift
@@ -410,12 +410,12 @@ private final class UITestHelperProcess: HelperProcess {
     }
 
     private func emitStatuses(for portals: [ReconcilePortalPayload]) {
-        guard [.online, .stopped, .remoteOnline, .authenticating, .awaitingApproval, .stale, .restarting, .loginOffer, .loginOfferApproval, .loginOfferError, .management, .durableManagement].contains(scenario) else { return }
+        guard [.online, .stopped, .remoteOnline, .authenticating, .awaitingApproval, .stale, .restarting, .loginOffer, .loginOfferApproval, .loginOfferError, .management, .durableManagement, .creation].contains(scenario) else { return }
         for portal in portals {
             let state: PortalTailscaleState
             if scenario == .stopped {
                 state = .stopped
-            } else if scenario == .authenticating {
+            } else if scenario == .authenticating || scenario == .creation {
                 state = .authenticating
             } else if scenario == .awaitingApproval {
                 state = .awaitingApproval

--- a/PorticoUITests/PorticoUITests.swift
+++ b/PorticoUITests/PorticoUITests.swift
@@ -326,6 +326,9 @@ final class PorticoUITests: XCTestCase {
         ).firstMatch
         XCTAssertTrue(focusedAuthenticate.waitForExistence(timeout: 3), app.debugDescription)
         XCTAssertTrue(authenticate.isHittable, app.debugDescription)
+        app.buttons["management-sidebar-overview"].click()
+        app.buttons["management-sidebar-portal-manual-portal"].click()
+        XCTAssertFalse(focusedAuthenticate.waitForExistence(timeout: 1), app.debugDescription)
         XCTAssertTrue(FileManager.default.fileExists(atPath: "\(root)/helper-enrollment.txt"))
     }
 

--- a/PorticoUITests/PorticoUITests.swift
+++ b/PorticoUITests/PorticoUITests.swift
@@ -154,7 +154,20 @@ final class PorticoUITests: XCTestCase {
         app.buttons["management-sidebar-portal-portal-one"].click()
         XCTAssertTrue(app.buttons["selected-authenticate"].waitForExistence(timeout: 3))
         XCTAssertTrue(app.buttons["selected-authenticate"].isEnabled)
+        XCTAssertTrue(app.staticTexts["selected-authentication-guidance"].exists)
         XCTAssertFalse(app.buttons["selected-open-portal-url"].isEnabled)
+
+        app = launch(scenario: "stale-authenticating")
+        app.typeKey("o", modifierFlags: [.command, .shift])
+        app.buttons["management-sidebar-portal-portal-one"].click()
+        XCTAssertTrue(waitForValue(
+            "Authentication required — Last Known",
+            element: app.staticTexts["selected-tailscale-state"],
+            timeout: 3
+        ))
+        XCTAssertTrue(app.buttons["selected-authenticate"].exists)
+        XCTAssertFalse(app.buttons["selected-authenticate"].isEnabled)
+        XCTAssertFalse(app.staticTexts["selected-authentication-guidance"].exists)
 
         app = launch(scenario: "awaiting-approval")
         app.typeKey("o", modifierFlags: [.command, .shift])
@@ -306,7 +319,13 @@ final class PorticoUITests: XCTestCase {
         XCTAssertFalse(app.descendants(matching: .any)["add-portal-sheet"].waitForExistence(timeout: 3))
         XCTAssertTrue(waitForValue("manual-portal", element: app.staticTexts["selected-portal-name"], timeout: 3))
         XCTAssertTrue(app.staticTexts["selected-authentication-guidance"].waitForExistence(timeout: 3))
-        XCTAssertTrue(app.buttons["selected-authenticate"].isEnabled)
+        let authenticate = app.buttons["selected-authenticate"]
+        XCTAssertTrue(authenticate.isEnabled)
+        let focusedAuthenticate = app.buttons.matching(
+            NSPredicate(format: "identifier == %@ AND hasKeyboardFocus == true", "selected-authenticate")
+        ).firstMatch
+        XCTAssertTrue(focusedAuthenticate.waitForExistence(timeout: 3), app.debugDescription)
+        XCTAssertTrue(authenticate.isHittable, app.debugDescription)
         XCTAssertTrue(FileManager.default.fileExists(atPath: "\(root)/helper-enrollment.txt"))
     }
 

--- a/PorticoUITests/PorticoUITests.swift
+++ b/PorticoUITests/PorticoUITests.swift
@@ -326,7 +326,7 @@ final class PorticoUITests: XCTestCase {
         ).firstMatch
         XCTAssertTrue(focusedAuthenticate.waitForExistence(timeout: 3), app.debugDescription)
         XCTAssertTrue(authenticate.isHittable, app.debugDescription)
-        app.buttons["management-sidebar-overview"].click()
+        app.descendants(matching: .any)["management-sidebar-overview"].click()
         app.buttons["management-sidebar-portal-manual-portal"].click()
         XCTAssertFalse(focusedAuthenticate.waitForExistence(timeout: 1), app.debugDescription)
         XCTAssertTrue(FileManager.default.fileExists(atPath: "\(root)/helper-enrollment.txt"))
@@ -703,7 +703,7 @@ final class PorticoUITests: XCTestCase {
 
         app.buttons["login-offer-reminder"].click()
 
-        XCTAssertTrue(app.staticTexts["No Portals"].waitForExistence(timeout: 3), app.debugDescription)
+        XCTAssertTrue(app.staticTexts["Connect Your Tailnet"].waitForExistence(timeout: 3), app.debugDescription)
         XCTAssertTrue(app.descendants(matching: .any)["overview-launch-at-login-offer"].exists)
         app.buttons["overview-login-offer-decline"].click()
         XCTAssertFalse(app.descendants(matching: .any)["overview-launch-at-login-offer"].waitForExistence(timeout: 2))

--- a/PorticoUITests/PorticoUITests.swift
+++ b/PorticoUITests/PorticoUITests.swift
@@ -14,7 +14,11 @@ final class PorticoUITests: XCTestCase {
         XCTAssertTrue(app.buttons["overview-logging-disabled"].exists)
 
         app.buttons["overview-logging-enabled"].click()
-        XCTAssertTrue(app.staticTexts["No Portals"].waitForExistence(timeout: 3), app.debugDescription)
+        XCTAssertTrue(app.staticTexts["Connect Your Tailnet"].waitForExistence(timeout: 3), app.debugDescription)
+        XCTAssertTrue(
+            app.staticTexts["overview-first-portal-authentication-guidance"].waitForExistence(timeout: 3),
+            app.debugDescription
+        )
         XCTAssertTrue(app.buttons["overview-add-portal"].isEnabled)
         let emptyStateAddPortal = app.buttons["overview-empty-add-portal"]
         XCTAssertTrue(emptyStateAddPortal.waitForExistence(timeout: 3), app.debugDescription)
@@ -36,7 +40,7 @@ final class PorticoUITests: XCTestCase {
         let overview = app.descendants(matching: .any)["management-overview"]
         XCTAssertTrue(overview.waitForExistence(timeout: 3), app.debugDescription)
         app.buttons["overview-logging-enabled"].click()
-        XCTAssertTrue(app.staticTexts["No Portals"].waitForExistence(timeout: 3))
+        XCTAssertTrue(app.staticTexts["Connect Your Tailnet"].waitForExistence(timeout: 3))
         app.buttons["overview-add-portal"].click()
         XCTAssertTrue(app.descendants(matching: .any)["add-portal-sheet"].waitForExistence(timeout: 3))
         app.buttons["add-portal-next"].click()
@@ -249,7 +253,7 @@ final class PorticoUITests: XCTestCase {
         let root = makeRoot()
         let app = launch(scenario: "creation", root: root)
         app.typeKey("o", modifierFlags: [.command, .shift])
-        XCTAssertTrue(app.staticTexts["No Portals"].waitForExistence(timeout: 3))
+        XCTAssertTrue(app.staticTexts["Connect Your Tailnet"].waitForExistence(timeout: 3))
         XCTAssertTrue(app.buttons["overview-add-portal"].waitForExistence(timeout: 3))
         app.buttons["overview-add-portal"].click()
         XCTAssertTrue(app.descendants(matching: .any)["add-portal-sheet"].waitForExistence(timeout: 3))
@@ -300,7 +304,9 @@ final class PorticoUITests: XCTestCase {
         app.buttons["add-portal"].click()
 
         XCTAssertFalse(app.descendants(matching: .any)["add-portal-sheet"].waitForExistence(timeout: 3))
-        XCTAssertTrue(app.staticTexts["overview-portal-manual-portal"].waitForExistence(timeout: 3))
+        XCTAssertTrue(waitForValue("manual-portal", element: app.staticTexts["selected-portal-name"], timeout: 3))
+        XCTAssertTrue(app.staticTexts["selected-authentication-guidance"].waitForExistence(timeout: 3))
+        XCTAssertTrue(app.buttons["selected-authenticate"].isEnabled)
         XCTAssertTrue(FileManager.default.fileExists(atPath: "\(root)/helper-enrollment.txt"))
     }
 


### PR DESCRIPTION
## Summary

- make the first Portal setup explicitly describe the browser Tailscale sign-in step
- open a newly created Portal so its authentication action is immediately in context
- cover the handoff with the existing native UI-test scenario

## Why

A new installation did not explain when browser authentication happens, and creating a Portal returned to Overview instead of the sign-in action.

## Validation

- `xcodebuild -project Portico.xcodeproj -scheme Portico -destination 'platform=macOS' -derivedDataPath .build/xcode build`
- `xcodebuild -project Portico.xcodeproj -scheme 'Portico UI Tests' -destination 'platform=macOS' -derivedDataPath .build/xcode build-for-testing`
- `git diff --check`

The focused XCTest commands built successfully but their local XCTest runner stalled before launching Portico, so no runtime UI-test verdict is claimed.